### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,10 +65,11 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a249374d6349eeb31348a849666f3d47cacb18e0e05454fbd11a1fc69fae8e7e"
 dependencies = [
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-svm-transaction",
 ]
 
@@ -3448,33 +3449,22 @@ dependencies = [
 [[package]]
 name = "solana-account"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730219420b206253977b8cc8fd7846ffe021ab2e2c718e70db420efbd2775547"
 dependencies = [
  "bincode",
  "serde",
  "serde_bytes",
  "serde_derive",
- "solana-instruction 2.1.0",
- "solana-program 2.1.0",
-]
-
-[[package]]
-name = "solana-account"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "bincode",
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction 2.1.1",
- "solana-program 2.1.1",
+ "solana-instruction",
+ "solana-program",
 ]
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e5b1c167335942b659d077552607f79b2eca3472e40eeed97a2c55838b84ef"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -3487,7 +3477,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-config-program",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "spl-token",
  "spl-token-2022",
  "spl-token-group-interface",
@@ -3498,47 +3488,38 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee0750d2f106ecbee6d4508b6e2029e6946cb5f67288bf002b5a62f9f451c43"
 dependencies = [
  "base64 0.22.1",
  "bs58",
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account 2.1.1",
- "solana-pubkey 2.1.1",
+ "solana-account",
+ "solana-pubkey",
  "zstd",
 ]
 
 [[package]]
 name = "solana-account-info"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6abe81cfc4a75f71a510c6856b03a7d8525e416af3c69d55daef62e6078b8d40"
 dependencies = [
  "bincode",
  "serde",
- "solana-program-error 2.1.0",
- "solana-program-memory 2.1.0",
- "solana-pubkey 2.1.0",
-]
-
-[[package]]
-name = "solana-account-info"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "bincode",
- "serde",
- "solana-program-error 2.1.1",
- "solana-program-memory 2.1.1",
- "solana-pubkey 2.1.1",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fecc332ad4edd98ed63e5a46d990ecaf6fe4abd2bf9795c15474a64534ced6"
 dependencies = [
  "ahash",
  "bincode",
@@ -3572,7 +3553,7 @@ dependencies = [
  "solana-metrics",
  "solana-nohash-hasher",
  "solana-rayon-threadlimit",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-svm-transaction",
  "static_assertions",
  "tar",
@@ -3582,48 +3563,43 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf79a76f2878982b9781dfd0831d58ee15eb905be65406ccf7370c3ecd69c52"
 dependencies = [
  "bincode",
  "bytemuck",
  "log",
  "num-derive 0.4.2",
  "num-traits",
- "solana-feature-set 2.1.1",
+ "solana-feature-set",
  "solana-log-collector",
- "solana-program 2.1.1",
+ "solana-program",
  "solana-program-runtime",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-atomic-u64"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
-dependencies = [
- "parking_lot",
-]
-
-[[package]]
-name = "solana-atomic-u64"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391b795afcdcad39ddc6c938d64b789d036cdfe00d9dc5ff83024cf2da9f066f"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "solana-banks-client"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f857fb6590467d433f40eee507666ca496ec67907e50b7d530b6c04f6541875"
 dependencies = [
  "borsh 1.5.1",
  "futures",
  "solana-banks-interface",
- "solana-program 2.1.1",
- "solana-sdk 2.1.1",
+ "solana-program",
+ "solana-sdk",
  "tarpc",
  "thiserror",
  "tokio",
@@ -3632,28 +3608,30 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20052d231bb9ac3268dc61a713e3915d6c95fc942f9a5c15ca3a81a3fcd9cc12"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10db60e4bf077b870a7e75f8596bf3790d079b3762e9b4edc032475077007d0b"
 dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures",
  "solana-banks-interface",
  "solana-client",
- "solana-feature-set 2.1.1",
+ "solana-feature-set",
  "solana-runtime",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-send-transaction-service",
  "solana-svm",
  "tarpc",
@@ -3664,55 +3642,34 @@ dependencies = [
 [[package]]
 name = "solana-bincode"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e85cb5961c356345a61378163fd9057011b35540f8bcdd8d8a09cb10117264f"
 dependencies = [
  "bincode",
  "serde",
- "solana-instruction 2.1.0",
-]
-
-[[package]]
-name = "solana-bincode"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "bincode",
- "serde",
- "solana-instruction 2.1.1",
+ "solana-instruction",
 ]
 
 [[package]]
 name = "solana-bn254"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39c4030db26ad618f7e18fb5284df19fd52a68e092a1ca58db857108c4cc777"
 dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
  "bytemuck",
- "solana-program 2.1.0",
- "thiserror",
-]
-
-[[package]]
-name = "solana-bn254"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "bytemuck",
- "solana-program 2.1.1",
+ "solana-program",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-borsh"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d526f3525ab22a3ada3f9a1d642664dafac00dc9208326b701a2045514eb04"
 dependencies = [
  "borsh 0.10.4",
  "borsh 1.5.1",
@@ -3720,24 +3677,25 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142e0407f8428a1d2a33154d1d3d1c134ad257651ddff0811c17a6ee840def36"
 dependencies = [
  "bincode",
  "byteorder",
  "libsecp256k1",
  "log",
  "scopeguard",
- "solana-bn254 2.1.1",
+ "solana-bn254",
  "solana-compute-budget",
- "solana-curve25519 2.1.1",
- "solana-feature-set 2.1.1",
+ "solana-curve25519",
+ "solana-feature-set",
  "solana-log-collector",
  "solana-measure",
  "solana-poseidon",
- "solana-program-memory 2.1.1",
+ "solana-program-memory",
  "solana-program-runtime",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-timings",
  "solana-type-overrides",
  "solana_rbpf",
@@ -3746,8 +3704,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66eb348939fcfea6e40eed61bca06a1c631f8cb70f1801a5b14021bddefe93eb"
 dependencies = [
  "bv",
  "bytemuck",
@@ -3758,14 +3717,15 @@ dependencies = [
  "num_enum",
  "rand 0.8.5",
  "solana-measure",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "tempfile",
 ]
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854270e266040355f5fd5b67c91855bc36cebf1d3f325eb54d8b1b0ca385f74b"
 dependencies = [
  "ahash",
  "lazy_static",
@@ -3775,16 +3735,17 @@ dependencies = [
  "solana-compute-budget-program",
  "solana-config-program",
  "solana-loader-v4-program",
- "solana-sdk 2.1.1",
- "solana-stake-program 2.1.1",
+ "solana-sdk",
+ "solana-stake-program 2.1.0",
  "solana-system-program",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-client"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9a40b8e9e11604e8c05e8b5fcdb89359235db47d1aae84dcba0fc98e95dd0c"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3803,7 +3764,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-rpc-client-nonce-utils",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-streamer",
  "solana-thin-client",
  "solana-tpu-client",
@@ -3815,45 +3776,38 @@ dependencies = [
 [[package]]
 name = "solana-clock"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7848171e53fa528efd41dd4b3ab919f47b851f8bb4a827d63ff95678f08737fc"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-macro 2.1.0",
-]
-
-[[package]]
-name = "solana-clock"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-macro 2.1.1",
- "solana-sysvar-id",
+ "solana-sdk-macro",
 ]
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf2f023f471bd1195b7f420e13ffc2422592dd48e71104b4901300b49ac493e"
 dependencies = [
- "solana-sdk 2.1.1",
+ "solana-sdk",
 ]
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73eddf023f02a56daa838818e30894b874368a741782457468eeefdfce2f7f53"
 dependencies = [
  "solana-program-runtime",
- "solana-sdk 2.1.1",
+ "solana-sdk",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a035a01970ebbf40a244b3b79af533329ac8d48d80b0b98e166e23e35aa88171"
 dependencies = [
  "bincode",
  "chrono",
@@ -3861,14 +3815,15 @@ dependencies = [
  "serde_derive",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk 2.1.1",
- "solana-short-vec 2.1.1",
+ "solana-sdk",
+ "solana-short-vec",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f45dd2a6d5d55ed951781486231d0d2ee9ff7047fdafaed01ee021e236319d0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3880,78 +3835,62 @@ dependencies = [
  "rayon",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "solana-cost-model"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "448128561bb950bce19cdbbdc1780955a52ef25f1984c9c13b35b4b9cdc548c4"
 dependencies = [
  "ahash",
  "lazy_static",
  "log",
  "solana-builtins-default-costs",
  "solana-compute-budget",
- "solana-feature-set 2.1.1",
+ "solana-feature-set",
  "solana-metrics",
  "solana-runtime-transaction",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-svm-transaction",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-cpi"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25c536ad0ce25d84a64f48dedcb773e764827e0ef781eda41fa1fa35f5d64b38"
 dependencies = [
- "solana-account-info 2.1.1",
- "solana-define-syscall 2.1.1",
- "solana-instruction 2.1.1",
- "solana-program-error 2.1.1",
- "solana-pubkey 2.1.1",
- "solana-stable-layout 2.1.1",
+ "solana-account-info",
+ "solana-define-syscall",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-stable-layout",
 ]
 
 [[package]]
 name = "solana-curve25519"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f934d38b6f2a940fb1e1d8eaa17a14ffd3773b37be9fb29fa4bcec1bac5e4591"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-program 2.1.0",
- "thiserror",
-]
-
-[[package]]
-name = "solana-curve25519"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek 4.1.3",
- "solana-program 2.1.1",
+ "solana-program",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-decode-error"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "solana-decode-error"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a431f532d030098e81d120877f2dddbd3dd90bea5b259198a6aae4ff6456c3"
 dependencies = [
  "num-traits",
 ]
@@ -3959,27 +3898,14 @@ dependencies = [
 [[package]]
 name = "solana-define-syscall"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
-
-[[package]]
-name = "solana-define-syscall"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7062ae1de58e294d3bee5fd2c89efc155b7f7383ddce4cb88345dfafaaabc5bd"
 
 [[package]]
 name = "solana-derivation-path"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
-dependencies = [
- "derivation-path",
- "qstring",
- "uriparse",
-]
-
-[[package]]
-name = "solana-derivation-path"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12080d9bf8eecd559c6f40b5aaf9e47f7f28f515218087f83f02e493b46d8388"
 dependencies = [
  "derivation-path",
  "qstring",
@@ -3989,73 +3915,43 @@ dependencies = [
 [[package]]
 name = "solana-epoch-schedule"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c4cf7d7c266d353169cf4feeada5e4bba3a55f33715535fa1ef49080eac3e0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-macro 2.1.0",
-]
-
-[[package]]
-name = "solana-epoch-schedule"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-macro 2.1.1",
- "solana-sysvar-id",
+ "solana-sdk-macro",
 ]
 
 [[package]]
 name = "solana-feature-set"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cebf45992982065a0b01b4e109bf039b2ebf6394b21672382fd951516d4c9b0"
 dependencies = [
  "lazy_static",
- "solana-clock 2.1.0",
- "solana-epoch-schedule 2.1.0",
- "solana-hash 2.1.0",
- "solana-pubkey 2.1.0",
- "solana-sha256-hasher 2.1.0",
-]
-
-[[package]]
-name = "solana-feature-set"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "lazy_static",
- "solana-clock 2.1.1",
- "solana-epoch-schedule 2.1.1",
- "solana-hash 2.1.1",
- "solana-pubkey 2.1.1",
- "solana-sha256-hasher 2.1.1",
+ "solana-clock",
+ "solana-epoch-schedule",
+ "solana-hash",
+ "solana-pubkey",
+ "solana-sha256-hasher",
 ]
 
 [[package]]
 name = "solana-fee"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833e9a34c8cb1271e360b240dce43065cc4419ad74fc7e807c4e30cf06ebca80"
 dependencies = [
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-svm-transaction",
 ]
 
 [[package]]
 name = "solana-fee-calculator"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
-dependencies = [
- "log",
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "solana-fee-calculator"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2befe056ece2eb5807298c2b569a35ee52f79df859bdd16a1f97869f8224a28"
 dependencies = [
  "log",
  "serde",
@@ -4065,7 +3961,8 @@ dependencies = [
 [[package]]
 name = "solana-hash"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1807bc4e9e1d25271514167d5a1e698ce5a330bce547a368242dd63b355b5faa"
 dependencies = [
  "borsh 1.5.1",
  "bs58",
@@ -4074,32 +3971,16 @@ dependencies = [
  "js-sys",
  "serde",
  "serde_derive",
- "solana-atomic-u64 2.1.0",
- "solana-sanitize 2.1.0",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-hash"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "borsh 1.5.1",
- "bs58",
- "bytemuck",
- "bytemuck_derive",
- "js-sys",
- "serde",
- "serde_derive",
- "solana-atomic-u64 2.1.1",
- "solana-sanitize 2.1.1",
+ "solana-atomic-u64",
+ "solana-sanitize",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-inflation"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60b572cdf0ec8fcf5a53e5ba4e3e19814dd96c2b9c156d5828be68d0d2e7103"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4107,17 +3988,19 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24c9c6590e4eaf91efa887b2689b2941fe4b324bccd9a95f77853168f3d9a88"
 dependencies = [
  "bytemuck",
- "solana-pubkey 2.1.1",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-instruction"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfef689e06e5c7cb6206d4dc61ac77733de4f72d754e0d531393206abc27dbe4"
 dependencies = [
  "bincode",
  "borsh 1.5.1",
@@ -4126,43 +4009,27 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-define-syscall 2.1.0",
- "solana-pubkey 2.1.0",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-instruction"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "bincode",
- "borsh 1.5.1",
- "getrandom 0.2.15",
- "js-sys",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-define-syscall 2.1.1",
- "solana-pubkey 2.1.1",
+ "solana-define-syscall",
+ "solana-pubkey",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-last-restart-slot"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3186feae497bdfd2e77bfa56caed38b1cb1b0f389506666e3331f0b9ae799cb"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-macro 2.1.1",
- "solana-sysvar-id",
+ "solana-sdk-macro",
 ]
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ec86f48a8694d55757922823823069a3652d2896f61f3ffc4b741646c166a62"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -4172,8 +4039,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94c6915a49e537925e934551dbce2db2357d555d257a311bbf5ba0810cb1017a"
 dependencies = [
  "log",
  "solana-bpf-loader-program",
@@ -4181,23 +4049,25 @@ dependencies = [
  "solana-log-collector",
  "solana-measure",
  "solana-program-runtime",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-type-overrides",
  "solana_rbpf",
 ]
 
 [[package]]
 name = "solana-log-collector"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b529f5736a6c0794a885dac2e091138d3db6d924335906f117a62b58b0d3b5dc"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c5431bad14b10fbb62614b48720b746672558dba3244167ff7d251890c355"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -4206,53 +4076,45 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b2047a2f588082b71080b060918f107c3330ae1505f759c3b2d74bae9d9c88"
 
 [[package]]
 name = "solana-metrics"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6319c74238e8ed4f7159fd37c693a574ab8316d03b053103f9cc83dce13f1d5c"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
  "lazy_static",
  "log",
  "reqwest",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-msg"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7551f85064bc7299d56dbd7126258b084a2d78d0325b1579324f818b405123"
 dependencies = [
- "solana-define-syscall 2.1.0",
-]
-
-[[package]]
-name = "solana-msg"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "solana-define-syscall 2.1.1",
+ "solana-define-syscall",
 ]
 
 [[package]]
 name = "solana-native-token"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
-
-[[package]]
-name = "solana-native-token"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0c4074f5fc67574dabd8f30fe6e51e290a812d88326b19b49c462058e23340"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbac19474a4c4f91cb264c2fccead8a1a4f65384ce650b24360d9df5650e65bc"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4262,7 +4124,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "tokio",
  "url",
 ]
@@ -4275,8 +4137,9 @@ checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
 name = "solana-packet"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dafc2d84e57dbfe32583fe915962bd2ca3af6be496628a871db3c3d697b38d7"
 dependencies = [
  "bincode",
  "bitflags 2.6.0",
@@ -4288,8 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8299f1ba518f9888da8cafa861addc6ffdd639c689e3ce219ae08212c0dcd0e"
 dependencies = [
  "ahash",
  "bincode",
@@ -4307,44 +4171,38 @@ dependencies = [
  "serde",
  "solana-metrics",
  "solana-rayon-threadlimit",
- "solana-sdk 2.1.1",
- "solana-short-vec 2.1.1",
+ "solana-sdk",
+ "solana-short-vec",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-poseidon"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f193a65f0db7fe5615c76c2814d6450a2e4cda61f786d5bf7a6b1ad0c179b947"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
- "solana-define-syscall 2.1.1",
+ "solana-define-syscall",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-precompile-error"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30ab58b9e37cde4e5577282670f30df71b97b6b06dbdb420e9b84e57b831227"
 dependencies = [
  "num-traits",
- "solana-decode-error 2.1.0",
-]
-
-[[package]]
-name = "solana-precompile-error"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "num-traits",
- "solana-decode-error 2.1.1",
+ "solana-decode-error",
 ]
 
 [[package]]
 name = "solana-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9040decf2f295d35da22557eeab3768ab8dfca8aed9afe668663c8fa0e97d60e"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4375,107 +4233,39 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.8",
  "sha3",
- "solana-account-info 2.1.0",
- "solana-atomic-u64 2.1.0",
- "solana-bincode 2.1.0",
- "solana-clock 2.1.0",
- "solana-decode-error 2.1.0",
- "solana-define-syscall 2.1.0",
- "solana-epoch-schedule 2.1.0",
- "solana-fee-calculator 2.1.0",
- "solana-hash 2.1.0",
- "solana-instruction 2.1.0",
- "solana-msg 2.1.0",
- "solana-native-token 2.1.0",
- "solana-program-entrypoint 2.1.0",
- "solana-program-error 2.1.0",
- "solana-program-memory 2.1.0",
- "solana-program-option 2.1.0",
- "solana-program-pack 2.1.0",
- "solana-pubkey 2.1.0",
- "solana-rent 2.1.0",
- "solana-sanitize 2.1.0",
- "solana-sdk-macro 2.1.0",
- "solana-secp256k1-recover 2.1.0",
- "solana-serde-varint 2.1.0",
- "solana-serialize-utils 2.1.0",
- "solana-sha256-hasher 2.1.0",
- "solana-short-vec 2.1.0",
- "solana-slot-hashes 2.1.0",
- "solana-stable-layout 2.1.0",
- "solana-transaction-error 2.1.0",
- "thiserror",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-program"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "bitflags 2.6.0",
- "blake3",
- "borsh 0.10.4",
- "borsh 1.5.1",
- "bs58",
- "bv",
- "bytemuck",
- "bytemuck_derive",
- "console_error_panic_hook",
- "console_log",
- "curve25519-dalek 4.1.3",
- "five8_const",
- "getrandom 0.2.15",
- "js-sys",
- "lazy_static",
- "log",
- "memoffset",
- "num-bigint 0.4.6",
- "num-derive 0.4.2",
- "num-traits",
- "parking_lot",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "serde_derive",
- "sha2 0.10.8",
- "sha3",
- "solana-account-info 2.1.1",
- "solana-atomic-u64 2.1.1",
- "solana-bincode 2.1.1",
+ "solana-account-info",
+ "solana-atomic-u64",
+ "solana-bincode",
  "solana-borsh",
- "solana-clock 2.1.1",
+ "solana-clock",
  "solana-cpi",
- "solana-decode-error 2.1.1",
- "solana-define-syscall 2.1.1",
- "solana-epoch-schedule 2.1.1",
- "solana-fee-calculator 2.1.1",
- "solana-hash 2.1.1",
- "solana-instruction 2.1.1",
+ "solana-decode-error",
+ "solana-define-syscall",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-hash",
+ "solana-instruction",
  "solana-last-restart-slot",
- "solana-msg 2.1.1",
- "solana-native-token 2.1.1",
- "solana-program-entrypoint 2.1.1",
- "solana-program-error 2.1.1",
- "solana-program-memory 2.1.1",
- "solana-program-option 2.1.1",
- "solana-program-pack 2.1.1",
- "solana-pubkey 2.1.1",
- "solana-rent 2.1.1",
- "solana-sanitize 2.1.1",
- "solana-sdk-macro 2.1.1",
- "solana-secp256k1-recover 2.1.1",
- "solana-serde-varint 2.1.1",
- "solana-serialize-utils 2.1.1",
- "solana-sha256-hasher 2.1.1",
- "solana-short-vec 2.1.1",
- "solana-slot-hashes 2.1.1",
+ "solana-msg",
+ "solana-native-token",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sanitize",
+ "solana-sdk-macro",
+ "solana-secp256k1-recover",
+ "solana-serde-varint",
+ "solana-serialize-utils",
+ "solana-sha256-hasher",
+ "solana-short-vec",
+ "solana-slot-hashes",
  "solana-slot-history",
- "solana-stable-layout 2.1.1",
- "solana-sysvar-id",
- "solana-transaction-error 2.1.1",
+ "solana-stable-layout",
+ "solana-transaction-error",
  "thiserror",
  "wasm-bindgen",
 ]
@@ -4483,103 +4273,61 @@ dependencies = [
 [[package]]
 name = "solana-program-entrypoint"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb90f3fa3e979b912451a404508f1f90bb6e5c1d7767625f622b20016fb9fde"
 dependencies = [
- "solana-account-info 2.1.0",
- "solana-msg 2.1.0",
- "solana-program-error 2.1.0",
- "solana-pubkey 2.1.0",
-]
-
-[[package]]
-name = "solana-program-entrypoint"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "solana-account-info 2.1.1",
- "solana-msg 2.1.1",
- "solana-program-error 2.1.1",
- "solana-pubkey 2.1.1",
+ "solana-account-info",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-program-error"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd089caeef26dd07bd12b7b67d45e92faddc2fc67a960f316df7ae4776a2f3d5"
 dependencies = [
  "borsh 1.5.1",
  "num-traits",
  "serde",
  "serde_derive",
- "solana-decode-error 2.1.0",
- "solana-instruction 2.1.0",
- "solana-msg 2.1.0",
- "solana-pubkey 2.1.0",
-]
-
-[[package]]
-name = "solana-program-error"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "borsh 1.5.1",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-decode-error 2.1.1",
- "solana-instruction 2.1.1",
- "solana-msg 2.1.1",
- "solana-pubkey 2.1.1",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-program-memory"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4bc044dc2b49c323aeff04aec03c908a052e278c2edf2f7616f32fc0f1bcd9"
 dependencies = [
  "num-traits",
- "solana-define-syscall 2.1.0",
-]
-
-[[package]]
-name = "solana-program-memory"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "num-traits",
- "solana-define-syscall 2.1.1",
+ "solana-define-syscall",
 ]
 
 [[package]]
 name = "solana-program-option"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
-
-[[package]]
-name = "solana-program-option"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3babbdffd81994c043fc9a61458ce87496218825d6e9a303de643c0a53089b9a"
 
 [[package]]
 name = "solana-program-pack"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fb28439d23e1f505e59c7a14ed5012365ab7aa0f20dc7bda048e02ff231cf6"
 dependencies = [
- "solana-program-error 2.1.0",
-]
-
-[[package]]
-name = "solana-program-pack"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "solana-program-error 2.1.1",
+ "solana-program-error",
 ]
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1de51df173401d50c0f4cf750f5070d7a4c82125a03c1aec9622dc041b0b54"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4593,11 +4341,11 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "solana-compute-budget",
- "solana-feature-set 2.1.1",
+ "solana-feature-set",
  "solana-log-collector",
  "solana-measure",
  "solana-metrics",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-timings",
  "solana-type-overrides",
  "solana-vote",
@@ -4607,8 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "974591eca853eafee8196a3445b81fd03ebd9b3e38a6dd7b6f22dc3414c32be6"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4624,14 +4373,14 @@ dependencies = [
  "solana-banks-server",
  "solana-bpf-loader-program",
  "solana-compute-budget",
- "solana-feature-set 2.1.1",
+ "solana-feature-set",
  "solana-inline-spl",
- "solana-instruction 2.1.1",
+ "solana-instruction",
  "solana-log-collector",
  "solana-logger",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-svm",
  "solana-timings",
  "solana-vote-program",
@@ -4643,7 +4392,8 @@ dependencies = [
 [[package]]
 name = "solana-pubkey"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea3215775fcedf200d47590c7e2ce9a3a46bc2b7d3f77d0eae9c6edf0a39aec"
 dependencies = [
  "borsh 0.10.4",
  "borsh 1.5.1",
@@ -4658,44 +4408,19 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_derive",
- "solana-atomic-u64 2.1.0",
- "solana-decode-error 2.1.0",
- "solana-define-syscall 2.1.0",
- "solana-sanitize 2.1.0",
- "solana-sha256-hasher 2.1.0",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-pubkey"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.1",
- "bs58",
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek 4.1.3",
- "five8_const",
- "getrandom 0.2.15",
- "js-sys",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "serde_derive",
- "solana-atomic-u64 2.1.1",
- "solana-decode-error 2.1.1",
- "solana-define-syscall 2.1.1",
- "solana-sanitize 2.1.1",
- "solana-sha256-hasher 2.1.1",
+ "solana-atomic-u64",
+ "solana-decode-error",
+ "solana-define-syscall",
+ "solana-sanitize",
+ "solana-sha256-hasher",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d28adf5ff89c19ef3cb24d0f484afa05852697881c2e4ef12aec190d61f76d8"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -4707,7 +4432,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-rpc-client-api",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4718,8 +4443,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259c6d420c0b7620557700f13fbbdb00afbb1b82274485c27ba30dd660ea921b"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -4735,7 +4461,7 @@ dependencies = [
  "solana-metrics",
  "solana-net-utils",
  "solana-rpc-client-api",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-streamer",
  "thiserror",
  "tokio",
@@ -4743,8 +4469,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c69806ad1a7b0986f750134e13e55d83919631d81a2328a588615740e14ed0a"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -4753,28 +4480,19 @@ dependencies = [
 [[package]]
 name = "solana-rent"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab3f4a270196c38d62c3bb3c7a2f07732af2c772b50da49c9b1e2c9d2ace286"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-macro 2.1.0",
-]
-
-[[package]]
-name = "solana-rent"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-macro 2.1.1",
- "solana-sysvar-id",
+ "solana-sdk-macro",
 ]
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b05822aceeb484074a72d82a1b289da9fc3383f9ba3f55ce4bfd003bf9d62e6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4790,7 +4508,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-rpc-client-api",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-transaction-status-client-types",
  "solana-version",
  "solana-vote-program",
@@ -4799,8 +4517,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9c6e64f01cfafef9b2d43d6adb02979bb22f579ec8ee88b77796259acce92e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4814,7 +4533,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-inline-spl",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-transaction-status-client-types",
  "solana-version",
  "thiserror",
@@ -4822,18 +4541,20 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0ab2d1ca3769c5058c689b438d35eb1cb7d2a32fc4b2b7c16fe72fa187927c"
 dependencies = [
  "solana-rpc-client",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-runtime"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f579df1ed24b2e7be5c99c2b97cb2a331823008129103b5b7753057ddf3cf7"
 dependencies = [
  "ahash",
  "aquamarine",
@@ -4881,7 +4602,7 @@ dependencies = [
  "solana-compute-budget-program",
  "solana-config-program",
  "solana-cost-model",
- "solana-feature-set 2.1.1",
+ "solana-feature-set",
  "solana-fee",
  "solana-inline-spl",
  "solana-lattice-hash",
@@ -4889,12 +4610,12 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-perf",
- "solana-program 2.1.1",
+ "solana-program",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime-transaction",
- "solana-sdk 2.1.1",
- "solana-stake-program 2.1.1",
+ "solana-sdk",
+ "solana-stake-program 2.1.0",
  "solana-svm",
  "solana-svm-rent-collector",
  "solana-svm-transaction",
@@ -4907,7 +4628,7 @@ dependencies = [
  "solana-zk-elgamal-proof-program",
  "solana-zk-sdk",
  "solana-zk-token-proof-program",
- "solana-zk-token-sdk 2.1.1",
+ "solana-zk-token-sdk",
  "static_assertions",
  "strum",
  "strum_macros",
@@ -4920,15 +4641,16 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e1757d4473c7a2f462d2ce5f3cb5689145cfbde3a6b12161a49e497633ab85"
 dependencies = [
  "agave-transaction-view",
  "log",
  "solana-builtins-default-costs",
  "solana-compute-budget",
- "solana-pubkey 2.1.1",
- "solana-sdk 2.1.1",
+ "solana-pubkey",
+ "solana-sdk",
  "solana-svm-transaction",
  "thiserror",
 ]
@@ -4936,17 +4658,14 @@ dependencies = [
 [[package]]
 name = "solana-sanitize"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
-
-[[package]]
-name = "solana-sanitize"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203b90994371db8cade8e885f74ec9f68ee02a32b25d514594158b2551a4e5ed"
 
 [[package]]
 name = "solana-sdk"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524604d94185c189616296e5b7da1014cc96d1e446bd2b26f247f00708b9225a"
 dependencies = [
  "bincode",
  "bitflags 2.6.0",
@@ -4981,86 +4700,26 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "siphasher",
- "solana-account 2.1.0",
- "solana-bn254 2.1.0",
- "solana-decode-error 2.1.0",
- "solana-derivation-path 2.1.0",
- "solana-feature-set 2.1.0",
- "solana-instruction 2.1.0",
- "solana-native-token 2.1.0",
- "solana-precompile-error 2.1.0",
- "solana-program 2.1.0",
- "solana-program-memory 2.1.0",
- "solana-pubkey 2.1.0",
- "solana-sanitize 2.1.0",
- "solana-sdk-macro 2.1.0",
- "solana-secp256k1-recover 2.1.0",
- "solana-serde-varint 2.1.0",
- "solana-short-vec 2.1.0",
- "solana-signature 2.1.0",
- "solana-transaction-error 2.1.0",
- "thiserror",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-sdk"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "bincode",
- "bitflags 2.6.0",
- "borsh 1.5.1",
- "bs58",
- "bytemuck",
- "bytemuck_derive",
- "byteorder",
- "chrono",
- "digest 0.10.7",
- "ed25519-dalek",
- "ed25519-dalek-bip32",
- "getrandom 0.1.16",
- "hmac 0.12.1",
- "itertools 0.12.1",
- "js-sys",
- "lazy_static",
- "libsecp256k1",
- "log",
- "memmap2",
- "num-derive 0.4.2",
- "num-traits",
- "num_enum",
- "pbkdf2",
- "rand 0.7.3",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_json",
- "serde_with",
- "sha2 0.10.8",
- "sha3",
- "siphasher",
- "solana-account 2.1.1",
- "solana-bn254 2.1.1",
- "solana-decode-error 2.1.1",
- "solana-derivation-path 2.1.1",
- "solana-feature-set 2.1.1",
+ "solana-account",
+ "solana-bn254",
+ "solana-decode-error",
+ "solana-derivation-path",
+ "solana-feature-set",
  "solana-inflation",
- "solana-instruction 2.1.1",
- "solana-native-token 2.1.1",
+ "solana-instruction",
+ "solana-native-token",
  "solana-packet",
- "solana-precompile-error 2.1.1",
- "solana-program 2.1.1",
- "solana-program-memory 2.1.1",
- "solana-pubkey 2.1.1",
- "solana-sanitize 2.1.1",
- "solana-sdk-macro 2.1.1",
- "solana-secp256k1-recover 2.1.1",
- "solana-serde-varint 2.1.1",
- "solana-short-vec 2.1.1",
- "solana-signature 2.1.1",
- "solana-transaction-error 2.1.1",
+ "solana-precompile-error",
+ "solana-program",
+ "solana-program-memory",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sdk-macro",
+ "solana-secp256k1-recover",
+ "solana-serde-varint",
+ "solana-short-vec",
+ "solana-signature",
+ "solana-transaction-error",
  "thiserror",
  "wasm-bindgen",
 ]
@@ -5068,18 +4727,8 @@ dependencies = [
 [[package]]
 name = "solana-sdk-macro"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
-dependencies = [
- "bs58",
- "proc-macro2",
- "quote",
- "syn 2.0.83",
-]
-
-[[package]]
-name = "solana-sdk-macro"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd2265b93dce9d3dcf9f395abf1a85b5e06e4da4aa60ca147620003ac3abc67"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -5090,22 +4739,12 @@ dependencies = [
 [[package]]
 name = "solana-secp256k1-recover"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2eef5a00a75648273c3fb6e3d85b0c8c02fcc1e36c4271664dcc39b6b128d41"
 dependencies = [
  "borsh 1.5.1",
  "libsecp256k1",
- "solana-define-syscall 2.1.0",
- "thiserror",
-]
-
-[[package]]
-name = "solana-secp256k1-recover"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "borsh 1.5.1",
- "libsecp256k1",
- "solana-define-syscall 2.1.1",
+ "solana-define-syscall",
  "thiserror",
 ]
 
@@ -5117,8 +4756,9 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc6adaa31bdaab1e5f8932575e75160f4806553ab5e15e552c258dfe1d5594b"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -5127,22 +4767,15 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-tpu-client",
 ]
 
 [[package]]
 name = "solana-serde-varint"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "solana-serde-varint"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aeb51d3c20e2a61db0ef72617f3b8c9207a342a867af454a95f17add9f6c262"
 dependencies = [
  "serde",
 ]
@@ -5150,55 +4783,30 @@ dependencies = [
 [[package]]
 name = "solana-serialize-utils"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cfb0b57c6a431fb15ff33053caadb6c36aed4e1ce74bea9adfc459a710b3626"
 dependencies = [
- "solana-instruction 2.1.0",
- "solana-pubkey 2.1.0",
- "solana-sanitize 2.1.0",
-]
-
-[[package]]
-name = "solana-serialize-utils"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "solana-instruction 2.1.1",
- "solana-pubkey 2.1.1",
- "solana-sanitize 2.1.1",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sanitize",
 ]
 
 [[package]]
 name = "solana-sha256-hasher"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd115f3a1136314b0183235080d29023530c3a0a5df60505fdb7ea620eff9fd6"
 dependencies = [
  "sha2 0.10.8",
- "solana-define-syscall 2.1.0",
- "solana-hash 2.1.0",
-]
-
-[[package]]
-name = "solana-sha256-hasher"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "sha2 0.10.8",
- "solana-define-syscall 2.1.1",
- "solana-hash 2.1.1",
+ "solana-define-syscall",
+ "solana-hash",
 ]
 
 [[package]]
 name = "solana-short-vec"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "solana-short-vec"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08e55330b694db1139dcdf2a1ea7781abe8bd994dec2ab29e36abfd06e4e9274"
 dependencies = [
  "serde",
 ]
@@ -5206,7 +4814,8 @@ dependencies = [
 [[package]]
 name = "solana-signature"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad9784d110f195a3a4fe423479d18f05b01a1c380a1430644a3b3038fdbe2f0"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -5214,71 +4823,39 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_derive",
- "solana-sanitize 2.1.0",
-]
-
-[[package]]
-name = "solana-signature"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "bs58",
- "ed25519-dalek",
- "generic-array",
- "rand 0.8.5",
- "serde",
- "serde_derive",
- "solana-sanitize 2.1.1",
+ "solana-sanitize",
 ]
 
 [[package]]
 name = "solana-slot-hashes"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d216c0ebf00e95acaf2b1e227e6cc900a5ce50fb81fa0743272851e88a788d"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 2.1.0",
-]
-
-[[package]]
-name = "solana-slot-hashes"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash 2.1.1",
- "solana-sysvar-id",
+ "solana-hash",
 ]
 
 [[package]]
 name = "solana-slot-history"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88cbcdf767891c6a40116a5ef8f7241000f074ece4ba80c8f00b4f62705fc8a4"
 dependencies = [
  "bv",
  "serde",
  "serde_derive",
- "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-stable-layout"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5305ca88fb5deb219cd88f04e24f3a131769417d7fcb11a8da1126a8f98d23"
 dependencies = [
- "solana-instruction 2.1.0",
- "solana-pubkey 2.1.0",
-]
-
-[[package]]
-name = "solana-stable-layout"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "solana-instruction 2.1.1",
- "solana-pubkey 2.1.1",
+ "solana-instruction",
+ "solana-pubkey",
 ]
 
 [[package]]
@@ -5291,9 +4868,9 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_with",
- "solana-program 2.1.1",
+ "solana-program",
  "solana-program-test",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "thiserror",
 ]
 
@@ -5307,9 +4884,9 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "num_enum",
- "solana-program 2.1.1",
+ "solana-program",
  "solana-program-test",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-vote-program",
  "test-case",
  "thiserror",
@@ -5317,24 +4894,26 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8bb1a59fdd929becddfaed9ec33a1ca4db853f45ae85e14e4f4054a875fc41d"
 dependencies = [
  "bincode",
  "log",
  "solana-config-program",
- "solana-feature-set 2.1.1",
+ "solana-feature-set",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-type-overrides",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff771524872781eca074e0ba221d72b07fa0800cc1a7ffa400a9eb3e125fb922"
 dependencies = [
  "async-channel",
  "bytes",
@@ -5360,7 +4939,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-perf",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-transaction-metrics-tracker",
  "thiserror",
  "tokio",
@@ -5370,8 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f3b139a001effc93295b693437013f365785fab04dcf2fa679164af4206ec8"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -5380,14 +4960,14 @@ dependencies = [
  "serde_derive",
  "solana-bpf-loader-program",
  "solana-compute-budget",
- "solana-feature-set 2.1.1",
+ "solana-feature-set",
  "solana-fee",
  "solana-loader-v4-program",
  "solana-log-collector",
  "solana-measure",
  "solana-program-runtime",
  "solana-runtime-transaction",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-system-program",
@@ -5399,24 +4979,27 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e7068d6cc69c730190c96b87b106afd42cde203cf56164106792778cd0aaeb"
 dependencies = [
- "solana-sdk 2.1.1",
+ "solana-sdk",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a8533576cb7beca4a44b976ac27df9865bbf8c4cbca2ee8f4f3469cdd8175f"
 dependencies = [
- "solana-sdk 2.1.1",
+ "solana-sdk",
 ]
 
 [[package]]
 name = "solana-system-program"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "242634cdc1eacaa83738cc100fdd583eb88f99cc2edcc900c8ebe57d77af51b1"
 dependencies = [
  "bincode",
  "log",
@@ -5424,22 +5007,15 @@ dependencies = [
  "serde_derive",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-type-overrides",
 ]
 
 [[package]]
-name = "solana-sysvar-id"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "solana-pubkey 2.1.1",
-]
-
-[[package]]
 name = "solana-thin-client"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10314ae3e0889cf38140902862d2c2ea481895c82c19f51dc4457b7dfa3aa6d0"
 dependencies = [
  "bincode",
  "log",
@@ -5447,23 +5023,25 @@ dependencies = [
  "solana-connection-cache",
  "solana-rpc-client",
  "solana-rpc-client-api",
- "solana-sdk 2.1.1",
+ "solana-sdk",
 ]
 
 [[package]]
 name = "solana-timings"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a8e2f926d488c1e2a65cbc05544dcb68cfa88deb4d50f89db5bfbda7ff2419"
 dependencies = [
  "eager",
  "enum-iterator",
- "solana-sdk 2.1.1",
+ "solana-sdk",
 ]
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516cbed8800cd36fb3ecc9a65df1e76bf8251929aa32e9b10497e8d6612de605"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5477,7 +5055,7 @@ dependencies = [
  "solana-pubsub-client",
  "solana-rpc-client",
  "solana-rpc-client-api",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "thiserror",
  "tokio",
 ]
@@ -5485,29 +5063,20 @@ dependencies = [
 [[package]]
 name = "solana-transaction-error"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a4bea6d80b34fe6e785d19bf928fe103928d1f6c9935ec23bb6a9d4d7a33d2"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-instruction 2.1.0",
- "solana-sanitize 2.1.0",
-]
-
-[[package]]
-name = "solana-transaction-error"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-instruction 2.1.1",
- "solana-sanitize 2.1.1",
+ "solana-instruction",
+ "solana-sanitize",
 ]
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b668c986a83e6b2eb8f130039045b54abc37ee821853250755386d26c1c668"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5515,14 +5084,15 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "solana-perf",
- "solana-sdk 2.1.1",
- "solana-short-vec 2.1.1",
+ "solana-sdk",
+ "solana-short-vec",
 ]
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e8ed5bf2511c45b923de25482407c9a2eb56af73dba52c19db76df4dd35cba"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5535,7 +5105,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-transaction-status-client-types",
  "spl-associated-token-account",
  "spl-memo",
@@ -5548,8 +5118,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb35fb678fec581e9bdf6350d2c7f5829951a6280038fc06949b1589a9605e1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5558,15 +5129,16 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-sdk 2.1.1",
- "solana-signature 2.1.1",
+ "solana-sdk",
+ "solana-signature",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2066f25d460d63801f91436c2640aaba4f2dc95aa18fe1e76f7f2c063e981d4e"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -5574,13 +5146,14 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ec0cbc2d5e3379fafb2c1493f2358f07c09e76e2081c44e3a8c36da12fbd40"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
  "solana-net-utils",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-streamer",
  "thiserror",
  "tokio",
@@ -5588,34 +5161,37 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7310708b642fb83c04f44934509f4f149ffd69d0cd4cf76d9645c991177d7ea0"
 dependencies = [
  "semver",
  "serde",
  "serde_derive",
- "solana-feature-set 2.1.1",
- "solana-sanitize 2.1.1",
- "solana-serde-varint 2.1.1",
+ "solana-feature-set",
+ "solana-sanitize",
+ "solana-serde-varint",
 ]
 
 [[package]]
 name = "solana-vote"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab46788981765ee706094ca53ad8421aae0286a6b948e892fa7db88992a5373"
 dependencies = [
  "itertools 0.12.1",
  "log",
  "serde",
  "serde_derive",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637cadc921725d1804a451ea7d2dff83310a12b75e0b6c83a8bb67ebc02d10f1"
 dependencies = [
  "bincode",
  "log",
@@ -5623,32 +5199,34 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-feature-set 2.1.1",
+ "solana-feature-set",
  "solana-metrics",
- "solana-program 2.1.1",
+ "solana-program",
  "solana-program-runtime",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f5ac026a972c9cbc6bd0f72f692f85ff9ceec961fc4bcb1f2550e6387e962c"
 dependencies = [
  "bytemuck",
  "num-derive 0.4.2",
  "num-traits",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk 2.1.1",
+ "solana-sdk",
  "solana-zk-sdk",
 ]
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c2d96f65cb033f4dc16d3a1b085f8af0ea38012c514a8f65b9b6d75bc9339f"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -5667,9 +5245,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha3",
- "solana-derivation-path 2.1.1",
- "solana-program 2.1.1",
- "solana-sdk 2.1.1",
+ "solana-derivation-path",
+ "solana-program",
+ "solana-sdk",
  "subtle",
  "thiserror",
  "wasm-bindgen",
@@ -5678,23 +5256,25 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83029f0fac09633fc4463dd5a7d13959d1825dccf77889c6e617e2b1265fb2f1"
 dependencies = [
  "bytemuck",
  "num-derive 0.4.2",
  "num-traits",
- "solana-feature-set 2.1.1",
+ "solana-feature-set",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk 2.1.1",
- "solana-zk-token-sdk 2.1.1",
+ "solana-sdk",
+ "solana-zk-token-sdk",
 ]
 
 [[package]]
 name = "solana-zk-token-sdk"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed293089d8eebd6b5c1b53ee4ad6817889fea254274ddb34cb01ad35a2f817cb"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -5713,41 +5293,10 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha3",
- "solana-curve25519 2.1.0",
- "solana-derivation-path 2.1.0",
- "solana-program 2.1.0",
- "solana-sdk 2.1.0",
- "subtle",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "solana-zk-token-sdk"
-version = "2.1.1"
-source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
-dependencies = [
- "aes-gcm-siv",
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "byteorder",
- "curve25519-dalek 4.1.3",
- "itertools 0.12.1",
- "lazy_static",
- "merlin",
- "num-derive 0.4.2",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "serde_derive",
- "serde_json",
- "sha3",
- "solana-curve25519 2.1.1",
- "solana-derivation-path 2.1.1",
- "solana-program 2.1.1",
- "solana-sdk 2.1.1",
+ "solana-curve25519",
+ "solana-derivation-path",
+ "solana-program",
+ "solana-sdk",
  "subtle",
  "thiserror",
  "zeroize",
@@ -5796,7 +5345,7 @@ dependencies = [
  "borsh 1.5.1",
  "num-derive 0.4.2",
  "num-traits",
- "solana-program 2.1.0",
+ "solana-program",
  "spl-token",
  "spl-token-2022",
  "thiserror",
@@ -5809,7 +5358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a38ea8b6dedb7065887f12d62ed62c1743aa70749e8558f963609793f6fb12bc"
 dependencies = [
  "bytemuck",
- "solana-program 2.1.0",
+ "solana-program",
  "spl-discriminator-derive",
 ]
 
@@ -5843,7 +5392,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0dba2f2bb6419523405d21c301a32c9f9568354d4742552e7972af801f4bdb3"
 dependencies = [
- "solana-program 2.1.0",
+ "solana-program",
 ]
 
 [[package]]
@@ -5855,8 +5404,8 @@ dependencies = [
  "borsh 1.5.1",
  "bytemuck",
  "bytemuck_derive",
- "solana-program 2.1.0",
- "solana-zk-token-sdk 2.1.0",
+ "solana-program",
+ "solana-zk-token-sdk",
  "spl-program-error",
 ]
 
@@ -5868,7 +5417,7 @@ checksum = "d7b28bed65356558133751cc32b48a7a5ddfc59ac4e941314630bbed1ac10532"
 dependencies = [
  "num-derive 0.4.2",
  "num-traits",
- "solana-program 2.1.0",
+ "solana-program",
  "spl-program-error-derive",
  "thiserror",
 ]
@@ -5892,7 +5441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a75a5f0fcc58126693ed78a17042e9dc53f07e357d6be91789f7d62aff61a4"
 dependencies = [
  "bytemuck",
- "solana-program 2.1.0",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -5910,7 +5459,7 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "num_enum",
- "solana-program 2.1.0",
+ "solana-program",
  "thiserror",
 ]
 
@@ -5925,9 +5474,9 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "num_enum",
- "solana-program 2.1.0",
+ "solana-program",
  "solana-security-txt",
- "solana-zk-token-sdk 2.1.0",
+ "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
  "spl-token",
@@ -5945,7 +5494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8752b85a5ecc1d9f3a43bce3dd9a6a053673aacf5deb513d1cbb88d3534ffd"
 dependencies = [
  "bytemuck",
- "solana-program 2.1.0",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -5958,7 +5507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c2318ddff97e006ed9b1291ebec0750a78547f870f62a69c56fe3b46a5d8fc"
 dependencies = [
  "borsh 1.5.1",
- "solana-program 2.1.0",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -5973,7 +5522,7 @@ checksum = "a110f33d941275d9f868b96daaa993f1e73b6806cc8836e43075b4d3ad8338a7"
 dependencies = [
  "arrayref",
  "bytemuck",
- "solana-program 2.1.0",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -5988,7 +5537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdcd73ec187bc409464c60759232e309f83b52a18a9c5610bf281c9c6432918c"
 dependencies = [
  "bytemuck",
- "solana-program 2.1.0",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -7081,8 +6630,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "spl-associated-token-account"
-version = "5.0.1"
-source = "git+https://github.com/solana-labs/solana-program-library.git#a7dc7b14f30afd0e620b8b1761b63a420b6b9c26"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,10 +65,10 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-svm-transaction",
 ]
 
@@ -700,6 +700,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cfg_eval"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.83",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1548,7 +1560,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util 0.7.12",
@@ -1563,6 +1575,12 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1605,6 +1623,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "histogram"
@@ -1802,12 +1826,24 @@ checksum = "4e6ba961c14e98151cd6416dd3685efe786a94c38bc1a535c06ceff0a1600813"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.0",
+ "serde",
 ]
 
 [[package]]
@@ -2275,6 +2311,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "num-derive"
@@ -2853,9 +2900,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3258,9 +3305,16 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.6.0",
  "serde",
  "serde_derive",
+ "serde_json",
  "serde_with_macros",
+ "time",
 ]
 
 [[package]]
@@ -3400,14 +3454,27 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "solana-instruction",
- "solana-program",
+ "solana-instruction 2.1.0",
+ "solana-program 2.1.0",
+]
+
+[[package]]
+name = "solana-account"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction 2.1.1",
+ "solana-program 2.1.1",
 ]
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -3420,7 +3487,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-config-program",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "spl-token",
  "spl-token-2022",
  "spl-token-group-interface",
@@ -3431,16 +3498,16 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account",
- "solana-pubkey",
+ "solana-account 2.1.1",
+ "solana-pubkey 2.1.1",
  "zstd",
 ]
 
@@ -3451,15 +3518,27 @@ source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4b
 dependencies = [
  "bincode",
  "serde",
- "solana-program-error",
- "solana-program-memory",
- "solana-pubkey",
+ "solana-program-error 2.1.0",
+ "solana-program-memory 2.1.0",
+ "solana-pubkey 2.1.0",
+]
+
+[[package]]
+name = "solana-account-info"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "bincode",
+ "serde",
+ "solana-program-error 2.1.1",
+ "solana-program-memory 2.1.1",
+ "solana-pubkey 2.1.1",
 ]
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "ahash",
  "bincode",
@@ -3471,7 +3550,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "index_list",
- "indexmap",
+ "indexmap 2.6.0",
  "itertools 0.12.1",
  "lazy_static",
  "log",
@@ -3493,7 +3572,7 @@ dependencies = [
  "solana-metrics",
  "solana-nohash-hasher",
  "solana-rayon-threadlimit",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-svm-transaction",
  "static_assertions",
  "tar",
@@ -3503,19 +3582,19 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bincode",
  "bytemuck",
  "log",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
- "solana-feature-set",
+ "solana-feature-set 2.1.1",
  "solana-log-collector",
- "solana-program",
+ "solana-program 2.1.1",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "thiserror",
 ]
 
@@ -3528,15 +3607,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-atomic-u64"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "solana-banks-client"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "borsh 1.5.1",
  "futures",
  "solana-banks-interface",
- "solana-program",
- "solana-sdk",
+ "solana-program 2.1.1",
+ "solana-sdk 2.1.1",
  "tarpc",
  "thiserror",
  "tokio",
@@ -3545,28 +3632,28 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures",
  "solana-banks-interface",
  "solana-client",
- "solana-feature-set",
+ "solana-feature-set 2.1.1",
  "solana-runtime",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-send-transaction-service",
  "solana-svm",
  "tarpc",
@@ -3581,7 +3668,17 @@ source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4b
 dependencies = [
  "bincode",
  "serde",
- "solana-instruction",
+ "solana-instruction 2.1.0",
+]
+
+[[package]]
+name = "solana-bincode"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "bincode",
+ "serde",
+ "solana-instruction 2.1.1",
 ]
 
 [[package]]
@@ -3594,30 +3691,53 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "bytemuck",
- "solana-program",
+ "solana-program 2.1.0",
  "thiserror",
 ]
 
 [[package]]
+name = "solana-bn254"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "bytemuck",
+ "solana-program 2.1.1",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-borsh"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "borsh 0.10.4",
+ "borsh 1.5.1",
+]
+
+[[package]]
 name = "solana-bpf-loader-program"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bincode",
  "byteorder",
  "libsecp256k1",
  "log",
  "scopeguard",
- "solana-bn254",
+ "solana-bn254 2.1.1",
  "solana-compute-budget",
- "solana-curve25519",
- "solana-feature-set",
+ "solana-curve25519 2.1.1",
+ "solana-feature-set 2.1.1",
  "solana-log-collector",
  "solana-measure",
  "solana-poseidon",
- "solana-program-memory",
+ "solana-program-memory 2.1.1",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-timings",
  "solana-type-overrides",
  "solana_rbpf",
@@ -3626,8 +3746,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bv",
  "bytemuck",
@@ -3638,14 +3758,14 @@ dependencies = [
  "num_enum",
  "rand 0.8.5",
  "solana-measure",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "tempfile",
 ]
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "ahash",
  "lazy_static",
@@ -3655,23 +3775,23 @@ dependencies = [
  "solana-compute-budget-program",
  "solana-config-program",
  "solana-loader-v4-program",
- "solana-sdk",
- "solana-stake-program 2.1.0",
+ "solana-sdk 2.1.1",
+ "solana-stake-program 2.1.1",
  "solana-system-program",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-client"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "async-trait",
  "bincode",
  "dashmap",
  "futures",
  "futures-util",
- "indexmap",
+ "indexmap 2.6.0",
  "indicatif",
  "log",
  "quinn",
@@ -3683,7 +3803,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-rpc-client-nonce-utils",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-streamer",
  "solana-thin-client",
  "solana-tpu-client",
@@ -3699,30 +3819,41 @@ source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4b
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-macro",
+ "solana-sdk-macro 2.1.0",
+]
+
+[[package]]
+name = "solana-clock"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-macro 2.1.1",
+ "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
- "solana-sdk",
+ "solana-sdk 2.1.1",
 ]
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "solana-program-runtime",
- "solana-sdk",
+ "solana-sdk 2.1.1",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bincode",
  "chrono",
@@ -3730,46 +3861,59 @@ dependencies = [
  "serde_derive",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk",
- "solana-short-vec",
+ "solana-sdk 2.1.1",
+ "solana-short-vec 2.1.1",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "async-trait",
  "bincode",
  "crossbeam-channel",
  "futures-util",
- "indexmap",
+ "indexmap 2.6.0",
  "log",
  "rand 0.8.5",
  "rayon",
  "solana-measure",
  "solana-metrics",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "solana-cost-model"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "ahash",
  "lazy_static",
  "log",
  "solana-builtins-default-costs",
  "solana-compute-budget",
- "solana-feature-set",
+ "solana-feature-set 2.1.1",
  "solana-metrics",
  "solana-runtime-transaction",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-svm-transaction",
  "solana-vote-program",
+]
+
+[[package]]
+name = "solana-cpi"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "solana-account-info 2.1.1",
+ "solana-define-syscall 2.1.1",
+ "solana-instruction 2.1.1",
+ "solana-program-error 2.1.1",
+ "solana-pubkey 2.1.1",
+ "solana-stable-layout 2.1.1",
 ]
 
 [[package]]
@@ -3780,7 +3924,19 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-program",
+ "solana-program 2.1.0",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-curve25519"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek 4.1.3",
+ "solana-program 2.1.1",
  "thiserror",
 ]
 
@@ -3793,14 +3949,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-decode-error"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "solana-define-syscall"
 version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 
 [[package]]
+name = "solana-define-syscall"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+
+[[package]]
 name = "solana-derivation-path"
 version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+dependencies = [
+ "derivation-path",
+ "qstring",
+ "uriparse",
+]
+
+[[package]]
+name = "solana-derivation-path"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "derivation-path",
  "qstring",
@@ -3814,7 +3993,18 @@ source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4b
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-macro",
+ "solana-sdk-macro 2.1.0",
+]
+
+[[package]]
+name = "solana-epoch-schedule"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-macro 2.1.1",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -3823,19 +4013,32 @@ version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 dependencies = [
  "lazy_static",
- "solana-clock",
- "solana-epoch-schedule",
- "solana-hash",
- "solana-pubkey",
- "solana-sha256-hasher",
+ "solana-clock 2.1.0",
+ "solana-epoch-schedule 2.1.0",
+ "solana-hash 2.1.0",
+ "solana-pubkey 2.1.0",
+ "solana-sha256-hasher 2.1.0",
+]
+
+[[package]]
+name = "solana-feature-set"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "lazy_static",
+ "solana-clock 2.1.1",
+ "solana-epoch-schedule 2.1.1",
+ "solana-hash 2.1.1",
+ "solana-pubkey 2.1.1",
+ "solana-sha256-hasher 2.1.1",
 ]
 
 [[package]]
 name = "solana-fee"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-svm-transaction",
 ]
 
@@ -3843,6 +4046,16 @@ dependencies = [
 name = "solana-fee-calculator"
 version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-fee-calculator"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "log",
  "serde",
@@ -3861,18 +4074,44 @@ dependencies = [
  "js-sys",
  "serde",
  "serde_derive",
- "solana-atomic-u64",
- "solana-sanitize",
+ "solana-atomic-u64 2.1.0",
+ "solana-sanitize 2.1.0",
  "wasm-bindgen",
 ]
 
 [[package]]
+name = "solana-hash"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "borsh 1.5.1",
+ "bs58",
+ "bytemuck",
+ "bytemuck_derive",
+ "js-sys",
+ "serde",
+ "serde_derive",
+ "solana-atomic-u64 2.1.1",
+ "solana-sanitize 2.1.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-inflation"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "solana-inline-spl"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bytemuck",
- "solana-pubkey",
+ "solana-pubkey 2.1.1",
 ]
 
 [[package]]
@@ -3887,15 +4126,43 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-define-syscall",
- "solana-pubkey",
+ "solana-define-syscall 2.1.0",
+ "solana-pubkey 2.1.0",
  "wasm-bindgen",
 ]
 
 [[package]]
+name = "solana-instruction"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "bincode",
+ "borsh 1.5.1",
+ "getrandom 0.2.15",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-define-syscall 2.1.1",
+ "solana-pubkey 2.1.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-last-restart-slot"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-macro 2.1.1",
+ "solana-sysvar-id",
+]
+
+[[package]]
 name = "solana-lattice-hash"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -3905,8 +4172,8 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "log",
  "solana-bpf-loader-program",
@@ -3914,23 +4181,23 @@ dependencies = [
  "solana-log-collector",
  "solana-measure",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-type-overrides",
  "solana_rbpf",
 ]
 
 [[package]]
 name = "solana-log-collector"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -3939,20 +4206,20 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 
 [[package]]
 name = "solana-metrics"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
  "lazy_static",
  "log",
  "reqwest",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "thiserror",
 ]
 
@@ -3961,7 +4228,15 @@ name = "solana-msg"
 version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 dependencies = [
- "solana-define-syscall",
+ "solana-define-syscall 2.1.0",
+]
+
+[[package]]
+name = "solana-msg"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "solana-define-syscall 2.1.1",
 ]
 
 [[package]]
@@ -3970,9 +4245,14 @@ version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 
 [[package]]
+name = "solana-native-token"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+
+[[package]]
 name = "solana-net-utils"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -3982,7 +4262,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "tokio",
  "url",
 ]
@@ -3994,9 +4274,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
+name = "solana-packet"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "bincode",
+ "bitflags 2.6.0",
+ "cfg_eval",
+ "serde",
+ "serde_derive",
+ "serde_with",
+]
+
+[[package]]
 name = "solana-perf"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "ahash",
  "bincode",
@@ -4014,19 +4307,19 @@ dependencies = [
  "serde",
  "solana-metrics",
  "solana-rayon-threadlimit",
- "solana-sdk",
- "solana-short-vec",
+ "solana-sdk 2.1.1",
+ "solana-short-vec 2.1.1",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-poseidon"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
- "solana-define-syscall",
+ "solana-define-syscall 2.1.1",
  "thiserror",
 ]
 
@@ -4036,7 +4329,16 @@ version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 dependencies = [
  "num-traits",
- "solana-decode-error",
+ "solana-decode-error 2.1.0",
+]
+
+[[package]]
+name = "solana-precompile-error"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "num-traits",
+ "solana-decode-error 2.1.1",
 ]
 
 [[package]]
@@ -4064,7 +4366,7 @@ dependencies = [
  "log",
  "memoffset",
  "num-bigint 0.4.6",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "parking_lot",
  "rand 0.8.5",
@@ -4073,35 +4375,107 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.8",
  "sha3",
- "solana-account-info",
- "solana-atomic-u64",
- "solana-bincode",
- "solana-clock",
- "solana-decode-error",
- "solana-define-syscall",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
- "solana-msg",
- "solana-native-token",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-macro",
- "solana-secp256k1-recover",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-sha256-hasher",
- "solana-short-vec",
- "solana-slot-hashes",
- "solana-stable-layout",
- "solana-transaction-error",
+ "solana-account-info 2.1.0",
+ "solana-atomic-u64 2.1.0",
+ "solana-bincode 2.1.0",
+ "solana-clock 2.1.0",
+ "solana-decode-error 2.1.0",
+ "solana-define-syscall 2.1.0",
+ "solana-epoch-schedule 2.1.0",
+ "solana-fee-calculator 2.1.0",
+ "solana-hash 2.1.0",
+ "solana-instruction 2.1.0",
+ "solana-msg 2.1.0",
+ "solana-native-token 2.1.0",
+ "solana-program-entrypoint 2.1.0",
+ "solana-program-error 2.1.0",
+ "solana-program-memory 2.1.0",
+ "solana-program-option 2.1.0",
+ "solana-program-pack 2.1.0",
+ "solana-pubkey 2.1.0",
+ "solana-rent 2.1.0",
+ "solana-sanitize 2.1.0",
+ "solana-sdk-macro 2.1.0",
+ "solana-secp256k1-recover 2.1.0",
+ "solana-serde-varint 2.1.0",
+ "solana-serialize-utils 2.1.0",
+ "solana-sha256-hasher 2.1.0",
+ "solana-short-vec 2.1.0",
+ "solana-slot-hashes 2.1.0",
+ "solana-stable-layout 2.1.0",
+ "solana-transaction-error 2.1.0",
+ "thiserror",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-program"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "bitflags 2.6.0",
+ "blake3",
+ "borsh 0.10.4",
+ "borsh 1.5.1",
+ "bs58",
+ "bv",
+ "bytemuck",
+ "bytemuck_derive",
+ "console_error_panic_hook",
+ "console_log",
+ "curve25519-dalek 4.1.3",
+ "five8_const",
+ "getrandom 0.2.15",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "memoffset",
+ "num-bigint 0.4.6",
+ "num-derive 0.4.2",
+ "num-traits",
+ "parking_lot",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "sha2 0.10.8",
+ "sha3",
+ "solana-account-info 2.1.1",
+ "solana-atomic-u64 2.1.1",
+ "solana-bincode 2.1.1",
+ "solana-borsh",
+ "solana-clock 2.1.1",
+ "solana-cpi",
+ "solana-decode-error 2.1.1",
+ "solana-define-syscall 2.1.1",
+ "solana-epoch-schedule 2.1.1",
+ "solana-fee-calculator 2.1.1",
+ "solana-hash 2.1.1",
+ "solana-instruction 2.1.1",
+ "solana-last-restart-slot",
+ "solana-msg 2.1.1",
+ "solana-native-token 2.1.1",
+ "solana-program-entrypoint 2.1.1",
+ "solana-program-error 2.1.1",
+ "solana-program-memory 2.1.1",
+ "solana-program-option 2.1.1",
+ "solana-program-pack 2.1.1",
+ "solana-pubkey 2.1.1",
+ "solana-rent 2.1.1",
+ "solana-sanitize 2.1.1",
+ "solana-sdk-macro 2.1.1",
+ "solana-secp256k1-recover 2.1.1",
+ "solana-serde-varint 2.1.1",
+ "solana-serialize-utils 2.1.1",
+ "solana-sha256-hasher 2.1.1",
+ "solana-short-vec 2.1.1",
+ "solana-slot-hashes 2.1.1",
+ "solana-slot-history",
+ "solana-stable-layout 2.1.1",
+ "solana-sysvar-id",
+ "solana-transaction-error 2.1.1",
  "thiserror",
  "wasm-bindgen",
 ]
@@ -4111,10 +4485,21 @@ name = "solana-program-entrypoint"
 version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 dependencies = [
- "solana-account-info",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
+ "solana-account-info 2.1.0",
+ "solana-msg 2.1.0",
+ "solana-program-error 2.1.0",
+ "solana-pubkey 2.1.0",
+]
+
+[[package]]
+name = "solana-program-entrypoint"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "solana-account-info 2.1.1",
+ "solana-msg 2.1.1",
+ "solana-program-error 2.1.1",
+ "solana-pubkey 2.1.1",
 ]
 
 [[package]]
