### PR TITLE
program: respond to jon code review

### DIFF
--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -14,7 +14,7 @@ fn process_instruction(
     instruction_data: &[u8],
 ) -> ProgramResult {
     if let Err(error) = Processor::process(program_id, accounts, instruction_data) {
-        msg!("ERROR: {:?}", error);
+        msg!("ERROR: {}", error);
         Err(error)
     } else {
         Ok(())

--- a/program/src/helpers/delegate.rs
+++ b/program/src/helpers/delegate.rs
@@ -1,5 +1,5 @@
 use {
-    crate::PERPETUAL_NEW_WARMUP,
+    crate::PERPETUAL_NEW_WARMUP_COOLDOWN_RATE_EPOCH,
     solana_program::{
         account_info::AccountInfo,
         clock::Epoch,
@@ -41,7 +41,12 @@ pub(crate) fn redelegate_stake(
     stake_history: &StakeHistorySysvar,
 ) -> Result<(), ProgramError> {
     // If stake is currently active:
-    if stake.stake(epoch, stake_history, PERPETUAL_NEW_WARMUP) != 0 {
+    if stake.stake(
+        epoch,
+        stake_history,
+        PERPETUAL_NEW_WARMUP_COOLDOWN_RATE_EPOCH,
+    ) != 0
+    {
         // If pubkey of new voter is the same as current,
         // and we are scheduled to start deactivating this epoch,
         // we rescind deactivation

--- a/program/src/helpers/merge.rs
+++ b/program/src/helpers/merge.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{helpers::checked_add, PERPETUAL_NEW_WARMUP},
+    crate::{helpers::checked_add, PERPETUAL_NEW_WARMUP_COOLDOWN_RATE_EPOCH},
     solana_program::{
         clock::{Clock, Epoch},
         entrypoint::ProgramResult,
@@ -48,7 +48,7 @@ impl MergeKind {
                 let status = stake.delegation.stake_activating_and_deactivating(
                     clock.epoch,
                     stake_history,
-                    PERPETUAL_NEW_WARMUP,
+                    PERPETUAL_NEW_WARMUP_COOLDOWN_RATE_EPOCH,
                 );
 
                 match (status.effective, status.activating, status.deactivating) {

--- a/program/src/helpers/mod.rs
+++ b/program/src/helpers/mod.rs
@@ -13,23 +13,6 @@ pub(crate) fn checked_add(a: u64, b: u64) -> Result<u64, ProgramError> {
     a.checked_add(b).ok_or(ProgramError::InsufficientFunds)
 }
 
-// FIXME this is kind of a hack... but better than mapping *all*
-// InstructionError into ProgramError::InvalidAccountData idk if theres a more
-// standard way
-// XXX jon suggests an error wrapper like
-// struct InfallibleInstructionError(InstructionError);
-// impl From<InfallibleInstructionError> for ProgramError { ... }
-// meta.authorized.authorize(...).map_err(|e|
-// InfallibleInstructionError(e).into())?;
-pub(crate) trait TurnInto {
-    fn turn_into(self) -> ProgramError;
-}
-
-impl TurnInto for InstructionError {
-    fn turn_into(self) -> ProgramError {
-        match ProgramError::try_from(self) {
-            Ok(program_error) => program_error,
-            Err(_) => ProgramError::InvalidAccountData,
-        }
-    }
+pub(crate) fn to_program_error(e: InstructionError) -> ProgramError {
+    ProgramError::try_from(e).unwrap_or(ProgramError::InvalidAccountData)
 }

--- a/program/src/helpers/mod.rs
+++ b/program/src/helpers/mod.rs
@@ -16,6 +16,11 @@ pub(crate) fn checked_add(a: u64, b: u64) -> Result<u64, ProgramError> {
 // FIXME this is kind of a hack... but better than mapping *all*
 // InstructionError into ProgramError::InvalidAccountData idk if theres a more
 // standard way
+// XXX jon suggests an error wrapper like
+// struct InfallibleInstructionError(InstructionError);
+// impl From<InfallibleInstructionError> for ProgramError { ... }
+// meta.authorized.authorize(...).map_err(|e|
+// InfallibleInstructionError(e).into())?;
 pub(crate) trait TurnInto {
     fn turn_into(self) -> ProgramError;
 }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -15,21 +15,21 @@ solana_program::declare_id!("Stake11111111111111111111111111111111111111");
 // * stake_raise_minimum_delegation_to_1_sol /
 //   9onWzzvCzNC2jfhxxeqRgs5q7nFAAKpCUvkj6T6GJK9i this may or may not be
 //   activated by time we are done, but it should be confined to the program so
-//   we use a placeholder for now to call it out but we can just change the
-//   program it is unclear if or when it will ever be activated, because it
+//   we use a placeholder for now to call it out. but we can just change the
+//   program. it is unclear if or when it will ever be activated, because it
 //   requires a validator vote
 const FEATURE_STAKE_RAISE_MINIMUM_DELEGATION_TO_1_SOL: bool = false;
 
 // feature_set::reduce_stake_warmup_cooldown changed the warmup/cooldown from
-// 25% to 9% a function is provided by the sdk,
+// 25% to 9%. a function is provided by the sdk,
 // new_warmup_cooldown_rate_epoch(), which returns the epoch this change
-// happened this function is not available to bpf programs. however, we dont
-// need it the number is necessary to calculate historical effective stake from
-// stake history but we only care that stake we are dealing with in the present
-// epoch has been fully (de)activated this means, as long as one epoch has
-// passed since activation where all prior stake had escaped cooldown...
-// ...we can pretend the rate has always beein 9% without issue. so we do that
-const PERPETUAL_NEW_WARMUP: Option<u64> = Some(0);
+// happened. this function is not available to bpf programs. however, we dont
+// need it. the number is necessary to calculate historical effective stake from
+// stake history, but we only care that stake we are dealing with in the present
+// epoch has been fully (de)activated. this means, as long as one epoch has
+// passed since activation where all prior stake had escaped warmup/cooldown,
+// we can pretend the rate has always beein 9% without issue. so we do that
+const PERPETUAL_NEW_WARMUP_COOLDOWN_RATE_EPOCH: Option<u64> = Some(0);
 
 /// The minimum stake amount that can be delegated, in lamports.
 /// NOTE: This is also used to calculate the minimum balance of a delegated


### PR DESCRIPTION
address points raised in initial code review:
* convert `InstructionError` to `ProgramError` without a trait
* use `VoteState::deserialize_into_uninit()`
* drop one lamport borrow before taking another
* rewrite how signers are handled to be clearer and also preserve unfortunate native stake program permissiveness
* add comments for skipped owner checks

also some of the block comments changed but thats because there was a rustfmt rule that messed with comments, which i didnt notice garbled them in a push to master commit lol

after this pr, the most important thing for me to do with the stake program is get solfuzz-agave up and running. currently this repo has better (exhaustive tests for all stake account state combinations for complex operations like split and merge, exhaustive tests for missing signers) but also worse (many of the ad hoc tests for edge cases have not been ported, and lockup coverage is very lacking) test coverage than the monorepo stake program. i believe tho that firedancer ported all the tests in `stake_instruction.rs` to test fixtures. so if we pass those, i will be very confident my implementation is correct

also i think i will implement the sysvar skipping logic, theres no downside to it and after we launch we can remove all those accounts from the instruction builders. but i want to do this after solfuzz-agave because it might cause false negatives if there are tests that expect omitting a sysvar to cause a failed transaction