@@ -4126,10 +4511,25 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-pubkey",
+ "solana-decode-error 2.1.0",
+ "solana-instruction 2.1.0",
+ "solana-msg 2.1.0",
+ "solana-pubkey 2.1.0",
+]
+
+[[package]]
+name = "solana-program-error"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "borsh 1.5.1",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-decode-error 2.1.1",
+ "solana-instruction 2.1.1",
+ "solana-msg 2.1.1",
+ "solana-pubkey 2.1.1",
 ]
 
 [[package]]
@@ -4138,7 +4538,16 @@ version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 dependencies = [
  "num-traits",
- "solana-define-syscall",
+ "solana-define-syscall 2.1.0",
+]
+
+[[package]]
+name = "solana-program-memory"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "num-traits",
+ "solana-define-syscall 2.1.1",
 ]
 
 [[package]]
@@ -4147,17 +4556,30 @@ version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 
 [[package]]
+name = "solana-program-option"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+
+[[package]]
 name = "solana-program-pack"
 version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 dependencies = [
- "solana-program-error",
+ "solana-program-error 2.1.0",
+]
+
+[[package]]
+name = "solana-program-pack"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "solana-program-error 2.1.1",
 ]
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4165,17 +4587,17 @@ dependencies = [
  "itertools 0.12.1",
  "libc",
  "log",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "percentage",
  "rand 0.8.5",
  "serde",
  "solana-compute-budget",
- "solana-feature-set",
+ "solana-feature-set 2.1.1",
  "solana-log-collector",
  "solana-measure",
  "solana-metrics",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-timings",
  "solana-type-overrides",
  "solana-vote",
@@ -4185,8 +4607,8 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4202,14 +4624,14 @@ dependencies = [
  "solana-banks-server",
  "solana-bpf-loader-program",
  "solana-compute-budget",
- "solana-feature-set",
+ "solana-feature-set 2.1.1",
  "solana-inline-spl",
- "solana-instruction",
+ "solana-instruction 2.1.1",
  "solana-log-collector",
  "solana-logger",
  "solana-program-runtime",
  "solana-runtime",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-svm",
  "solana-timings",
  "solana-vote-program",
@@ -4236,18 +4658,44 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_derive",
- "solana-atomic-u64",
- "solana-decode-error",
- "solana-define-syscall",
- "solana-sanitize",
- "solana-sha256-hasher",
+ "solana-atomic-u64 2.1.0",
+ "solana-decode-error 2.1.0",
+ "solana-define-syscall 2.1.0",
+ "solana-sanitize 2.1.0",
+ "solana-sha256-hasher 2.1.0",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-pubkey"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "borsh 0.10.4",
+ "borsh 1.5.1",
+ "bs58",
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek 4.1.3",
+ "five8_const",
+ "getrandom 0.2.15",
+ "js-sys",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "solana-atomic-u64 2.1.1",
+ "solana-decode-error 2.1.1",
+ "solana-define-syscall 2.1.1",
+ "solana-sanitize 2.1.1",
+ "solana-sha256-hasher 2.1.1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -4259,7 +4707,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4270,8 +4718,8 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -4287,7 +4735,7 @@ dependencies = [
  "solana-metrics",
  "solana-net-utils",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-streamer",
  "thiserror",
  "tokio",
@@ -4295,8 +4743,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -4309,13 +4757,24 @@ source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4b
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-macro",
+ "solana-sdk-macro 2.1.0",
+]
+
+[[package]]
+name = "solana-rent"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-macro 2.1.1",
+ "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4331,7 +4790,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-transaction-status-client-types",
  "solana-version",
  "solana-vote-program",
@@ -4340,8 +4799,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4355,7 +4814,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-inline-spl",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-transaction-status-client-types",
  "solana-version",
  "thiserror",
@@ -4363,18 +4822,18 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "solana-rpc-client",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-runtime"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "ahash",
  "aquamarine",
@@ -4401,7 +4860,7 @@ dependencies = [
  "memmap2",
  "mockall",
  "modular-bitfield",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "num_cpus",
  "num_enum",
@@ -4422,7 +4881,7 @@ dependencies = [
  "solana-compute-budget-program",
  "solana-config-program",
  "solana-cost-model",
- "solana-feature-set",
+ "solana-feature-set 2.1.1",
  "solana-fee",
  "solana-inline-spl",
  "solana-lattice-hash",
@@ -4430,12 +4889,12 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-perf",
- "solana-program",
+ "solana-program 2.1.1",
  "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime-transaction",
- "solana-sdk",
- "solana-stake-program 2.1.0",
+ "solana-sdk 2.1.1",
+ "solana-stake-program 2.1.1",
  "solana-svm",
  "solana-svm-rent-collector",
  "solana-svm-transaction",
@@ -4448,7 +4907,7 @@ dependencies = [
  "solana-zk-elgamal-proof-program",
  "solana-zk-sdk",
  "solana-zk-token-proof-program",
- "solana-zk-token-sdk",
+ "solana-zk-token-sdk 2.1.1",
  "static_assertions",
  "strum",
  "strum_macros",
@@ -4461,15 +4920,15 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "agave-transaction-view",
  "log",
  "solana-builtins-default-costs",
  "solana-compute-budget",
- "solana-pubkey",
- "solana-sdk",
+ "solana-pubkey 2.1.1",
+ "solana-sdk 2.1.1",
  "solana-svm-transaction",
  "thiserror",
 ]
@@ -4478,6 +4937,11 @@ dependencies = [
 name = "solana-sanitize"
 version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+
+[[package]]
+name = "solana-sanitize"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 
 [[package]]
 name = "solana-sdk"
@@ -4503,7 +4967,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "memmap2",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "num_enum",
  "pbkdf2",
@@ -4517,24 +4981,86 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "siphasher",
- "solana-account",
- "solana-bn254",
- "solana-decode-error",
- "solana-derivation-path",
- "solana-feature-set",
- "solana-instruction",
- "solana-native-token",
- "solana-precompile-error",
- "solana-program",
- "solana-program-memory",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-macro",
- "solana-secp256k1-recover",
- "solana-serde-varint",
- "solana-short-vec",
- "solana-signature",
- "solana-transaction-error",
+ "solana-account 2.1.0",
+ "solana-bn254 2.1.0",
+ "solana-decode-error 2.1.0",
+ "solana-derivation-path 2.1.0",
+ "solana-feature-set 2.1.0",
+ "solana-instruction 2.1.0",
+ "solana-native-token 2.1.0",
+ "solana-precompile-error 2.1.0",
+ "solana-program 2.1.0",
+ "solana-program-memory 2.1.0",
+ "solana-pubkey 2.1.0",
+ "solana-sanitize 2.1.0",
+ "solana-sdk-macro 2.1.0",
+ "solana-secp256k1-recover 2.1.0",
+ "solana-serde-varint 2.1.0",
+ "solana-short-vec 2.1.0",
+ "solana-signature 2.1.0",
+ "solana-transaction-error 2.1.0",
+ "thiserror",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-sdk"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "bincode",
+ "bitflags 2.6.0",
+ "borsh 1.5.1",
+ "bs58",
+ "bytemuck",
+ "bytemuck_derive",
+ "byteorder",
+ "chrono",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "getrandom 0.1.16",
+ "hmac 0.12.1",
+ "itertools 0.12.1",
+ "js-sys",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "memmap2",
+ "num-derive 0.4.2",
+ "num-traits",
+ "num_enum",
+ "pbkdf2",
+ "rand 0.7.3",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.8",
+ "sha3",
+ "siphasher",
+ "solana-account 2.1.1",
+ "solana-bn254 2.1.1",
+ "solana-decode-error 2.1.1",
+ "solana-derivation-path 2.1.1",
+ "solana-feature-set 2.1.1",
+ "solana-inflation",
+ "solana-instruction 2.1.1",
+ "solana-native-token 2.1.1",
+ "solana-packet",
+ "solana-precompile-error 2.1.1",
+ "solana-program 2.1.1",
+ "solana-program-memory 2.1.1",
+ "solana-pubkey 2.1.1",
+ "solana-sanitize 2.1.1",
+ "solana-sdk-macro 2.1.1",
+ "solana-secp256k1-recover 2.1.1",
+ "solana-serde-varint 2.1.1",
+ "solana-short-vec 2.1.1",
+ "solana-signature 2.1.1",
+ "solana-transaction-error 2.1.1",
  "thiserror",
  "wasm-bindgen",
 ]
@@ -4551,13 +5077,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-sdk-macro"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "bs58",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.83",
+]
+
+[[package]]
 name = "solana-secp256k1-recover"
 version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 dependencies = [
  "borsh 1.5.1",
  "libsecp256k1",
- "solana-define-syscall",
+ "solana-define-syscall 2.1.0",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-secp256k1-recover"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "borsh 1.5.1",
+ "libsecp256k1",
+ "solana-define-syscall 2.1.1",
  "thiserror",
 ]
 
@@ -4569,8 +5117,8 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -4579,7 +5127,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-tpu-client",
 ]
 
@@ -4592,13 +5140,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-serde-varint"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "solana-serialize-utils"
 version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 dependencies = [
- "solana-instruction",
- "solana-pubkey",
- "solana-sanitize",
+ "solana-instruction 2.1.0",
+ "solana-pubkey 2.1.0",
+ "solana-sanitize 2.1.0",
+]
+
+[[package]]
+name = "solana-serialize-utils"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "solana-instruction 2.1.1",
+ "solana-pubkey 2.1.1",
+ "solana-sanitize 2.1.1",
 ]
 
 [[package]]
@@ -4607,14 +5173,32 @@ version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 dependencies = [
  "sha2 0.10.8",
- "solana-define-syscall",
- "solana-hash",
+ "solana-define-syscall 2.1.0",
+ "solana-hash 2.1.0",
+]
+
+[[package]]
+name = "solana-sha256-hasher"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "sha2 0.10.8",
+ "solana-define-syscall 2.1.1",
+ "solana-hash 2.1.1",
 ]
 
 [[package]]
 name = "solana-short-vec"
 version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "solana-short-vec"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "serde",
 ]
@@ -4630,7 +5214,21 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_derive",
- "solana-sanitize",
+ "solana-sanitize 2.1.0",
+]
+
+[[package]]
+name = "solana-signature"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "bs58",
+ "ed25519-dalek",
+ "generic-array",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "solana-sanitize 2.1.1",
 ]
 
 [[package]]
@@ -4640,7 +5238,29 @@ source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4b
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash",
+ "solana-hash 2.1.0",
+]
+
+[[package]]
+name = "solana-slot-hashes"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-hash 2.1.1",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-slot-history"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "bv",
+ "serde",
+ "serde_derive",
+ "solana-sysvar-id",
 ]
 
 [[package]]
@@ -4648,8 +5268,33 @@ name = "solana-stable-layout"
 version = "2.1.0"
 source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
 dependencies = [
- "solana-instruction",
- "solana-pubkey",
+ "solana-instruction 2.1.0",
+ "solana-pubkey 2.1.0",
+]
+
+[[package]]
+name = "solana-stable-layout"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "solana-instruction 2.1.1",
+ "solana-pubkey 2.1.1",
+]
+
+[[package]]
+name = "solana-stake-client"
+version = "0.0.0"
+dependencies = [
+ "assert_matches",
+ "borsh 0.10.4",
+ "num-derive 0.3.3",
+ "num-traits",
+ "serde",
+ "serde_with",
+ "solana-program 2.1.1",
+ "solana-program-test",
+ "solana-sdk 2.1.1",
+ "thiserror",
 ]
 
 [[package]]
@@ -4659,12 +5304,12 @@ dependencies = [
  "arrayref",
  "bincode",
  "borsh 1.5.1",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "num_enum",
- "solana-program",
+ "solana-program 2.1.1",
  "solana-program-test",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-vote-program",
  "test-case",
  "thiserror",
@@ -4672,24 +5317,24 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bincode",
  "log",
  "solana-config-program",
- "solana-feature-set",
+ "solana-feature-set 2.1.1",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-type-overrides",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "async-channel",
  "bytes",
@@ -4699,7 +5344,7 @@ dependencies = [
  "futures-util",
  "governor",
  "histogram",
- "indexmap",
+ "indexmap 2.6.0",
  "itertools 0.12.1",
  "libc",
  "log",
@@ -4715,7 +5360,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-perf",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-transaction-metrics-tracker",
  "thiserror",
  "tokio",
@@ -4725,8 +5370,8 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -4735,14 +5380,14 @@ dependencies = [
  "serde_derive",
  "solana-bpf-loader-program",
  "solana-compute-budget",
- "solana-feature-set",
+ "solana-feature-set 2.1.1",
  "solana-fee",
  "solana-loader-v4-program",
  "solana-log-collector",
  "solana-measure",
  "solana-program-runtime",
  "solana-runtime-transaction",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-system-program",
@@ -4754,24 +5399,24 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
- "solana-sdk",
+ "solana-sdk 2.1.1",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
- "solana-sdk",
+ "solana-sdk 2.1.1",
 ]
 
 [[package]]
 name = "solana-system-program"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bincode",
  "log",
@@ -4779,14 +5424,22 @@ dependencies = [
  "serde_derive",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-type-overrides",
 ]
 
 [[package]]
+name = "solana-sysvar-id"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "solana-pubkey 2.1.1",
+]
+
+[[package]]
 name = "solana-thin-client"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bincode",
  "log",
@@ -4794,28 +5447,28 @@ dependencies = [
  "solana-connection-cache",
  "solana-rpc-client",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-sdk 2.1.1",
 ]
 
 [[package]]
 name = "solana-timings"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "eager",
  "enum-iterator",
- "solana-sdk",
+ "solana-sdk 2.1.1",
 ]
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "async-trait",
  "bincode",
  "futures-util",
- "indexmap",
+ "indexmap 2.6.0",
  "indicatif",
  "log",
  "rayon",
@@ -4824,7 +5477,7 @@ dependencies = [
  "solana-pubsub-client",
  "solana-rpc-client",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "thiserror",
  "tokio",
 ]
@@ -4836,14 +5489,25 @@ source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4b
 dependencies = [
  "serde",
  "serde_derive",
- "solana-instruction",
- "solana-sanitize",
+ "solana-instruction 2.1.0",
+ "solana-sanitize 2.1.0",
+]
+
+[[package]]
+name = "solana-transaction-error"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-instruction 2.1.1",
+ "solana-sanitize 2.1.1",
 ]
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4851,14 +5515,14 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "solana-perf",
- "solana-sdk",
- "solana-short-vec",
+ "solana-sdk 2.1.1",
+ "solana-short-vec 2.1.1",
 ]
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -4871,7 +5535,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-transaction-status-client-types",
  "spl-associated-token-account",
  "spl-memo",
@@ -4884,8 +5548,8 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4894,15 +5558,15 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-sdk",
- "solana-signature",
+ "solana-sdk 2.1.1",
+ "solana-signature 2.1.1",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -4910,13 +5574,13 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
  "solana-net-utils",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-streamer",
  "thiserror",
  "tokio",
@@ -4924,67 +5588,67 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "semver",
  "serde",
  "serde_derive",
- "solana-feature-set",
- "solana-sanitize",
- "solana-serde-varint",
+ "solana-feature-set 2.1.1",
+ "solana-sanitize 2.1.1",
+ "solana-serde-varint 2.1.1",
 ]
 
 [[package]]
 name = "solana-vote"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "itertools 0.12.1",
  "log",
  "serde",
  "serde_derive",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bincode",
  "log",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "serde",
  "serde_derive",
- "solana-feature-set",
+ "solana-feature-set 2.1.1",
  "solana-metrics",
- "solana-program",
+ "solana-program 2.1.1",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-sdk 2.1.1",
  "solana-zk-sdk",
 ]
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -4996,16 +5660,16 @@ dependencies = [
  "js-sys",
  "lazy_static",
  "merlin",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "rand 0.8.5",
  "serde",
  "serde_derive",
  "serde_json",
  "sha3",
- "solana-derivation-path",
- "solana-program",
- "solana-sdk",
+ "solana-derivation-path 2.1.1",
+ "solana-program 2.1.1",
+ "solana-sdk 2.1.1",
  "subtle",
  "thiserror",
  "wasm-bindgen",
@@ -5014,17 +5678,17 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave.git#0e16e60e08fcfdb1b4a12f19ca4be4054a2707dc"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
 dependencies = [
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
- "solana-feature-set",
+ "solana-feature-set 2.1.1",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk",
- "solana-zk-token-sdk",
+ "solana-sdk 2.1.1",
+ "solana-zk-token-sdk 2.1.1",
 ]
 
 [[package]]
@@ -5042,17 +5706,48 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "merlin",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "rand 0.8.5",
  "serde",
  "serde_derive",
  "serde_json",
  "sha3",
- "solana-curve25519",
- "solana-derivation-path",
- "solana-program",
- "solana-sdk",
+ "solana-curve25519 2.1.0",
+ "solana-derivation-path 2.1.0",
+ "solana-program 2.1.0",
+ "solana-sdk 2.1.0",
+ "subtle",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "solana-zk-token-sdk"
+version = "2.1.1"
+source = "git+https://github.com/anza-xyz/agave.git?branch=v2.1#b76df54042d86548a770d657cdbd60b7c7445b2c"
+dependencies = [
+ "aes-gcm-siv",
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "byteorder",
+ "curve25519-dalek 4.1.3",
+ "itertools 0.12.1",
+ "lazy_static",
+ "merlin",
+ "num-derive 0.4.2",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha3",
+ "solana-curve25519 2.1.1",
+ "solana-derivation-path 2.1.1",
+ "solana-program 2.1.1",
+ "solana-sdk 2.1.1",
  "subtle",
  "thiserror",
  "zeroize",
@@ -5099,9 +5794,9 @@ checksum = "68034596cf4804880d265f834af1ff2f821ad5293e41fa0f8f59086c181fc38e"
 dependencies = [
  "assert_matches",
  "borsh 1.5.1",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
- "solana-program",
+ "solana-program 2.1.0",
  "spl-token",
  "spl-token-2022",
  "thiserror",
@@ -5114,7 +5809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a38ea8b6dedb7065887f12d62ed62c1743aa70749e8558f963609793f6fb12bc"
 dependencies = [
  "bytemuck",
- "solana-program",
+ "solana-program 2.1.0",
  "spl-discriminator-derive",
 ]
 
@@ -5148,7 +5843,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0dba2f2bb6419523405d21c301a32c9f9568354d4742552e7972af801f4bdb3"
 dependencies = [
- "solana-program",
+ "solana-program 2.1.0",
 ]
 
 [[package]]
@@ -5160,8 +5855,8 @@ dependencies = [
  "borsh 1.5.1",
  "bytemuck",
  "bytemuck_derive",
- "solana-program",
- "solana-zk-token-sdk",
+ "solana-program 2.1.0",
+ "solana-zk-token-sdk 2.1.0",
  "spl-program-error",
 ]
 
@@ -5171,9 +5866,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b28bed65356558133751cc32b48a7a5ddfc59ac4e941314630bbed1ac10532"
 dependencies = [
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
- "solana-program",
+ "solana-program 2.1.0",
  "spl-program-error-derive",
  "thiserror",
 ]
@@ -5197,7 +5892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a75a5f0fcc58126693ed78a17042e9dc53f07e357d6be91789f7d62aff61a4"
 dependencies = [
  "bytemuck",
- "solana-program",
+ "solana-program 2.1.0",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -5212,10 +5907,10 @@ checksum = "70a0f06ac7f23dc0984931b1fe309468f14ea58e32660439c1cef19456f5d0e3"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "num_enum",
- "solana-program",
+ "solana-program 2.1.0",
  "thiserror",
 ]
 
@@ -5227,12 +5922,12 @@ checksum = "d9c10f3483e48679619c76598d4e4aebb955bc49b0a5cc63323afbf44135c9bf"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "num_enum",
- "solana-program",
+ "solana-program 2.1.0",
  "solana-security-txt",
- "solana-zk-token-sdk",
+ "solana-zk-token-sdk 2.1.0",
  "spl-memo",
  "spl-pod",
  "spl-token",
@@ -5250,7 +5945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8752b85a5ecc1d9f3a43bce3dd9a6a053673aacf5deb513d1cbb88d3534ffd"
 dependencies = [
  "bytemuck",
- "solana-program",
+ "solana-program 2.1.0",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -5263,7 +5958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c2318ddff97e006ed9b1291ebec0750a78547f870f62a69c56fe3b46a5d8fc"
 dependencies = [
  "borsh 1.5.1",
- "solana-program",
+ "solana-program 2.1.0",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -5278,7 +5973,7 @@ checksum = "a110f33d941275d9f868b96daaa993f1e73b6806cc8836e43075b4d3ad8338a7"
 dependencies = [
  "arrayref",
  "bytemuck",
- "solana-program",
+ "solana-program 2.1.0",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -5293,7 +5988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdcd73ec187bc409464c60759232e309f83b52a18a9c5610bf281c9c6432918c"
 dependencies = [
  "bytemuck",
- "solana-program",
+ "solana-program 2.1.0",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -5740,7 +6435,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.6.0",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
-    # XXX removed due to dependency issues "clients/rust",
+    "clients/rust",
     "program",
 ]
 
@@ -11,11 +11,11 @@ solana = "edge"
 # Specify Rust toolchains for rustfmt, clippy, and build.
 # Any unprovided toolchains default to stable.
 [workspace.metadata.toolchains]
-format = "nightly-2023-10-05"
-lint = "nightly-2023-10-05"
+format = "nightly-2024-08-08"
+lint = "nightly-2024-08-08"
 
 [patch.crates-io]
-solana-program = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-solana-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-solana-zk-token-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
+solana-program = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1" }
+solana-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1" }
+solana-zk-token-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1" }
 spl-associated-token-account = { git = "https://github.com/solana-labs/solana-program-library.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,3 @@ solana = "edge"
 [workspace.metadata.toolchains]
 format = "nightly-2024-08-08"
 lint = "nightly-2024-08-08"
-
-[patch.crates-io]
-solana-program = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1" }
-solana-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1" }
-solana-zk-token-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1" }
-spl-associated-token-account = { git = "https://github.com/solana-labs/solana-program-library.git" }

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -17,10 +17,10 @@ num-derive = "^0.3"
 num-traits = "^0.2"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.0", optional = true }
-solana-program = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
+solana-program = ">= 1.16, < 3"
 thiserror = "^1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-solana-program-test = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
-solana-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
+solana-program-test = "2.1"
+solana-sdk = "2.1"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -17,7 +17,7 @@ num-derive = "^0.3"
 num-traits = "^0.2"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.0", optional = true }
-solana-program = ">= 1.16, < 3"
+solana-program = "2.1"
 thiserror = "^1.0"
 
 [dev-dependencies]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -8,27 +8,19 @@ readme = "README.md"
 license-file = "../../LICENSE"
 
 [features]
-anchor = ["dep:anchor-lang"]
 test-sbf = []
 serde = ["dep:serde", "dep:serde_with"]
 
 [dependencies]
-anchor-lang = { version = "0.30.0", optional = true }
 borsh = "^0.10"
 num-derive = "^0.3"
 num-traits = "^0.2"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.0", optional = true }
-solana-program = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
+solana-program = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
 thiserror = "^1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-solana-program-test = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-solana-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-
-[patch.crates-io]
-solana-program = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-solana-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-solana-zk-token-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-spl-associated-token-account = { git = "https://github.com/solana-labs/solana-program-library.git" }
+solana-program-test = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
+solana-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }

--- a/clients/rust/src/generated/errors/mod.rs
+++ b/clients/rust/src/generated/errors/mod.rs
@@ -3,3 +3,4 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!

--- a/clients/rust/src/generated/instructions/authorize.rs
+++ b/clients/rust/src/generated/instructions/authorize.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use {
     crate::generated::types::StakeAuthorize,
@@ -16,9 +17,7 @@ pub struct Authorize {
     pub stake: solana_program::pubkey::Pubkey,
     /// Clock sysvar
     pub clock: solana_program::pubkey::Pubkey,
-    /// stake's current stake or withdraw authority to change away from. If
-    /// stake Lockup is active, the signing lockup authority must follow if
-    /// updating withdrawer
+    /// stake's current stake or withdraw authority to change away from. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer
     pub authority: solana_program::pubkey::Pubkey,
 }
 
@@ -118,9 +117,7 @@ impl AuthorizeBuilder {
         self.clock = Some(clock);
         self
     }
-    /// stake's current stake or withdraw authority to change away from. If
-    /// stake Lockup is active, the signing lockup authority must follow if
-    /// updating withdrawer
+    /// stake's current stake or withdraw authority to change away from. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer
     #[inline(always)]
     pub fn authority(&mut self, authority: solana_program::pubkey::Pubkey) -> &mut Self {
         self.authority = Some(authority);
@@ -182,9 +179,7 @@ pub struct AuthorizeCpiAccounts<'a, 'b> {
     pub stake: &'b solana_program::account_info::AccountInfo<'a>,
     /// Clock sysvar
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
-    /// stake's current stake or withdraw authority to change away from. If
-    /// stake Lockup is active, the signing lockup authority must follow if
-    /// updating withdrawer
+    /// stake's current stake or withdraw authority to change away from. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
@@ -196,9 +191,7 @@ pub struct AuthorizeCpi<'a, 'b> {
     pub stake: &'b solana_program::account_info::AccountInfo<'a>,
     /// Clock sysvar
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
-    /// stake's current stake or withdraw authority to change away from. If
-    /// stake Lockup is active, the signing lockup authority must follow if
-    /// updating withdrawer
+    /// stake's current stake or withdraw authority to change away from. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: AuthorizeInstructionArgs,
@@ -334,9 +327,7 @@ impl<'a, 'b> AuthorizeCpiBuilder<'a, 'b> {
         self.instruction.clock = Some(clock);
         self
     }
-    /// stake's current stake or withdraw authority to change away from. If
-    /// stake Lockup is active, the signing lockup authority must follow if
-    /// updating withdrawer
+    /// stake's current stake or withdraw authority to change away from. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer
     #[inline(always)]
     pub fn authority(
         &mut self,
@@ -370,9 +361,8 @@ impl<'a, 'b> AuthorizeCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/authorize_checked.rs
+++ b/clients/rust/src/generated/instructions/authorize_checked.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use {
     crate::generated::types::StakeAuthorize,
@@ -17,8 +18,7 @@ pub struct AuthorizeChecked {
     pub clock: solana_program::pubkey::Pubkey,
     /// stake's current stake or withdraw authority to change away from
     pub authority: solana_program::pubkey::Pubkey,
-    /// stake's new stake or withdraw authority to change to. If stake Lockup is
-    /// active, the signing lockup authority must follow if updating withdrawer.
+    /// stake's new stake or withdraw authority to change to. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     pub new_authority: solana_program::pubkey::Pubkey,
 }
 
@@ -128,8 +128,7 @@ impl AuthorizeCheckedBuilder {
         self.authority = Some(authority);
         self
     }
-    /// stake's new stake or withdraw authority to change to. If stake Lockup is
-    /// active, the signing lockup authority must follow if updating withdrawer.
+    /// stake's new stake or withdraw authority to change to. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     #[inline(always)]
     pub fn new_authority(&mut self, new_authority: solana_program::pubkey::Pubkey) -> &mut Self {
         self.new_authority = Some(new_authority);
@@ -185,8 +184,7 @@ pub struct AuthorizeCheckedCpiAccounts<'a, 'b> {
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
     /// stake's current stake or withdraw authority to change away from
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
-    /// stake's new stake or withdraw authority to change to. If stake Lockup is
-    /// active, the signing lockup authority must follow if updating withdrawer.
+    /// stake's new stake or withdraw authority to change to. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     pub new_authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
@@ -200,8 +198,7 @@ pub struct AuthorizeCheckedCpi<'a, 'b> {
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
     /// stake's current stake or withdraw authority to change away from
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
-    /// stake's new stake or withdraw authority to change to. If stake Lockup is
-    /// active, the signing lockup authority must follow if updating withdrawer.
+    /// stake's new stake or withdraw authority to change to. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     pub new_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: AuthorizeCheckedInstructionArgs,
@@ -353,8 +350,7 @@ impl<'a, 'b> AuthorizeCheckedCpiBuilder<'a, 'b> {
         self.instruction.authority = Some(authority);
         self
     }
-    /// stake's new stake or withdraw authority to change to. If stake Lockup is
-    /// active, the signing lockup authority must follow if updating withdrawer.
+    /// stake's new stake or withdraw authority to change to. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     #[inline(always)]
     pub fn new_authority(
         &mut self,
@@ -383,9 +379,8 @@ impl<'a, 'b> AuthorizeCheckedCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/authorize_checked_with_seed.rs
+++ b/clients/rust/src/generated/instructions/authorize_checked_with_seed.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use {
     crate::generated::types::StakeAuthorize,
@@ -18,8 +19,7 @@ pub struct AuthorizeCheckedWithSeed {
     pub authority_base: solana_program::pubkey::Pubkey,
     /// Clock sysvar
     pub clock: solana_program::pubkey::Pubkey,
-    /// stake's new stake or withdraw authority to change to. If stake Lockup is
-    /// active, the signing lockup authority must follow if updating withdrawer.
+    /// stake's new stake or withdraw authority to change to. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     pub new_authority: solana_program::pubkey::Pubkey,
 }
 
@@ -135,8 +135,7 @@ impl AuthorizeCheckedWithSeedBuilder {
         self.clock = Some(clock);
         self
     }
-    /// stake's new stake or withdraw authority to change to. If stake Lockup is
-    /// active, the signing lockup authority must follow if updating withdrawer.
+    /// stake's new stake or withdraw authority to change to. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     #[inline(always)]
     pub fn new_authority(&mut self, new_authority: solana_program::pubkey::Pubkey) -> &mut Self {
         self.new_authority = Some(new_authority);
@@ -210,8 +209,7 @@ pub struct AuthorizeCheckedWithSeedCpiAccounts<'a, 'b> {
     pub authority_base: &'b solana_program::account_info::AccountInfo<'a>,
     /// Clock sysvar
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
-    /// stake's new stake or withdraw authority to change to. If stake Lockup is
-    /// active, the signing lockup authority must follow if updating withdrawer.
+    /// stake's new stake or withdraw authority to change to. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     pub new_authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
@@ -225,8 +223,7 @@ pub struct AuthorizeCheckedWithSeedCpi<'a, 'b> {
     pub authority_base: &'b solana_program::account_info::AccountInfo<'a>,
     /// Clock sysvar
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
-    /// stake's new stake or withdraw authority to change to. If stake Lockup is
-    /// active, the signing lockup authority must follow if updating withdrawer.
+    /// stake's new stake or withdraw authority to change to. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     pub new_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: AuthorizeCheckedWithSeedInstructionArgs,
@@ -382,8 +379,7 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpiBuilder<'a, 'b> {
         self.instruction.clock = Some(clock);
         self
     }
-    /// stake's new stake or withdraw authority to change to. If stake Lockup is
-    /// active, the signing lockup authority must follow if updating withdrawer.
+    /// stake's new stake or withdraw authority to change to. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     #[inline(always)]
     pub fn new_authority(
         &mut self,
@@ -422,9 +418,8 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/authorize_with_seed.rs
+++ b/clients/rust/src/generated/instructions/authorize_with_seed.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use {
     crate::generated::types::StakeAuthorize,
@@ -12,13 +13,11 @@ use {
 
 /// Accounts.
 pub struct AuthorizeWithSeed {
-    /// The stake account to be updated, with the authority to be updated being
-    /// an account created with Pubkey::create_with_seed()
+    /// The stake account to be updated, with the authority to be updated being an account created with Pubkey::create_with_seed()
     pub stake: solana_program::pubkey::Pubkey,
     /// Base account of stake's authority to be updated
     pub authority_base: solana_program::pubkey::Pubkey,
-    /// Clock sysvar. If stake Lockup is active, the signing lockup authority
-    /// must follow if updating withdrawer.
+    /// Clock sysvar. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     pub clock: solana_program::pubkey::Pubkey,
 }
 
@@ -112,8 +111,7 @@ impl AuthorizeWithSeedBuilder {
     pub fn new() -> Self {
         Self::default()
     }
-    /// The stake account to be updated, with the authority to be updated being
-    /// an account created with Pubkey::create_with_seed()
+    /// The stake account to be updated, with the authority to be updated being an account created with Pubkey::create_with_seed()
     #[inline(always)]
     pub fn stake(&mut self, stake: solana_program::pubkey::Pubkey) -> &mut Self {
         self.stake = Some(stake);
@@ -125,8 +123,7 @@ impl AuthorizeWithSeedBuilder {
         self.authority_base = Some(authority_base);
         self
     }
-    /// Clock sysvar. If stake Lockup is active, the signing lockup authority
-    /// must follow if updating withdrawer.
+    /// Clock sysvar. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     #[inline(always)]
     pub fn clock(&mut self, clock: solana_program::pubkey::Pubkey) -> &mut Self {
         self.clock = Some(clock);
@@ -202,13 +199,11 @@ impl AuthorizeWithSeedBuilder {
 
 /// `authorize_with_seed` CPI accounts.
 pub struct AuthorizeWithSeedCpiAccounts<'a, 'b> {
-    /// The stake account to be updated, with the authority to be updated being
-    /// an account created with Pubkey::create_with_seed()
+    /// The stake account to be updated, with the authority to be updated being an account created with Pubkey::create_with_seed()
     pub stake: &'b solana_program::account_info::AccountInfo<'a>,
     /// Base account of stake's authority to be updated
     pub authority_base: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Clock sysvar. If stake Lockup is active, the signing lockup authority
-    /// must follow if updating withdrawer.
+    /// Clock sysvar. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
@@ -216,13 +211,11 @@ pub struct AuthorizeWithSeedCpiAccounts<'a, 'b> {
 pub struct AuthorizeWithSeedCpi<'a, 'b> {
     /// The program to invoke.
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
-    /// The stake account to be updated, with the authority to be updated being
-    /// an account created with Pubkey::create_with_seed()
+    /// The stake account to be updated, with the authority to be updated being an account created with Pubkey::create_with_seed()
     pub stake: &'b solana_program::account_info::AccountInfo<'a>,
     /// Base account of stake's authority to be updated
     pub authority_base: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Clock sysvar. If stake Lockup is active, the signing lockup authority
-    /// must follow if updating withdrawer.
+    /// Clock sysvar. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: AuthorizeWithSeedInstructionArgs,
@@ -350,8 +343,7 @@ impl<'a, 'b> AuthorizeWithSeedCpiBuilder<'a, 'b> {
         });
         Self { instruction }
     }
-    /// The stake account to be updated, with the authority to be updated being
-    /// an account created with Pubkey::create_with_seed()
+    /// The stake account to be updated, with the authority to be updated being an account created with Pubkey::create_with_seed()
     #[inline(always)]
     pub fn stake(&mut self, stake: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.stake = Some(stake);
@@ -366,8 +358,7 @@ impl<'a, 'b> AuthorizeWithSeedCpiBuilder<'a, 'b> {
         self.instruction.authority_base = Some(authority_base);
         self
     }
-    /// Clock sysvar. If stake Lockup is active, the signing lockup authority
-    /// must follow if updating withdrawer.
+    /// Clock sysvar. If stake Lockup is active, the signing lockup authority must follow if updating withdrawer.
     #[inline(always)]
     pub fn clock(&mut self, clock: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.clock = Some(clock);
@@ -408,9 +399,8 @@ impl<'a, 'b> AuthorizeWithSeedCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/deactivate.rs
+++ b/clients/rust/src/generated/instructions/deactivate.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -306,9 +307,8 @@ impl<'a, 'b> DeactivateCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/deactivate_delinquent.rs
+++ b/clients/rust/src/generated/instructions/deactivate_delinquent.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -12,8 +13,7 @@ pub struct DeactivateDelinquent {
     pub stake: solana_program::pubkey::Pubkey,
     /// stake's delinquent vote account
     pub vote: solana_program::pubkey::Pubkey,
-    /// Reference vote account that has voted at least once in the last
-    /// MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION epochs
+    /// Reference vote account that has voted at least once in the last MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION epochs
     pub reference_vote: solana_program::pubkey::Pubkey,
 }
 
@@ -100,8 +100,7 @@ impl DeactivateDelinquentBuilder {
         self.vote = Some(vote);
         self
     }
-    /// Reference vote account that has voted at least once in the last
-    /// MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION epochs
+    /// Reference vote account that has voted at least once in the last MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION epochs
     #[inline(always)]
     pub fn reference_vote(&mut self, reference_vote: solana_program::pubkey::Pubkey) -> &mut Self {
         self.reference_vote = Some(reference_vote);
@@ -143,8 +142,7 @@ pub struct DeactivateDelinquentCpiAccounts<'a, 'b> {
     pub stake: &'b solana_program::account_info::AccountInfo<'a>,
     /// stake's delinquent vote account
     pub vote: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Reference vote account that has voted at least once in the last
-    /// MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION epochs
+    /// Reference vote account that has voted at least once in the last MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION epochs
     pub reference_vote: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
@@ -156,8 +154,7 @@ pub struct DeactivateDelinquentCpi<'a, 'b> {
     pub stake: &'b solana_program::account_info::AccountInfo<'a>,
     /// stake's delinquent vote account
     pub vote: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Reference vote account that has voted at least once in the last
-    /// MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION epochs
+    /// Reference vote account that has voted at least once in the last MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION epochs
     pub reference_vote: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
@@ -287,8 +284,7 @@ impl<'a, 'b> DeactivateDelinquentCpiBuilder<'a, 'b> {
         self.instruction.vote = Some(vote);
         self
     }
-    /// Reference vote account that has voted at least once in the last
-    /// MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION epochs
+    /// Reference vote account that has voted at least once in the last MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION epochs
     #[inline(always)]
     pub fn reference_vote(
         &mut self,
@@ -312,9 +308,8 @@ impl<'a, 'b> DeactivateDelinquentCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/delegate_stake.rs
+++ b/clients/rust/src/generated/instructions/delegate_stake.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -410,9 +411,8 @@ impl<'a, 'b> DelegateStakeCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/get_minimum_delegation.rs
+++ b/clients/rust/src/generated/instructions/get_minimum_delegation.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -54,6 +55,7 @@ impl Default for GetMinimumDelegationInstructionData {
 /// Instruction builder for `GetMinimumDelegation`.
 ///
 /// ### Accounts:
+///
 #[derive(Clone, Debug, Default)]
 pub struct GetMinimumDelegationBuilder {
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
@@ -166,6 +168,7 @@ impl<'a, 'b> GetMinimumDelegationCpi<'a, 'b> {
 /// Instruction builder for `GetMinimumDelegation` via CPI.
 ///
 /// ### Accounts:
+///
 #[derive(Clone, Debug)]
 pub struct GetMinimumDelegationCpiBuilder<'a, 'b> {
     instruction: Box<GetMinimumDelegationCpiBuilderInstruction<'a, 'b>>,
@@ -194,9 +197,8 @@ impl<'a, 'b> GetMinimumDelegationCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/initialize.rs
+++ b/clients/rust/src/generated/instructions/initialize.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use {
     borsh::{BorshDeserialize, BorshSerialize},
@@ -84,8 +85,7 @@ pub struct InitializeInstructionArgs {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[optional]` rent (default to
-///      `SysvarRent111111111111111111111111111111111`)
+///   1. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializeBuilder {
     stake: Option<solana_program::pubkey::Pubkey>,
@@ -108,8 +108,8 @@ impl InitializeBuilder {
         self.stake = Some(stake);
         self
     }
-    /// `[optional account, default to
-    /// 'SysvarRent111111111111111111111111111111111']` Rent sysvar
+    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
+    /// Rent sysvar
     #[inline(always)]
     pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
@@ -366,9 +366,8 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/initialize_checked.rs
+++ b/clients/rust/src/generated/instructions/initialize_checked.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -79,8 +80,7 @@ impl Default for InitializeCheckedInstructionData {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[optional]` rent (default to
-///      `SysvarRent111111111111111111111111111111111`)
+///   1. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 ///   2. `[]` stake_authority
 ///   3. `[signer]` withdraw_authority
 #[derive(Clone, Debug, Default)]
@@ -102,8 +102,8 @@ impl InitializeCheckedBuilder {
         self.stake = Some(stake);
         self
     }
-    /// `[optional account, default to
-    /// 'SysvarRent111111111111111111111111111111111']` Rent sysvar
+    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
+    /// Rent sysvar
     #[inline(always)]
     pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
@@ -355,9 +355,8 @@ impl<'a, 'b> InitializeCheckedCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/merge.rs
+++ b/clients/rust/src/generated/instructions/merge.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -10,8 +11,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 pub struct Merge {
     /// The destination stake account to merge into
     pub to: solana_program::pubkey::Pubkey,
-    /// The stake account to merge from. Must have exact same lockup and
-    /// authority as to. This account will be drained.
+    /// The stake account to merge from. Must have exact same lockup and authority as to. This account will be drained.
     pub from: solana_program::pubkey::Pubkey,
     /// Clock sysvar
     pub clock: solana_program::pubkey::Pubkey,
@@ -107,8 +107,7 @@ impl MergeBuilder {
         self.to = Some(to);
         self
     }
-    /// The stake account to merge from. Must have exact same lockup and
-    /// authority as to. This account will be drained.
+    /// The stake account to merge from. Must have exact same lockup and authority as to. This account will be drained.
     #[inline(always)]
     pub fn from(&mut self, from: solana_program::pubkey::Pubkey) -> &mut Self {
         self.from = Some(from);
@@ -171,8 +170,7 @@ impl MergeBuilder {
 pub struct MergeCpiAccounts<'a, 'b> {
     /// The destination stake account to merge into
     pub to: &'b solana_program::account_info::AccountInfo<'a>,
-    /// The stake account to merge from. Must have exact same lockup and
-    /// authority as to. This account will be drained.
+    /// The stake account to merge from. Must have exact same lockup and authority as to. This account will be drained.
     pub from: &'b solana_program::account_info::AccountInfo<'a>,
     /// Clock sysvar
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
@@ -188,8 +186,7 @@ pub struct MergeCpi<'a, 'b> {
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The destination stake account to merge into
     pub to: &'b solana_program::account_info::AccountInfo<'a>,
-    /// The stake account to merge from. Must have exact same lockup and
-    /// authority as to. This account will be drained.
+    /// The stake account to merge from. Must have exact same lockup and authority as to. This account will be drained.
     pub from: &'b solana_program::account_info::AccountInfo<'a>,
     /// Clock sysvar
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
@@ -333,8 +330,7 @@ impl<'a, 'b> MergeCpiBuilder<'a, 'b> {
         self.instruction.to = Some(to);
         self
     }
-    /// The stake account to merge from. Must have exact same lockup and
-    /// authority as to. This account will be drained.
+    /// The stake account to merge from. Must have exact same lockup and authority as to. This account will be drained.
     #[inline(always)]
     pub fn from(&mut self, from: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.from = Some(from);
@@ -379,9 +375,8 @@ impl<'a, 'b> MergeCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/mod.rs
+++ b/clients/rust/src/generated/instructions/mod.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 pub(crate) mod r#authorize;
 pub(crate) mod r#authorize_checked;

--- a/clients/rust/src/generated/instructions/set_lockup.rs
+++ b/clients/rust/src/generated/instructions/set_lockup.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use {
     borsh::{BorshDeserialize, BorshSerialize},
@@ -341,9 +342,8 @@ impl<'a, 'b> SetLockupCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/set_lockup_checked.rs
+++ b/clients/rust/src/generated/instructions/set_lockup_checked.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -10,9 +11,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 pub struct SetLockupChecked {
     /// The stake account to set the lockup of
     pub stake: solana_program::pubkey::Pubkey,
-    /// stake's withdraw authority or lockup authority if lockup is active. If
-    /// setting a new lockup authority, the signing new lockup authority must
-    /// follow.
+    /// stake's withdraw authority or lockup authority if lockup is active. If setting a new lockup authority, the signing new lockup authority must follow.
     pub authority: solana_program::pubkey::Pubkey,
 }
 
@@ -101,9 +100,7 @@ impl SetLockupCheckedBuilder {
         self.stake = Some(stake);
         self
     }
-    /// stake's withdraw authority or lockup authority if lockup is active. If
-    /// setting a new lockup authority, the signing new lockup authority must
-    /// follow.
+    /// stake's withdraw authority or lockup authority if lockup is active. If setting a new lockup authority, the signing new lockup authority must follow.
     #[inline(always)]
     pub fn authority(&mut self, authority: solana_program::pubkey::Pubkey) -> &mut Self {
         self.authority = Some(authority);
@@ -158,9 +155,7 @@ impl SetLockupCheckedBuilder {
 pub struct SetLockupCheckedCpiAccounts<'a, 'b> {
     /// The stake account to set the lockup of
     pub stake: &'b solana_program::account_info::AccountInfo<'a>,
-    /// stake's withdraw authority or lockup authority if lockup is active. If
-    /// setting a new lockup authority, the signing new lockup authority must
-    /// follow.
+    /// stake's withdraw authority or lockup authority if lockup is active. If setting a new lockup authority, the signing new lockup authority must follow.
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
@@ -170,9 +165,7 @@ pub struct SetLockupCheckedCpi<'a, 'b> {
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The stake account to set the lockup of
     pub stake: &'b solana_program::account_info::AccountInfo<'a>,
-    /// stake's withdraw authority or lockup authority if lockup is active. If
-    /// setting a new lockup authority, the signing new lockup authority must
-    /// follow.
+    /// stake's withdraw authority or lockup authority if lockup is active. If setting a new lockup authority, the signing new lockup authority must follow.
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SetLockupCheckedInstructionArgs,
@@ -294,9 +287,7 @@ impl<'a, 'b> SetLockupCheckedCpiBuilder<'a, 'b> {
         self.instruction.stake = Some(stake);
         self
     }
-    /// stake's withdraw authority or lockup authority if lockup is active. If
-    /// setting a new lockup authority, the signing new lockup authority must
-    /// follow.
+    /// stake's withdraw authority or lockup authority if lockup is active. If setting a new lockup authority, the signing new lockup authority must follow.
     #[inline(always)]
     pub fn authority(
         &mut self,
@@ -332,9 +323,8 @@ impl<'a, 'b> SetLockupCheckedCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/split.rs
+++ b/clients/rust/src/generated/instructions/split.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -10,8 +11,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 pub struct Split {
     /// The stake account to split. Must be in the Initialized or Stake state
     pub from: solana_program::pubkey::Pubkey,
-    /// The uninitialized stake account to split to. Must be rent-exempt
-    /// starting from solana 1.17.
+    /// The uninitialized stake account to split to. Must be rent-exempt starting from solana 1.17.
     pub to: solana_program::pubkey::Pubkey,
     /// from's stake authority
     pub stake_authority: solana_program::pubkey::Pubkey,
@@ -105,8 +105,7 @@ impl SplitBuilder {
         self.from = Some(from);
         self
     }
-    /// The uninitialized stake account to split to. Must be rent-exempt
-    /// starting from solana 1.17.
+    /// The uninitialized stake account to split to. Must be rent-exempt starting from solana 1.17.
     #[inline(always)]
     pub fn to(&mut self, to: solana_program::pubkey::Pubkey) -> &mut Self {
         self.to = Some(to);
@@ -163,8 +162,7 @@ impl SplitBuilder {
 pub struct SplitCpiAccounts<'a, 'b> {
     /// The stake account to split. Must be in the Initialized or Stake state
     pub from: &'b solana_program::account_info::AccountInfo<'a>,
-    /// The uninitialized stake account to split to. Must be rent-exempt
-    /// starting from solana 1.17.
+    /// The uninitialized stake account to split to. Must be rent-exempt starting from solana 1.17.
     pub to: &'b solana_program::account_info::AccountInfo<'a>,
     /// from's stake authority
     pub stake_authority: &'b solana_program::account_info::AccountInfo<'a>,
@@ -176,8 +174,7 @@ pub struct SplitCpi<'a, 'b> {
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The stake account to split. Must be in the Initialized or Stake state
     pub from: &'b solana_program::account_info::AccountInfo<'a>,
-    /// The uninitialized stake account to split to. Must be rent-exempt
-    /// starting from solana 1.17.
+    /// The uninitialized stake account to split to. Must be rent-exempt starting from solana 1.17.
     pub to: &'b solana_program::account_info::AccountInfo<'a>,
     /// from's stake authority
     pub stake_authority: &'b solana_program::account_info::AccountInfo<'a>,
@@ -308,8 +305,7 @@ impl<'a, 'b> SplitCpiBuilder<'a, 'b> {
         self.instruction.from = Some(from);
         self
     }
-    /// The uninitialized stake account to split to. Must be rent-exempt
-    /// starting from solana 1.17.
+    /// The uninitialized stake account to split to. Must be rent-exempt starting from solana 1.17.
     #[inline(always)]
     pub fn to(&mut self, to: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.to = Some(to);
@@ -344,9 +340,8 @@ impl<'a, 'b> SplitCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/instructions/withdraw.rs
+++ b/clients/rust/src/generated/instructions/withdraw.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -16,8 +17,7 @@ pub struct Withdraw {
     pub clock: solana_program::pubkey::Pubkey,
     /// Stake history sysvar
     pub stake_history: solana_program::pubkey::Pubkey,
-    /// from's withdraw authority. If stake Lockup is active, the signing lockup
-    /// authority must follow.
+    /// from's withdraw authority. If stake Lockup is active, the signing lockup authority must follow.
     pub withdraw_authority: solana_program::pubkey::Pubkey,
 }
 
@@ -138,8 +138,7 @@ impl WithdrawBuilder {
         self.stake_history = Some(stake_history);
         self
     }
-    /// from's withdraw authority. If stake Lockup is active, the signing lockup
-    /// authority must follow.
+    /// from's withdraw authority. If stake Lockup is active, the signing lockup authority must follow.
     #[inline(always)]
     pub fn withdraw_authority(
         &mut self,
@@ -200,8 +199,7 @@ pub struct WithdrawCpiAccounts<'a, 'b> {
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
     /// Stake history sysvar
     pub stake_history: &'b solana_program::account_info::AccountInfo<'a>,
-    /// from's withdraw authority. If stake Lockup is active, the signing lockup
-    /// authority must follow.
+    /// from's withdraw authority. If stake Lockup is active, the signing lockup authority must follow.
     pub withdraw_authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
@@ -217,8 +215,7 @@ pub struct WithdrawCpi<'a, 'b> {
     pub clock: &'b solana_program::account_info::AccountInfo<'a>,
     /// Stake history sysvar
     pub stake_history: &'b solana_program::account_info::AccountInfo<'a>,
-    /// from's withdraw authority. If stake Lockup is active, the signing lockup
-    /// authority must follow.
+    /// from's withdraw authority. If stake Lockup is active, the signing lockup authority must follow.
     pub withdraw_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: WithdrawInstructionArgs,
@@ -384,8 +381,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
         self.instruction.stake_history = Some(stake_history);
         self
     }
-    /// from's withdraw authority. If stake Lockup is active, the signing lockup
-    /// authority must follow.
+    /// from's withdraw authority. If stake Lockup is active, the signing lockup authority must follow.
     #[inline(always)]
     pub fn withdraw_authority(
         &mut self,
@@ -414,9 +410,8 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     }
     /// Add additional accounts to the instruction.
     ///
-    /// Each account is represented by a tuple of the `AccountInfo`, a `bool`
-    /// indicating whether the account is writable or not, and a `bool`
-    /// indicating whether the account is a signer or not.
+    /// Each account is represented by a tuple of the `AccountInfo`, a `bool` indicating whether the account is writable or not,
+    /// and a `bool` indicating whether the account is a signer or not.
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,

--- a/clients/rust/src/generated/mod.rs
+++ b/clients/rust/src/generated/mod.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 pub mod errors;
 pub mod instructions;

--- a/clients/rust/src/generated/programs.rs
+++ b/clients/rust/src/generated/programs.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use solana_program::{pubkey, pubkey::Pubkey};
 

--- a/clients/rust/src/generated/types/mod.rs
+++ b/clients/rust/src/generated/types/mod.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 pub(crate) mod r#stake_authorize;
 

--- a/clients/rust/src/generated/types/stake_authorize.rs
+++ b/clients/rust/src/generated/types/stake_authorize.rs
@@ -3,6 +3,7 @@
 //! to add features, then rerun codama to update it.
 //!
 //! <https://github.com/codama-idl/codama>
+//!
 
 use {
     borsh::{BorshDeserialize, BorshSerialize},

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@codama/nodes-from-anchor": "^1.0.0",
     "@codama/renderers-js": "^1.0.1",
-    "@codama/renderers-rust": "^1.0.2",
+    "@codama/renderers-rust": "^1.0.3",
     "@iarna/toml": "^2.2.5",
     "@metaplex-foundation/shank-js": "^0.1.7",
     "codama": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@codama/renderers-rust':
-        specifier: ^1.0.2
-        version: 1.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+        specifier: ^1.0.3
+        version: 1.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
@@ -54,8 +54,8 @@ packages:
   '@codama/renderers-js@1.0.1':
     resolution: {integrity: sha512-RwTJM5L4ZuKZ9TUdr1K5PODr7Ji0lsqcqQGXQ71Hg+ZHQ+F4jj3RPvoWHxYm5tYMuqRajQxqL/W49kxqEtc96w==}
 
-  '@codama/renderers-rust@1.0.2':
-    resolution: {integrity: sha512-iNJY4gTb0MJ8aXmWHVpazumVzFpLgtH5tNpt267IS/NU9NURDfsehAZtpq46jiK/RqazCWMCpb55YC3tjqi+pA==}
+  '@codama/renderers-rust@1.0.3':
+    resolution: {integrity: sha512-S2n+bq92q5YZ01Z+8klNNbvgVErKsJzUYWN0Y0rPymx2vwkHfTkeQHEOuckb/kzHJm9QGXrzkDtSDBy5EDS1Wg==}
 
   '@codama/validators@1.0.0':
     resolution: {integrity: sha512-jSfU5IrcGTvcqsJSBSzD3Ochig+hKKg2NKsT/vUfQ4jAw2cQrVUP5f4dMXyX779JYfHLHCwZnBYvgEdgi9gBZQ==}
@@ -91,24 +91,28 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@solana/codecs-core@2.0.0-rc.1':
-    resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
+  '@solana/codecs-core@2.0.0-rc.3':
+    resolution: {integrity: sha512-Z+KkHRHxxN/Ei4ujIxZeNiSuhioGSKnxNbswBvd/nNAv6Q9zi1DJMV2gIE1MKE/H6ZtrLCAiiHYBRtHpdAyndg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-numbers@2.0.0-rc.1':
-    resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
+  '@solana/codecs-numbers@2.0.0-rc.3':
+    resolution: {integrity: sha512-ii05vAeZt5c5wbA8KLSLiV2WR5hHcnk1cp57UnjvIs2kX2oORXP0xKonK9AX0YxEc66ZnMBnE9e0wW28M4Bk/A==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-strings@2.0.0-rc.1':
-    resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
+  '@solana/codecs-strings@2.0.0-rc.3':
+    resolution: {integrity: sha512-eSYCPOEY1OARiP+i0ovrTyzRPlRVp8e8fmtGwSXKQoqvsdTJCWm80YVc6IeP8pIQD4KLO39Xae2WNq13e94CMg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
-  '@solana/errors@2.0.0-rc.1':
-    resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
+  '@solana/errors@2.0.0-rc.3':
+    resolution: {integrity: sha512-bFEOfktu53RzZw9VVeFS+tHXmHEXD9KYtRu764Z4QxKe33RqwZgHiLh4MHvPska8BPN3VAw4azotF+KWVMGztw==}
+    engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
       typescript: '>=5'
@@ -472,7 +476,7 @@ snapshots:
       '@codama/nodes-from-anchor': 1.0.0
       '@codama/renderers-core': 1.0.0
       '@codama/visitors-core': 1.0.0
-      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-strings': 2.0.0-rc.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       nunjucks: 3.2.4
       prettier: 3.3.3
     transitivePeerDependencies:
@@ -480,13 +484,13 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/renderers-rust@1.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
+  '@codama/renderers-rust@1.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
       '@codama/errors': 1.0.0
       '@codama/nodes': 1.0.0
       '@codama/renderers-core': 1.0.0
       '@codama/visitors-core': 1.0.0
-      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-strings': 2.0.0-rc.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       nunjucks: 3.2.4
     transitivePeerDependencies:
       - chokidar
@@ -544,26 +548,26 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@solana/codecs-core@2.0.0-rc.1(typescript@5.6.3)':
+  '@solana/codecs-core@2.0.0-rc.3(typescript@5.6.3)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.3(typescript@5.6.3)
       typescript: 5.6.3
 
-  '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.6.3)':
+  '@solana/codecs-numbers@2.0.0-rc.3(typescript@5.6.3)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/codecs-core': 2.0.0-rc.3(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.3(typescript@5.6.3)
       typescript: 5.6.3
 
-  '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
+  '@solana/codecs-strings@2.0.0-rc.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/codecs-core': 2.0.0-rc.3(typescript@5.6.3)
+      '@solana/codecs-numbers': 2.0.0-rc.3(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.3(typescript@5.6.3)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.6.3
 
-  '@solana/errors@2.0.0-rc.1(typescript@5.6.3)':
+  '@solana/errors@2.0.0-rc.3(typescript@5.6.3)':
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -18,20 +18,14 @@ borsh = { version = "1.5.1", features = ["derive", "unstable__schema"] }
 num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.3"
-solana-program = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
+solana-program = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
 thiserror = "1.0.63"
 
 [dev-dependencies]
-solana-program-test = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-solana-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-solana-vote-program = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
+solana-program-test = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
+solana-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
+solana-vote-program = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
 test-case = "3.3.1"
-
-[patch.crates-io]
-solana-program = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-solana-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-solana-zk-token-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "=2.1.0" }
-spl-associated-token-account = { git = "https://github.com/solana-labs/solana-program-library.git" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0.63"
 
 [dev-dependencies]
 solana-program-test = "2.1"
-solana-sdk = "=2.1"
+solana-sdk = "2.1"
 solana-vote-program = "2.1"
 test-case = "3.3.1"
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -18,13 +18,13 @@ borsh = { version = "1.5.1", features = ["derive", "unstable__schema"] }
 num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.3"
-solana-program = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
+solana-program = "2.1"
 thiserror = "1.0.63"
 
 [dev-dependencies]
-solana-program-test = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
-solana-sdk = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
-solana-vote-program = { git = "https://github.com/anza-xyz/agave.git", version = "^2.1", branch = "v2.1" }
+solana-program-test = "2.1"
+solana-sdk = "=2.1"
+solana-vote-program = "2.1"
 test-case = "3.3.1"
 
 [lib]

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -80,6 +80,7 @@ codama.accept(
   renderRustVisitor(path.join(rustClient, 'src', 'generated'), {
     formatCode: true,
     crateFolder: rustClient,
+    anchorTraits: false,
     toolchain: getToolchainArgument('format'),
   })
 );


### PR DESCRIPTION
### Problem

Local build/CI are currently not working since `v2.1` moved to a branch now.

### Solution

Bump the dependencies for both the program and Rust client to use the version from `crates.io`.

The generated Rust client changed since the `@codama/renderer-rust` version was bumped to remove the dependency on Anchor.