### PR TITLE
interface: Re-add stake files from sdk with history

### DIFF
--- a/interface/src/config.rs
+++ b/interface/src/config.rs
@@ -1,0 +1,28 @@
+//! config for staking
+//!  carries variables that the stake program cares about
+use serde_derive::{Deserialize, Serialize};
+
+// stake config ID
+crate::declare_id!("StakeConfig11111111111111111111111111111111");
+
+// means that no more than RATE of current effective stake may be added or subtracted per
+//  epoch
+pub const DEFAULT_WARMUP_COOLDOWN_RATE: f64 = 0.25;
+pub const DEFAULT_SLASH_PENALTY: u8 = ((5 * std::u8::MAX as usize) / 100) as u8;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+pub struct Config {
+    /// how much stake we can activate/deactivate per-epoch as a fraction of currently effective stake
+    pub warmup_cooldown_rate: f64,
+    /// percentage of stake lost when slash, expressed as a portion of std::u8::MAX
+    pub slash_penalty: u8,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            warmup_cooldown_rate: DEFAULT_WARMUP_COOLDOWN_RATE,
+            slash_penalty: DEFAULT_SLASH_PENALTY,
+        }
+    }
+}

--- a/interface/src/config.rs
+++ b/interface/src/config.rs
@@ -1,15 +1,18 @@
 //! config for staking
 //!  carries variables that the stake program cares about
-use serde_derive::{Deserialize, Serialize};
+
+use {
+    super::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE},
+    serde_derive::{Deserialize, Serialize},
+};
 
 // stake config ID
-crate::declare_id!("StakeConfig11111111111111111111111111111111");
+crate::declare_deprecated_id!("StakeConfig11111111111111111111111111111111");
 
-// means that no more than RATE of current effective stake may be added or subtracted per
-//  epoch
-pub const DEFAULT_WARMUP_COOLDOWN_RATE: f64 = 0.25;
-pub const DEFAULT_SLASH_PENALTY: u8 = ((5 * std::u8::MAX as usize) / 100) as u8;
-
+#[deprecated(
+    since = "1.16.7",
+    note = "Please use `solana_sdk::stake::state::warmup_cooldown_rate()` instead"
+)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 pub struct Config {
     /// how much stake we can activate/deactivate per-epoch as a fraction of currently effective stake

--- a/interface/src/config.rs
+++ b/interface/src/config.rs
@@ -1,10 +1,12 @@
 //! config for staking
 //!  carries variables that the stake program cares about
 
-use {
-    super::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE},
-    serde_derive::{Deserialize, Serialize},
-};
+#[deprecated(
+    since = "1.16.7",
+    note = "Please use `solana_sdk::stake::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE}` instead"
+)]
+pub use super::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE};
+use serde_derive::{Deserialize, Serialize};
 
 // stake config ID
 crate::declare_deprecated_id!("StakeConfig11111111111111111111111111111111");

--- a/interface/src/config.rs
+++ b/interface/src/config.rs
@@ -19,7 +19,7 @@ crate::declare_deprecated_id!("StakeConfig11111111111111111111111111111111");
 pub struct Config {
     /// how much stake we can activate/deactivate per-epoch as a fraction of currently effective stake
     pub warmup_cooldown_rate: f64,
-    /// percentage of stake lost when slash, expressed as a portion of std::u8::MAX
+    /// percentage of stake lost when slash, expressed as a portion of u8::MAX
     pub slash_penalty: u8,
 }
 

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -68,7 +68,6 @@ pub enum StakeError {
     #[error("stake redelegation to the same vote account is not permitted")]
     RedelegateToSameVoteAccount,
 
-    #[allow(dead_code)]
     #[error("redelegated stake must be fully activated before deactivation")]
     RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted,
 }

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -8,7 +8,7 @@ use {
         pubkey::Pubkey,
         stake::{
             program::id,
-            state::{Authorized, Lockup, StakeAuthorize, StakeStateWithFlags},
+            state::{Authorized, Lockup, StakeAuthorize, StakeStateV2},
         },
         system_instruction, sysvar,
     },
@@ -364,7 +364,7 @@ pub fn create_account_with_seed(
             base,
             seed,
             lamports,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         initialize(stake_pubkey, authorized, lockup),
@@ -383,7 +383,7 @@ pub fn create_account(
             from_pubkey,
             stake_pubkey,
             lamports,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         initialize(stake_pubkey, authorized, lockup),
@@ -405,7 +405,7 @@ pub fn create_account_with_seed_checked(
             base,
             seed,
             lamports,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         initialize_checked(stake_pubkey, authorized),
@@ -423,7 +423,7 @@ pub fn create_account_checked(
             from_pubkey,
             stake_pubkey,
             lamports,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         initialize_checked(stake_pubkey, authorized),
@@ -452,7 +452,7 @@ pub fn split(
     split_stake_pubkey: &Pubkey,
 ) -> Vec<Instruction> {
     vec![
-        system_instruction::allocate(split_stake_pubkey, StakeStateWithFlags::size_of() as u64),
+        system_instruction::allocate(split_stake_pubkey, StakeStateV2::size_of() as u64),
         system_instruction::assign(split_stake_pubkey, &id()),
         _split(
             stake_pubkey,
@@ -476,7 +476,7 @@ pub fn split_with_seed(
             split_stake_pubkey,
             base,
             seed,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         _split(
@@ -796,10 +796,7 @@ pub fn redelegate(
     uninitialized_stake_pubkey: &Pubkey,
 ) -> Vec<Instruction> {
     vec![
-        system_instruction::allocate(
-            uninitialized_stake_pubkey,
-            StakeStateWithFlags::size_of() as u64,
-        ),
+        system_instruction::allocate(uninitialized_stake_pubkey, StakeStateV2::size_of() as u64),
         system_instruction::assign(uninitialized_stake_pubkey, &id()),
         _redelegate(
             stake_pubkey,
@@ -823,7 +820,7 @@ pub fn redelegate_with_seed(
             uninitialized_stake_pubkey,
             base,
             seed,
-            StakeStateWithFlags::size_of() as u64,
+            StakeStateV2::size_of() as u64,
             &id(),
         ),
         _redelegate(

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -66,6 +66,10 @@ pub enum StakeError {
 
     #[error("stake redelegation to the same vote account is not permitted")]
     RedelegateToSameVoteAccount,
+
+    #[allow(dead_code)]
+    #[error("redelegated stake must be fully activated before deactivation")]
+    RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted,
 }
 
 impl<E> DecodeError<E> for StakeError {

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -222,6 +222,15 @@ pub enum StakeInstruction {
     ///   1. `[SIGNER]` Lockup authority or withdraw authority
     ///   2. Optional: `[SIGNER]` New lockup authority
     SetLockupChecked(LockupCheckedArgs),
+
+    /// Get the minimum stake delegation, in lamports
+    ///
+    /// # Account references
+    ///   None
+    ///
+    /// The minimum delegation will be returned via the transaction context's returndata.
+    /// Use `get_return_data()` to retrieve the result.
+    GetMinimumDelegation,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
@@ -675,6 +684,14 @@ pub fn set_lockup_checked(
         id(),
         &StakeInstruction::SetLockupChecked(lockup_checked),
         account_metas,
+    )
+}
+
+pub fn get_minimum_delegation() -> Instruction {
+    Instruction::new_with_bincode(
+        id(),
+        &StakeInstruction::GetMinimumDelegation,
+        Vec::default(),
     )
 }
 

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -57,6 +57,9 @@ pub enum StakeError {
         "stake account has not been delinquent for the minimum epochs required for deactivation"
     )]
     MinimumDelinquentEpochsForDeactivationNotMet,
+
+    #[error("delegation amount is less than the minimum")]
+    InsufficientDelegation,
 }
 
 impl<E> DecodeError<E> for StakeError {

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -18,7 +18,7 @@ use {
 };
 
 /// Reasons the stake might have had an error
-#[derive(Error, Debug, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+#[derive(Error, Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
 pub enum StakeError {
     #[error("not enough credits to redeem")]
     NoCreditsToRedeem,
@@ -65,7 +65,7 @@ impl<E> DecodeError<E> for StakeError {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum StakeInstruction {
     /// Initialize a stake with lockup and authorization information
     ///
@@ -260,20 +260,20 @@ pub enum StakeInstruction {
     DeactivateDelinquent,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub struct LockupArgs {
     pub unix_timestamp: Option<UnixTimestamp>,
     pub epoch: Option<Epoch>,
     pub custodian: Option<Pubkey>,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub struct LockupCheckedArgs {
     pub unix_timestamp: Option<UnixTimestamp>,
     pub epoch: Option<Epoch>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct AuthorizeWithSeedArgs {
     pub new_authorized_pubkey: Pubkey,
     pub stake_authorize: StakeAuthorize,
@@ -281,7 +281,7 @@ pub struct AuthorizeWithSeedArgs {
     pub authority_owner: Pubkey,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct AuthorizeCheckedWithSeedArgs {
     pub stake_authorize: StakeAuthorize,
     pub authority_seed: String,

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -228,8 +228,11 @@ pub enum StakeInstruction {
     /// # Account references
     ///   None
     ///
-    /// The minimum delegation will be returned via the transaction context's returndata.
-    /// Use `get_return_data()` to retrieve the result.
+    /// Returns the minimum delegation as a little-endian encoded u64 value.
+    /// Programs can use the [`get_minimum_delegation()`] helper function to invoke and
+    /// retrieve the return value for this instruction.
+    ///
+    /// [`get_minimum_delegation()`]: super::tools::get_minimum_delegation
     GetMinimumDelegation,
 }
 

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -328,7 +328,7 @@ pub fn create_account_with_seed(
             base,
             seed,
             lamports,
-            std::mem::size_of::<StakeState>() as u64,
+            StakeState::size_of() as u64,
             &id(),
         ),
         initialize(stake_pubkey, authorized, lockup),
@@ -347,7 +347,7 @@ pub fn create_account(
             from_pubkey,
             stake_pubkey,
             lamports,
-            std::mem::size_of::<StakeState>() as u64,
+            StakeState::size_of() as u64,
             &id(),
         ),
         initialize(stake_pubkey, authorized, lockup),
@@ -369,7 +369,7 @@ pub fn create_account_with_seed_checked(
             base,
             seed,
             lamports,
-            std::mem::size_of::<StakeState>() as u64,
+            StakeState::size_of() as u64,
             &id(),
         ),
         initialize_checked(stake_pubkey, authorized),
@@ -387,7 +387,7 @@ pub fn create_account_checked(
             from_pubkey,
             stake_pubkey,
             lamports,
-            std::mem::size_of::<StakeState>() as u64,
+            StakeState::size_of() as u64,
             &id(),
         ),
         initialize_checked(stake_pubkey, authorized),
@@ -416,7 +416,7 @@ pub fn split(
     split_stake_pubkey: &Pubkey,
 ) -> Vec<Instruction> {
     vec![
-        system_instruction::allocate(split_stake_pubkey, std::mem::size_of::<StakeState>() as u64),
+        system_instruction::allocate(split_stake_pubkey, StakeState::size_of() as u64),
         system_instruction::assign(split_stake_pubkey, &id()),
         _split(
             stake_pubkey,
@@ -440,7 +440,7 @@ pub fn split_with_seed(
             split_stake_pubkey,
             base,
             seed,
-            std::mem::size_of::<StakeState>() as u64,
+            StakeState::size_of() as u64,
             &id(),
         ),
         _split(

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -59,8 +59,8 @@ pub enum StakeInstruction {
     /// Initialize a stake with lockup and authorization information
     ///
     /// # Account references
-    ///   0. [WRITE] Uninitialized stake account
-    ///   1. [] Rent sysvar
+    ///   0. `[WRITE]` Uninitialized stake account
+    ///   1. `[]` Rent sysvar
     ///
     /// Authorized carries pubkeys that must sign staker transactions
     ///   and withdrawer transactions.
@@ -70,22 +70,22 @@ pub enum StakeInstruction {
     /// Authorize a key to manage stake or withdrawal
     ///
     /// # Account references
-    ///   0. [WRITE] Stake account to be updated
-    ///   1. [] Clock sysvar
-    ///   2. [SIGNER] The stake or withdraw authority
-    ///   3. Optional: [SIGNER] Lockup authority, if updating StakeAuthorize::Withdrawer before
+    ///   0. `[WRITE]` Stake account to be updated
+    ///   1. `[]` Clock sysvar
+    ///   2. `[SIGNER]` The stake or withdraw authority
+    ///   3. Optional: `[SIGNER]` Lockup authority, if updating StakeAuthorize::Withdrawer before
     ///      lockup expiration
     Authorize(Pubkey, StakeAuthorize),
 
     /// Delegate a stake to a particular vote account
     ///
     /// # Account references
-    ///   0. [WRITE] Initialized stake account to be delegated
-    ///   1. [] Vote account to which this stake will be delegated
-    ///   2. [] Clock sysvar
-    ///   3. [] Stake history sysvar that carries stake warmup/cooldown history
-    ///   4. [] Address of config account that carries stake config
-    ///   5. [SIGNER] Stake authority
+    ///   0. `[WRITE]` Initialized stake account to be delegated
+    ///   1. `[]` Vote account to which this stake will be delegated
+    ///   2. `[]` Clock sysvar
+    ///   3. `[]` Stake history sysvar that carries stake warmup/cooldown history
+    ///   4. `[]` Address of config account that carries stake config
+    ///   5. `[SIGNER]` Stake authority
     ///
     /// The entire balance of the staking account is staked.  DelegateStake
     ///   can be called multiple times, but re-delegation is delayed
@@ -95,20 +95,20 @@ pub enum StakeInstruction {
     /// Split u64 tokens and stake off a stake account into another stake account.
     ///
     /// # Account references
-    ///   0. [WRITE] Stake account to be split; must be in the Initialized or Stake state
-    ///   1. [WRITE] Uninitialized stake account that will take the split-off amount
-    ///   2. [SIGNER] Stake authority
+    ///   0. `[WRITE]` Stake account to be split; must be in the Initialized or Stake state
+    ///   1. `[WRITE]` Uninitialized stake account that will take the split-off amount
+    ///   2. `[SIGNER]` Stake authority
     Split(u64),
 
     /// Withdraw unstaked lamports from the stake account
     ///
     /// # Account references
-    ///   0. [WRITE] Stake account from which to withdraw
-    ///   1. [WRITE] Recipient account
-    ///   2. [] Clock sysvar
-    ///   3. [] Stake history sysvar that carries stake warmup/cooldown history
-    ///   4. [SIGNER] Withdraw authority
-    ///   5. Optional: [SIGNER] Lockup authority, if before lockup expiration
+    ///   0. `[WRITE]` Stake account from which to withdraw
+    ///   1. `[WRITE]` Recipient account
+    ///   2. `[]` Clock sysvar
+    ///   3. `[]` Stake history sysvar that carries stake warmup/cooldown history
+    ///   4. `[SIGNER]` Withdraw authority
+    ///   5. Optional: `[SIGNER]` Lockup authority, if before lockup expiration
     ///
     /// The u64 is the portion of the stake account balance to be withdrawn,
     ///    must be `<= StakeAccount.lamports - staked_lamports`.
@@ -117,9 +117,9 @@ pub enum StakeInstruction {
     /// Deactivates the stake in the account
     ///
     /// # Account references
-    ///   0. [WRITE] Delegated stake account
-    ///   1. [] Clock sysvar
-    ///   2. [SIGNER] Stake authority
+    ///   0. `[WRITE]` Delegated stake account
+    ///   1. `[]` Clock sysvar
+    ///   2. `[SIGNER]` Stake authority
     Deactivate,
 
     /// Set stake lockup
@@ -128,8 +128,8 @@ pub enum StakeInstruction {
     /// If a lockup is active, the lockup custodian may update the lockup parameters
     ///
     /// # Account references
-    ///   0. [WRITE] Initialized stake account
-    ///   1. [SIGNER] Lockup authority or withdraw authority
+    ///   0. `[WRITE]` Initialized stake account
+    ///   1. `[SIGNER]` Lockup authority or withdraw authority
     SetLockup(LockupArgs),
 
     /// Merge two stake accounts.
@@ -151,20 +151,20 @@ pub enum StakeInstruction {
     /// non-zero effective stake.
     ///
     /// # Account references
-    ///   0. [WRITE] Destination stake account for the merge
-    ///   1. [WRITE] Source stake account for to merge.  This account will be drained
-    ///   2. [] Clock sysvar
-    ///   3. [] Stake history sysvar that carries stake warmup/cooldown history
-    ///   4. [SIGNER] Stake authority
+    ///   0. `[WRITE]` Destination stake account for the merge
+    ///   1. `[WRITE]` Source stake account for to merge.  This account will be drained
+    ///   2. `[]` Clock sysvar
+    ///   3. `[]` Stake history sysvar that carries stake warmup/cooldown history
+    ///   4. `[SIGNER]` Stake authority
     Merge,
 
     /// Authorize a key to manage stake or withdrawal with a derived key
     ///
     /// # Account references
-    ///   0. [WRITE] Stake account to be updated
-    ///   1. [SIGNER] Base key of stake or withdraw authority
-    ///   2. [] Clock sysvar
-    ///   3. Optional: [SIGNER] Lockup authority, if updating StakeAuthorize::Withdrawer before
+    ///   0. `[WRITE]` Stake account to be updated
+    ///   1. `[SIGNER]` Base key of stake or withdraw authority
+    ///   2. `[]` Clock sysvar
+    ///   3. Optional: `[SIGNER]` Lockup authority, if updating StakeAuthorize::Withdrawer before
     ///      lockup expiration
     AuthorizeWithSeed(AuthorizeWithSeedArgs),
 
@@ -174,10 +174,10 @@ pub enum StakeInstruction {
     /// must be a signer, and no lockup is applied to the account.
     ///
     /// # Account references
-    ///   0. [WRITE] Uninitialized stake account
-    ///   1. [] Rent sysvar
-    ///   2. [] The stake authority
-    ///   3. [SIGNER] The withdraw authority
+    ///   0. `[WRITE]` Uninitialized stake account
+    ///   1. `[]` Rent sysvar
+    ///   2. `[]` The stake authority
+    ///   3. `[SIGNER]` The withdraw authority
     ///
     InitializeChecked,
 
@@ -187,11 +187,11 @@ pub enum StakeInstruction {
     /// stake or withdraw authority must also be a signer.
     ///
     /// # Account references
-    ///   0. [WRITE] Stake account to be updated
-    ///   1. [] Clock sysvar
-    ///   2. [SIGNER] The stake or withdraw authority
-    ///   3. [SIGNER] The new stake or withdraw authority
-    ///   4. Optional: [SIGNER] Lockup authority, if updating StakeAuthorize::Withdrawer before
+    ///   0. `[WRITE]` Stake account to be updated
+    ///   1. `[]` Clock sysvar
+    ///   2. `[SIGNER]` The stake or withdraw authority
+    ///   3. `[SIGNER]` The new stake or withdraw authority
+    ///   4. Optional: `[SIGNER]` Lockup authority, if updating StakeAuthorize::Withdrawer before
     ///      lockup expiration
     AuthorizeChecked(StakeAuthorize),
 
@@ -201,11 +201,11 @@ pub enum StakeInstruction {
     /// the new stake or withdraw authority must also be a signer.
     ///
     /// # Account references
-    ///   0. [WRITE] Stake account to be updated
-    ///   1. [SIGNER] Base key of stake or withdraw authority
-    ///   2. [] Clock sysvar
-    ///   3. [SIGNER] The new stake or withdraw authority
-    ///   4. Optional: [SIGNER] Lockup authority, if updating StakeAuthorize::Withdrawer before
+    ///   0. `[WRITE]` Stake account to be updated
+    ///   1. `[SIGNER]` Base key of stake or withdraw authority
+    ///   2. `[]` Clock sysvar
+    ///   3. `[SIGNER]` The new stake or withdraw authority
+    ///   4. Optional: `[SIGNER]` Lockup authority, if updating StakeAuthorize::Withdrawer before
     ///      lockup expiration
     AuthorizeCheckedWithSeed(AuthorizeCheckedWithSeedArgs),
 
@@ -218,9 +218,9 @@ pub enum StakeInstruction {
     /// If a lockup is active, the lockup custodian may update the lockup parameters
     ///
     /// # Account references
-    ///   0. [WRITE] Initialized stake account
-    ///   1. [SIGNER] Lockup authority or withdraw authority
-    ///   2. Optional: [SIGNER] New lockup authority
+    ///   0. `[WRITE]` Initialized stake account
+    ///   1. `[SIGNER]` Lockup authority or withdraw authority
+    ///   2. Optional: `[SIGNER]` New lockup authority
     SetLockupChecked(LockupCheckedArgs),
 }
 

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -1,14 +1,14 @@
 use {
-    crate::stake::{
-        config,
-        program::id,
-        state::{Authorized, Lockup, StakeAuthorize, StakeState},
-    },
     crate::{
         clock::{Epoch, UnixTimestamp},
         decode_error::DecodeError,
         instruction::{AccountMeta, Instruction},
         pubkey::Pubkey,
+        stake::{
+            config,
+            program::id,
+            state::{Authorized, Lockup, StakeAuthorize, StakeState},
+        },
         system_instruction, sysvar,
     },
     log::*,
@@ -680,8 +680,7 @@ pub fn set_lockup_checked(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::instruction::InstructionError;
+    use {super::*, crate::instruction::InstructionError};
 
     #[test]
     fn test_custom_error_decode() {

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -8,7 +8,7 @@ use {
         pubkey::Pubkey,
         stake::{
             program::id,
-            state::{Authorized, Lockup, StakeAuthorize, StakeState},
+            state::{Authorized, Lockup, StakeAuthorize, StakeStateWithFlags},
         },
         system_instruction, sysvar,
     },
@@ -364,7 +364,7 @@ pub fn create_account_with_seed(
             base,
             seed,
             lamports,
-            StakeState::size_of() as u64,
+            StakeStateWithFlags::size_of() as u64,
             &id(),
         ),
         initialize(stake_pubkey, authorized, lockup),
@@ -383,7 +383,7 @@ pub fn create_account(
             from_pubkey,
             stake_pubkey,
             lamports,
-            StakeState::size_of() as u64,
+            StakeStateWithFlags::size_of() as u64,
             &id(),
         ),
         initialize(stake_pubkey, authorized, lockup),
@@ -405,7 +405,7 @@ pub fn create_account_with_seed_checked(
             base,
             seed,
             lamports,
-            StakeState::size_of() as u64,
+            StakeStateWithFlags::size_of() as u64,
             &id(),
         ),
         initialize_checked(stake_pubkey, authorized),
@@ -423,7 +423,7 @@ pub fn create_account_checked(
             from_pubkey,
             stake_pubkey,
             lamports,
-            StakeState::size_of() as u64,
+            StakeStateWithFlags::size_of() as u64,
             &id(),
         ),
         initialize_checked(stake_pubkey, authorized),
@@ -452,7 +452,7 @@ pub fn split(
     split_stake_pubkey: &Pubkey,
 ) -> Vec<Instruction> {
     vec![
-        system_instruction::allocate(split_stake_pubkey, StakeState::size_of() as u64),
+        system_instruction::allocate(split_stake_pubkey, StakeStateWithFlags::size_of() as u64),
         system_instruction::assign(split_stake_pubkey, &id()),
         _split(
             stake_pubkey,
@@ -476,7 +476,7 @@ pub fn split_with_seed(
             split_stake_pubkey,
             base,
             seed,
-            StakeState::size_of() as u64,
+            StakeStateWithFlags::size_of() as u64,
             &id(),
         ),
         _split(
@@ -796,7 +796,10 @@ pub fn redelegate(
     uninitialized_stake_pubkey: &Pubkey,
 ) -> Vec<Instruction> {
     vec![
-        system_instruction::allocate(uninitialized_stake_pubkey, StakeState::size_of() as u64),
+        system_instruction::allocate(
+            uninitialized_stake_pubkey,
+            StakeStateWithFlags::size_of() as u64,
+        ),
         system_instruction::assign(uninitialized_stake_pubkey, &id()),
         _redelegate(
             stake_pubkey,
@@ -820,7 +823,7 @@ pub fn redelegate_with_seed(
             uninitialized_stake_pubkey,
             base,
             seed,
-            StakeState::size_of() as u64,
+            StakeStateWithFlags::size_of() as u64,
             &id(),
         ),
         _redelegate(

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -1,3 +1,5 @@
+#[allow(deprecated)]
+use crate::stake::config;
 use {
     crate::{
         clock::{Epoch, UnixTimestamp},
@@ -5,7 +7,6 @@ use {
         instruction::{AccountMeta, Instruction},
         pubkey::Pubkey,
         stake::{
-            config,
             program::id,
             state::{Authorized, Lockup, StakeAuthorize, StakeState},
         },
@@ -676,6 +677,7 @@ pub fn delegate_stake(
         AccountMeta::new_readonly(*vote_pubkey, false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        #[allow(deprecated)]
         AccountMeta::new_readonly(config::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
@@ -780,6 +782,7 @@ fn _redelegate(
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new(*uninitialized_stake_pubkey, false),
         AccountMeta::new_readonly(*vote_pubkey, false),
+        #[allow(deprecated)]
         AccountMeta::new_readonly(config::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -1,5 +1,8 @@
-#[allow(deprecated)]
-use crate::stake::config;
+// Remove the following `allow` when the `Redelegate` variant is renamed to
+// `Unused` starting from v3.
+// Required to avoid warnings from uses of deprecated types during trait derivations.
+#![allow(deprecated)]
+
 use {
     crate::{
         clock::{Epoch, UnixTimestamp},
@@ -7,6 +10,7 @@ use {
         program_error::ProgramError,
         pubkey::Pubkey,
         stake::{
+            config,
             program::id,
             state::{Authorized, Lockup, StakeAuthorize, StakeStateV2},
         },
@@ -306,6 +310,7 @@ pub enum StakeInstruction {
     ///   3. `[]` Unused account, formerly the stake config
     ///   4. `[SIGNER]` Stake authority
     ///
+    #[deprecated(since = "2.1.0", note = "Redelegate will not be enabled")]
     Redelegate,
 
     /// Move stake between accounts with the same authorities and lockups, using Staker authority.
@@ -726,7 +731,6 @@ pub fn delegate_stake(
         AccountMeta::new_readonly(*vote_pubkey, false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(sysvar::stake_history::id(), false),
-        #[allow(deprecated)]
         // For backwards compatibility we pass the stake config, although this account is unused
         AccountMeta::new_readonly(config::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
@@ -832,7 +836,6 @@ fn _redelegate(
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new(*uninitialized_stake_pubkey, false),
         AccountMeta::new_readonly(*vote_pubkey, false),
-        #[allow(deprecated)]
         // For backwards compatibility we pass the stake config, although this account is unused
         AccountMeta::new_readonly(config::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
@@ -840,6 +843,7 @@ fn _redelegate(
     Instruction::new_with_bincode(id(), &StakeInstruction::Redelegate, account_metas)
 }
 
+#[deprecated(since = "2.1.0", note = "Redelegate will not be enabled")]
 pub fn redelegate(
     stake_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
@@ -858,6 +862,7 @@ pub fn redelegate(
     ]
 }
 
+#[deprecated(since = "2.1.0", note = "Redelegate will not be enabled")]
 pub fn redelegate_with_seed(
     stake_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -1,0 +1,508 @@
+use {
+    crate::stake::{
+        config,
+        program::id,
+        state::{Authorized, Lockup, StakeAuthorize, StakeState},
+    },
+    crate::{
+        clock::{Epoch, UnixTimestamp},
+        decode_error::DecodeError,
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        system_instruction, sysvar,
+    },
+    log::*,
+    num_derive::{FromPrimitive, ToPrimitive},
+    serde_derive::{Deserialize, Serialize},
+    thiserror::Error,
+};
+
+/// Reasons the stake might have had an error
+#[derive(Error, Debug, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+pub enum StakeError {
+    #[error("not enough credits to redeem")]
+    NoCreditsToRedeem,
+
+    #[error("lockup has not yet expired")]
+    LockupInForce,
+
+    #[error("stake already deactivated")]
+    AlreadyDeactivated,
+
+    #[error("one re-delegation permitted per epoch")]
+    TooSoonToRedelegate,
+
+    #[error("split amount is more than is staked")]
+    InsufficientStake,
+
+    #[error("stake account with transient stake cannot be merged")]
+    MergeTransientStake,
+
+    #[error("stake account merge failed due to different authority, lockups or state")]
+    MergeMismatch,
+
+    #[error("custodian address not present")]
+    CustodianMissing,
+
+    #[error("custodian signature not present")]
+    CustodianSignatureMissing,
+}
+
+impl<E> DecodeError<E> for StakeError {
+    fn type_of() -> &'static str {
+        "StakeError"
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum StakeInstruction {
+    /// Initialize a stake with lockup and authorization information
+    ///
+    /// # Account references
+    ///   0. [WRITE] Uninitialized stake account
+    ///   1. [] Rent sysvar
+    ///
+    /// Authorized carries pubkeys that must sign staker transactions
+    ///   and withdrawer transactions.
+    /// Lockup carries information about withdrawal restrictions
+    Initialize(Authorized, Lockup),
+
+    /// Authorize a key to manage stake or withdrawal
+    ///
+    /// # Account references
+    ///   0. [WRITE] Stake account to be updated
+    ///   1. [] Clock sysvar
+    ///   2. [SIGNER] The stake or withdraw authority
+    ///   3. Optional: [SIGNER] Lockup authority, if updating StakeAuthorize::Withdrawer before
+    ///      lockup expiration
+    Authorize(Pubkey, StakeAuthorize),
+
+    /// Delegate a stake to a particular vote account
+    ///
+    /// # Account references
+    ///   0. [WRITE] Initialized stake account to be delegated
+    ///   1. [] Vote account to which this stake will be delegated
+    ///   2. [] Clock sysvar
+    ///   3. [] Stake history sysvar that carries stake warmup/cooldown history
+    ///   4. [] Address of config account that carries stake config
+    ///   5. [SIGNER] Stake authority
+    ///
+    /// The entire balance of the staking account is staked.  DelegateStake
+    ///   can be called multiple times, but re-delegation is delayed
+    ///   by one epoch
+    DelegateStake,
+
+    /// Split u64 tokens and stake off a stake account into another stake account.
+    ///
+    /// # Account references
+    ///   0. [WRITE] Stake account to be split; must be in the Initialized or Stake state
+    ///   1. [WRITE] Uninitialized stake account that will take the split-off amount
+    ///   2. [SIGNER] Stake authority
+    Split(u64),
+
+    /// Withdraw unstaked lamports from the stake account
+    ///
+    /// # Account references
+    ///   0. [WRITE] Stake account from which to withdraw
+    ///   1. [WRITE] Recipient account
+    ///   2. [] Clock sysvar
+    ///   3. [] Stake history sysvar that carries stake warmup/cooldown history
+    ///   4. [SIGNER] Withdraw authority
+    ///   5. Optional: [SIGNER] Lockup authority, if before lockup expiration
+    ///
+    /// The u64 is the portion of the stake account balance to be withdrawn,
+    ///    must be `<= StakeAccount.lamports - staked_lamports`.
+    Withdraw(u64),
+
+    /// Deactivates the stake in the account
+    ///
+    /// # Account references
+    ///   0. [WRITE] Delegated stake account
+    ///   1. [] Clock sysvar
+    ///   2. [SIGNER] Stake authority
+    Deactivate,
+
+    /// Set stake lockup
+    ///
+    /// If a lockup is not active, the withdraw authority may set a new lockup
+    /// If a lockup is active, the lockup custodian may update the lockup parameters
+    ///
+    /// # Account references
+    ///   0. [WRITE] Initialized stake account
+    ///   1. [SIGNER] Lockup authority or withdraw authority
+    SetLockup(LockupArgs),
+
+    /// Merge two stake accounts.
+    ///
+    /// Both accounts must have identical lockup and authority keys. A merge
+    /// is possible between two stakes in the following states with no additional
+    /// conditions:
+    ///
+    /// * two deactivated stakes
+    /// * an inactive stake into an activating stake during its activation epoch
+    ///
+    /// For the following cases, the voter pubkey and vote credits observed must match:
+    ///
+    /// * two activated stakes
+    /// * two activating accounts that share an activation epoch, during the activation epoch
+    ///
+    /// All other combinations of stake states will fail to merge, including all
+    /// "transient" states, where a stake is activating or deactivating with a
+    /// non-zero effective stake.
+    ///
+    /// # Account references
+    ///   0. [WRITE] Destination stake account for the merge
+    ///   1. [WRITE] Source stake account for to merge.  This account will be drained
+    ///   2. [] Clock sysvar
+    ///   3. [] Stake history sysvar that carries stake warmup/cooldown history
+    ///   4. [SIGNER] Stake authority
+    Merge,
+
+    /// Authorize a key to manage stake or withdrawal with a derived key
+    ///
+    /// # Account references
+    ///   0. [WRITE] Stake account to be updated
+    ///   1. [SIGNER] Base key of stake or withdraw authority
+    ///   2. [] Clock sysvar
+    ///   3. Optional: [SIGNER] Lockup authority, if updating StakeAuthorize::Withdrawer before
+    ///      lockup expiration
+    AuthorizeWithSeed(AuthorizeWithSeedArgs),
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+pub struct LockupArgs {
+    pub unix_timestamp: Option<UnixTimestamp>,
+    pub epoch: Option<Epoch>,
+    pub custodian: Option<Pubkey>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct AuthorizeWithSeedArgs {
+    pub new_authorized_pubkey: Pubkey,
+    pub stake_authorize: StakeAuthorize,
+    pub authority_seed: String,
+    pub authority_owner: Pubkey,
+}
+
+pub fn initialize(stake_pubkey: &Pubkey, authorized: &Authorized, lockup: &Lockup) -> Instruction {
+    Instruction::new_with_bincode(
+        id(),
+        &StakeInstruction::Initialize(*authorized, *lockup),
+        vec![
+            AccountMeta::new(*stake_pubkey, false),
+            AccountMeta::new_readonly(sysvar::rent::id(), false),
+        ],
+    )
+}
+
+pub fn create_account_with_seed(
+    from_pubkey: &Pubkey,
+    stake_pubkey: &Pubkey,
+    base: &Pubkey,
+    seed: &str,
+    authorized: &Authorized,
+    lockup: &Lockup,
+    lamports: u64,
+) -> Vec<Instruction> {
+    vec![
+        system_instruction::create_account_with_seed(
+            from_pubkey,
+            stake_pubkey,
+            base,
+            seed,
+            lamports,
+            std::mem::size_of::<StakeState>() as u64,
+            &id(),
+        ),
+        initialize(stake_pubkey, authorized, lockup),
+    ]
+}
+
+pub fn create_account(
+    from_pubkey: &Pubkey,
+    stake_pubkey: &Pubkey,
+    authorized: &Authorized,
+    lockup: &Lockup,
+    lamports: u64,
+) -> Vec<Instruction> {
+    vec![
+        system_instruction::create_account(
+            from_pubkey,
+            stake_pubkey,
+            lamports,
+            std::mem::size_of::<StakeState>() as u64,
+            &id(),
+        ),
+        initialize(stake_pubkey, authorized, lockup),
+    ]
+}
+
+fn _split(
+    stake_pubkey: &Pubkey,
+    authorized_pubkey: &Pubkey,
+    lamports: u64,
+    split_stake_pubkey: &Pubkey,
+) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*stake_pubkey, false),
+        AccountMeta::new(*split_stake_pubkey, false),
+        AccountMeta::new_readonly(*authorized_pubkey, true),
+    ];
+
+    Instruction::new_with_bincode(id(), &StakeInstruction::Split(lamports), account_metas)
+}
+
+pub fn split(
+    stake_pubkey: &Pubkey,
+    authorized_pubkey: &Pubkey,
+    lamports: u64,
+    split_stake_pubkey: &Pubkey,
+) -> Vec<Instruction> {
+    vec![
+        system_instruction::allocate(split_stake_pubkey, std::mem::size_of::<StakeState>() as u64),
+        system_instruction::assign(split_stake_pubkey, &id()),
+        _split(
+            stake_pubkey,
+            authorized_pubkey,
+            lamports,
+            split_stake_pubkey,
+        ),
+    ]
+}
+
+pub fn split_with_seed(
+    stake_pubkey: &Pubkey,
+    authorized_pubkey: &Pubkey,
+    lamports: u64,
+    split_stake_pubkey: &Pubkey, // derived using create_with_seed()
+    base: &Pubkey,               // base
+    seed: &str,                  // seed
+) -> Vec<Instruction> {
+    vec![
+        system_instruction::allocate_with_seed(
+            split_stake_pubkey,
+            base,
+            seed,
+            std::mem::size_of::<StakeState>() as u64,
+            &id(),
+        ),
+        _split(
+            stake_pubkey,
+            authorized_pubkey,
+            lamports,
+            split_stake_pubkey,
+        ),
+    ]
+}
+
+pub fn merge(
+    destination_stake_pubkey: &Pubkey,
+    source_stake_pubkey: &Pubkey,
+    authorized_pubkey: &Pubkey,
+) -> Vec<Instruction> {
+    let account_metas = vec![
+        AccountMeta::new(*destination_stake_pubkey, false),
+        AccountMeta::new(*source_stake_pubkey, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(*authorized_pubkey, true),
+    ];
+
+    vec![Instruction::new_with_bincode(
+        id(),
+        &StakeInstruction::Merge,
+        account_metas,
+    )]
+}
+
+pub fn create_account_and_delegate_stake(
+    from_pubkey: &Pubkey,
+    stake_pubkey: &Pubkey,
+    vote_pubkey: &Pubkey,
+    authorized: &Authorized,
+    lockup: &Lockup,
+    lamports: u64,
+) -> Vec<Instruction> {
+    let mut instructions = create_account(from_pubkey, stake_pubkey, authorized, lockup, lamports);
+    instructions.push(delegate_stake(
+        stake_pubkey,
+        &authorized.staker,
+        vote_pubkey,
+    ));
+    instructions
+}
+
+pub fn create_account_with_seed_and_delegate_stake(
+    from_pubkey: &Pubkey,
+    stake_pubkey: &Pubkey,
+    base: &Pubkey,
+    seed: &str,
+    vote_pubkey: &Pubkey,
+    authorized: &Authorized,
+    lockup: &Lockup,
+    lamports: u64,
+) -> Vec<Instruction> {
+    let mut instructions = create_account_with_seed(
+        from_pubkey,
+        stake_pubkey,
+        base,
+        seed,
+        authorized,
+        lockup,
+        lamports,
+    );
+    instructions.push(delegate_stake(
+        stake_pubkey,
+        &authorized.staker,
+        vote_pubkey,
+    ));
+    instructions
+}
+
+pub fn authorize(
+    stake_pubkey: &Pubkey,
+    authorized_pubkey: &Pubkey,
+    new_authorized_pubkey: &Pubkey,
+    stake_authorize: StakeAuthorize,
+    custodian_pubkey: Option<&Pubkey>,
+) -> Instruction {
+    let mut account_metas = vec![
+        AccountMeta::new(*stake_pubkey, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(*authorized_pubkey, true),
+    ];
+
+    if let Some(custodian_pubkey) = custodian_pubkey {
+        account_metas.push(AccountMeta::new_readonly(*custodian_pubkey, true));
+    }
+
+    Instruction::new_with_bincode(
+        id(),
+        &StakeInstruction::Authorize(*new_authorized_pubkey, stake_authorize),
+        account_metas,
+    )
+}
+
+pub fn authorize_with_seed(
+    stake_pubkey: &Pubkey,
+    authority_base: &Pubkey,
+    authority_seed: String,
+    authority_owner: &Pubkey,
+    new_authorized_pubkey: &Pubkey,
+    stake_authorize: StakeAuthorize,
+    custodian_pubkey: Option<&Pubkey>,
+) -> Instruction {
+    let mut account_metas = vec![
+        AccountMeta::new(*stake_pubkey, false),
+        AccountMeta::new_readonly(*authority_base, true),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+    ];
+
+    if let Some(custodian_pubkey) = custodian_pubkey {
+        account_metas.push(AccountMeta::new_readonly(*custodian_pubkey, true));
+    }
+
+    let args = AuthorizeWithSeedArgs {
+        new_authorized_pubkey: *new_authorized_pubkey,
+        stake_authorize,
+        authority_seed,
+        authority_owner: *authority_owner,
+    };
+
+    Instruction::new_with_bincode(
+        id(),
+        &StakeInstruction::AuthorizeWithSeed(args),
+        account_metas,
+    )
+}
+
+pub fn delegate_stake(
+    stake_pubkey: &Pubkey,
+    authorized_pubkey: &Pubkey,
+    vote_pubkey: &Pubkey,
+) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*stake_pubkey, false),
+        AccountMeta::new_readonly(*vote_pubkey, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(config::id(), false),
+        AccountMeta::new_readonly(*authorized_pubkey, true),
+    ];
+    Instruction::new_with_bincode(id(), &StakeInstruction::DelegateStake, account_metas)
+}
+
+pub fn withdraw(
+    stake_pubkey: &Pubkey,
+    withdrawer_pubkey: &Pubkey,
+    to_pubkey: &Pubkey,
+    lamports: u64,
+    custodian_pubkey: Option<&Pubkey>,
+) -> Instruction {
+    let mut account_metas = vec![
+        AccountMeta::new(*stake_pubkey, false),
+        AccountMeta::new(*to_pubkey, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(*withdrawer_pubkey, true),
+    ];
+
+    if let Some(custodian_pubkey) = custodian_pubkey {
+        account_metas.push(AccountMeta::new_readonly(*custodian_pubkey, true));
+    }
+
+    Instruction::new_with_bincode(id(), &StakeInstruction::Withdraw(lamports), account_metas)
+}
+
+pub fn deactivate_stake(stake_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*stake_pubkey, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(*authorized_pubkey, true),
+    ];
+    Instruction::new_with_bincode(id(), &StakeInstruction::Deactivate, account_metas)
+}
+
+pub fn set_lockup(
+    stake_pubkey: &Pubkey,
+    lockup: &LockupArgs,
+    custodian_pubkey: &Pubkey,
+) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*stake_pubkey, false),
+        AccountMeta::new_readonly(*custodian_pubkey, true),
+    ];
+    Instruction::new_with_bincode(id(), &StakeInstruction::SetLockup(*lockup), account_metas)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instruction::InstructionError;
+
+    #[test]
+    fn test_custom_error_decode() {
+        use num_traits::FromPrimitive;
+        fn pretty_err<T>(err: InstructionError) -> String
+        where
+            T: 'static + std::error::Error + DecodeError<T> + FromPrimitive,
+        {
+            if let InstructionError::Custom(code) = err {
+                let specific_error: T = T::decode_custom_error_to_enum(code).unwrap();
+                format!(
+                    "{:?}: {}::{:?} - {}",
+                    err,
+                    T::type_of(),
+                    specific_error,
+                    specific_error,
+                )
+            } else {
+                "".to_string()
+            }
+        }
+        assert_eq!(
+            "Custom(0): StakeError::NoCreditsToRedeem - not enough credits to redeem",
+            pretty_err::<StakeError>(StakeError::NoCreditsToRedeem.into())
+        )
+    }
+}

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -21,6 +21,7 @@ use {
 /// Reasons the stake might have had an error
 #[derive(Error, Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
 pub enum StakeError {
+    // 0
     #[error("not enough credits to redeem")]
     NoCreditsToRedeem,
 
@@ -36,6 +37,7 @@ pub enum StakeError {
     #[error("split amount is more than is staked")]
     InsufficientStake,
 
+    // 5
     #[error("stake account with transient stake cannot be merged")]
     MergeTransientStake,
 
@@ -51,6 +53,7 @@ pub enum StakeError {
     #[error("insufficient voting activity in the reference vote account")]
     InsufficientReferenceVotes,
 
+    // 10
     #[error("stake account is not delegated to the provided vote account")]
     VoteAddressMismatch,
 
@@ -68,6 +71,7 @@ pub enum StakeError {
     #[error("stake redelegation to the same vote account is not permitted")]
     RedelegateToSameVoteAccount,
 
+    // 15
     #[error("redelegated stake must be fully activated before deactivation")]
     RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted,
 

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -108,7 +108,7 @@ pub enum StakeInstruction {
     ///   1. `[]` Vote account to which this stake will be delegated
     ///   2. `[]` Clock sysvar
     ///   3. `[]` Stake history sysvar that carries stake warmup/cooldown history
-    ///   4. `[]` Address of config account that carries stake config
+    ///   4. `[]` Unused account, formerly the stake config
     ///   5. `[SIGNER]` Stake authority
     ///
     /// The entire balance of the staking account is staked.  DelegateStake
@@ -289,7 +289,7 @@ pub enum StakeInstruction {
     ///      plus rent exempt minimum
     ///   1. `[WRITE]` Uninitialized stake account that will hold the redelegated stake
     ///   2. `[]` Vote account to which this stake will be re-delegated
-    ///   3. `[]` Address of config account that carries stake config
+    ///   3. `[]` Unused account, formerly the stake config
     ///   4. `[SIGNER]` Stake authority
     ///
     Redelegate,
@@ -677,6 +677,7 @@ pub fn delegate_stake(
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(sysvar::stake_history::id(), false),
         #[allow(deprecated)]
+        // For backwards compatibility we pass the stake config, although this account is unused
         AccountMeta::new_readonly(config::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
@@ -782,6 +783,7 @@ fn _redelegate(
         AccountMeta::new(*uninitialized_stake_pubkey, false),
         AccountMeta::new_readonly(*vote_pubkey, false),
         #[allow(deprecated)]
+        // For backwards compatibility we pass the stake config, although this account is unused
         AccountMeta::new_readonly(config::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -70,6 +70,9 @@ pub enum StakeError {
 
     #[error("redelegated stake must be fully activated before deactivation")]
     RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted,
+
+    #[error("stake action is not permitted while the epoch rewards period is active")]
+    EpochRewardsActive,
 }
 
 impl<E> DecodeError<E> for StakeError {

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -5,6 +5,7 @@ use {
         clock::{Epoch, UnixTimestamp},
         decode_error::DecodeError,
         instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
         pubkey::Pubkey,
         stake::{
             program::id,
@@ -77,6 +78,12 @@ pub enum StakeError {
 
     #[error("stake action is not permitted while the epoch rewards period is active")]
     EpochRewardsActive,
+}
+
+impl From<StakeError> for ProgramError {
+    fn from(e: StakeError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
 }
 
 impl<E> DecodeError<E> for StakeError {

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -3,7 +3,6 @@ use crate::stake::config;
 use {
     crate::{
         clock::{Epoch, UnixTimestamp},
-        decode_error::DecodeError,
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
         pubkey::Pubkey,
@@ -16,6 +15,7 @@ use {
     log::*,
     num_derive::{FromPrimitive, ToPrimitive},
     serde_derive::{Deserialize, Serialize},
+    solana_decode_error::DecodeError,
     thiserror::Error,
 };
 

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -5,7 +5,6 @@
 
 use {
     crate::{
-        clock::{Epoch, UnixTimestamp},
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
         pubkey::Pubkey,
@@ -19,6 +18,7 @@ use {
     log::*,
     num_derive::{FromPrimitive, ToPrimitive},
     serde_derive::{Deserialize, Serialize},
+    solana_clock::{Epoch, UnixTimestamp},
     solana_decode_error::DecodeError,
     thiserror::Error,
 };

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1,3 +1,7 @@
+//! The [stake native program][np].
+//!
+//! [np]: https://docs.solana.com/developing/runtime-facilities/sysvars#stakehistory
+
 pub mod config;
 pub mod instruction;
 pub mod state;

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod config;
 pub mod instruction;
+pub mod stake_flags;
 pub mod state;
 pub mod tools;
 

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -6,8 +6,6 @@ pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");
 }
 
-#[deprecated(
-    since = "1.10.6",
-    note = "This constant may be outdated, please use `solana_stake_program::get_minimum_delegation` instead"
-)]
+// NOTE: This constant will be deprecated soon; if possible, use
+// `solana_stake_program::get_minimum_delegation()` instead.
 pub const MINIMUM_STAKE_DELEGATION: u64 = 1;

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! [np]: https://docs.solana.com/developing/runtime-facilities/sysvars#stakehistory
 
+#[allow(deprecated)]
 pub mod config;
 pub mod instruction;
 pub mod stake_flags;

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -5,3 +5,8 @@ pub mod state;
 pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");
 }
+
+/// The minimum stake amount that can be delegated, in lamports.
+/// NOTE: This is also used to calculate the minimum balance of a stake account, which is the
+/// rent exempt reserve _plus_ the minimum stake delegation.
+pub const MINIMUM_STAKE_DELEGATION: u64 = 1;

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -10,3 +10,7 @@ pub mod program {
 // NOTE: This constant will be deprecated soon; if possible, use
 // `solana_stake_program::get_minimum_delegation()` instead.
 pub const MINIMUM_STAKE_DELEGATION: u64 = 1;
+
+/// The minimum number of epochs before stake account that is delegated to a delinquent vote
+/// account may be unstaked with `StakeInstruction::DeactivateDelinquent`
+pub const MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION: usize = 5;

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod config;
+pub mod instruction;
+pub mod state;
+
+pub mod program {
+    crate::declare_id!("Stake11111111111111111111111111111111111111");
+}

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -3,13 +3,12 @@ pub mod instruction;
 pub mod state;
 pub mod tools;
 
+mod deprecated;
+pub use deprecated::*;
+
 pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");
 }
-
-// NOTE: This constant will be deprecated soon; if possible, use
-// `solana_stake_program::get_minimum_delegation()` instead.
-pub const MINIMUM_STAKE_DELEGATION: u64 = 1;
 
 /// The minimum number of epochs before stake account that is delegated to a delinquent vote
 /// account may be unstaked with `StakeInstruction::DeactivateDelinquent`

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -6,7 +6,8 @@ pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");
 }
 
-/// The minimum stake amount that can be delegated, in lamports.
-/// NOTE: This is also used to calculate the minimum balance of a stake account, which is the
-/// rent exempt reserve _plus_ the minimum stake delegation.
+#[deprecated(
+    since = "1.10.6",
+    note = "This constant may be outdated, please use `solana_stake_program::get_minimum_delegation` instead"
+)]
 pub const MINIMUM_STAKE_DELEGATION: u64 = 1;

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod instruction;
 pub mod state;
+pub mod tools;
 
 pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1,6 +1,6 @@
 //! The [stake native program][np].
 //!
-//! [np]: https://docs.solana.com/developing/runtime-facilities/sysvars#stakehistory
+//! [np]: https://docs.solanalabs.com/runtime/sysvars#stakehistory
 
 #[allow(deprecated)]
 pub mod config;

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -9,9 +9,6 @@ pub mod stake_flags;
 pub mod state;
 pub mod tools;
 
-mod deprecated;
-pub use deprecated::*;
-
 pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");
 }

--- a/interface/src/stake_flags.rs
+++ b/interface/src/stake_flags.rs
@@ -1,0 +1,97 @@
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+
+/// Additional flags for stake state.
+#[allow(dead_code)]
+#[derive(
+    Serialize,
+    Deserialize,
+    AbiExample,
+    BorshDeserialize,
+    BorshSchema,
+    BorshSerialize,
+    Copy,
+    PartialEq,
+    Eq,
+    Clone,
+    PartialOrd,
+    Ord,
+    Hash,
+    Debug,
+)]
+pub struct StakeFlags {
+    bits: u8,
+}
+
+/// Currently, only bit 1 is used. The other 7 bits are reserved for future usage.
+#[allow(dead_code)]
+impl StakeFlags {
+    ///  Stake must be fully activated before deactivation is allowed (bit 1).
+    pub const MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED: Self =
+        Self { bits: 0b0000_0001 };
+
+    pub const fn empty() -> Self {
+        Self { bits: 0 }
+    }
+
+    pub const fn contains(&self, other: Self) -> bool {
+        (self.bits & other.bits) == other.bits
+    }
+
+    pub fn remove(&mut self, other: Self) {
+        self.bits &= !other.bits;
+    }
+
+    pub fn set(&mut self, other: Self) {
+        self.bits |= other.bits;
+    }
+
+    pub const fn union(self, other: Self) -> Self {
+        Self {
+            bits: self.bits | other.bits,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl Default for StakeFlags {
+    fn default() -> Self {
+        StakeFlags::empty()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_stake_flags() {
+        let mut f = StakeFlags::empty();
+        assert!(!f.contains(StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED));
+
+        f.set(StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED);
+        assert!(f.contains(StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED));
+
+        f.remove(StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED);
+        assert!(!f.contains(StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED));
+
+        let f1 = StakeFlags::empty();
+        let f2 = StakeFlags::empty();
+        let f3 = f1.union(f2);
+        assert!(!f3.contains(StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED));
+
+        let f1 = StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED;
+        let f2 = StakeFlags::empty();
+        let f3 = f1.union(f2);
+        assert!(f3.contains(StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED));
+
+        let f1 = StakeFlags::empty();
+        let f2 = StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED;
+        let f3 = f1.union(f2);
+        assert!(f3.contains(StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED));
+
+        let f1 = StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED;
+        let f2 = StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED;
+        let f3 = f1.union(f2);
+        assert!(f3.contains(StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED));
+    }
+}

--- a/interface/src/stake_flags.rs
+++ b/interface/src/stake_flags.rs
@@ -17,8 +17,52 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
     Hash,
     Debug,
 )]
+#[borsh(crate = "borsh")]
 pub struct StakeFlags {
     bits: u8,
+}
+impl borsh0_10::de::BorshDeserialize for StakeFlags {
+    fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
+        reader: &mut R,
+    ) -> ::core::result::Result<Self, borsh0_10::maybestd::io::Error> {
+        Ok(Self {
+            bits: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
+        })
+    }
+}
+impl borsh0_10::BorshSchema for StakeFlags {
+    fn declaration() -> borsh0_10::schema::Declaration {
+        "StakeFlags".to_string()
+    }
+    fn add_definitions_recursively(
+        definitions: &mut borsh0_10::maybestd::collections::HashMap<
+            borsh0_10::schema::Declaration,
+            borsh0_10::schema::Definition,
+        >,
+    ) {
+        let fields = borsh0_10::schema::Fields::NamedFields(<[_]>::into_vec(
+            borsh0_10::maybestd::boxed::Box::new([(
+                "bits".to_string(),
+                <u8 as borsh0_10::BorshSchema>::declaration(),
+            )]),
+        ));
+        let definition = borsh0_10::schema::Definition::Struct { fields };
+        Self::add_definition(
+            <Self as borsh0_10::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
+        <u8 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
+    }
+}
+impl borsh0_10::ser::BorshSerialize for StakeFlags {
+    fn serialize<W: borsh0_10::maybestd::io::Write>(
+        &self,
+        writer: &mut W,
+    ) -> ::core::result::Result<(), borsh0_10::maybestd::io::Error> {
+        borsh0_10::BorshSerialize::serialize(&self.bits, writer)?;
+        Ok(())
+    }
 }
 
 /// Currently, only bit 1 is used. The other 7 bits are reserved for future usage.

--- a/interface/src/stake_flags.rs
+++ b/interface/src/stake_flags.rs
@@ -1,7 +1,6 @@
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 /// Additional flags for stake state.
-#[allow(dead_code)]
 #[derive(
     Serialize,
     Deserialize,
@@ -23,7 +22,6 @@ pub struct StakeFlags {
 }
 
 /// Currently, only bit 1 is used. The other 7 bits are reserved for future usage.
-#[allow(dead_code)]
 impl StakeFlags {
     ///  Stake must be fully activated before deactivation is allowed (bit 1).
     pub const MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED: Self =
@@ -52,7 +50,6 @@ impl StakeFlags {
     }
 }
 
-#[allow(dead_code)]
 impl Default for StakeFlags {
     fn default() -> Self {
         StakeFlags::empty()

--- a/interface/src/stake_flags.rs
+++ b/interface/src/stake_flags.rs
@@ -65,6 +65,10 @@ impl borsh0_10::ser::BorshSerialize for StakeFlags {
 /// Currently, only bit 1 is used. The other 7 bits are reserved for future usage.
 impl StakeFlags {
     ///  Stake must be fully activated before deactivation is allowed (bit 1).
+    #[deprecated(
+        since = "2.1.0",
+        note = "This flag will be removed because it was only used for `redelegate`, which will not be enabled."
+    )]
     pub const MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED: Self =
         Self { bits: 0b0000_0001 };
 
@@ -102,6 +106,7 @@ mod test {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn test_stake_flags() {
         let mut f = StakeFlags::empty();
         assert!(!f.contains(StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED));

--- a/interface/src/stake_flags.rs
+++ b/interface/src/stake_flags.rs
@@ -1,10 +1,10 @@
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 /// Additional flags for stake state.
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(
     Serialize,
     Deserialize,
-    AbiExample,
     BorshDeserialize,
     BorshSchema,
     BorshSerialize,

--- a/interface/src/stake_flags.rs
+++ b/interface/src/stake_flags.rs
@@ -1,26 +1,19 @@
+#[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 /// Additional flags for stake state.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(
-    Serialize,
-    Deserialize,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
-    Copy,
-    PartialEq,
-    Eq,
-    Clone,
-    PartialOrd,
-    Ord,
-    Hash,
-    Debug,
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
 )]
-#[borsh(crate = "borsh")]
+#[derive(Serialize, Deserialize, Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
 pub struct StakeFlags {
     bits: u8,
 }
+
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for StakeFlags {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -30,6 +23,8 @@ impl borsh0_10::de::BorshDeserialize for StakeFlags {
         })
     }
 }
+
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for StakeFlags {
     fn declaration() -> borsh0_10::schema::Declaration {
         "StakeFlags".to_string()
@@ -55,6 +50,8 @@ impl borsh0_10::BorshSchema for StakeFlags {
         <u8 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for StakeFlags {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -11,6 +11,7 @@ use std::ops::Deref;
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, AbiExample)]
 pub struct StakeHistoryEntry {
     pub effective: u64,    // effective stake at this epoch

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -1,6 +1,6 @@
 //! A type to hold data for the [`StakeHistory` sysvar][sv].
 //!
-//! [sv]: https://docs.solana.com/developing/runtime-facilities/sysvars#stakehistory
+//! [sv]: https://docs.solanalabs.com/runtime/sysvars#stakehistory
 //!
 //! The sysvar ID is declared in [`sysvar::stake_history`].
 //!

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -3,7 +3,6 @@
 //! this account carries history about stake activations and de-activations
 //!
 pub use crate::clock::Epoch;
-
 use std::ops::Deref;
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -15,6 +15,42 @@ pub struct StakeHistoryEntry {
     pub deactivating: u64, // requested to be cooled down, not fully deactivated yet
 }
 
+impl StakeHistoryEntry {
+    pub fn with_effective(effective: u64) -> Self {
+        Self {
+            effective,
+            ..Self::default()
+        }
+    }
+
+    pub fn with_effective_and_activating(effective: u64, activating: u64) -> Self {
+        Self {
+            effective,
+            activating,
+            ..Self::default()
+        }
+    }
+
+    pub fn with_deactivating(deactivating: u64) -> Self {
+        Self {
+            effective: deactivating,
+            deactivating,
+            ..Self::default()
+        }
+    }
+}
+
+impl std::ops::Add for StakeHistoryEntry {
+    type Output = StakeHistoryEntry;
+    fn add(self, rhs: StakeHistoryEntry) -> Self::Output {
+        Self {
+            effective: self.effective.saturating_add(rhs.effective),
+            activating: self.activating.saturating_add(rhs.activating),
+            deactivating: self.deactivating.saturating_add(rhs.deactivating),
+        }
+    }
+}
+
 #[repr(C)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, AbiExample)]
 pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -56,8 +56,7 @@ impl std::ops::Add for StakeHistoryEntry {
 pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);
 
 impl StakeHistory {
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn get(&self, epoch: &Epoch) -> Option<&StakeHistoryEntry> {
+    pub fn get(&self, epoch: Epoch) -> Option<&StakeHistoryEntry> {
         self.binary_search_by(|probe| epoch.cmp(&probe.0))
             .ok()
             .map(|index| &self[index].1)
@@ -98,9 +97,9 @@ mod tests {
         }
         assert_eq!(stake_history.len(), MAX_ENTRIES);
         assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
-        assert_eq!(stake_history.get(&0), None);
+        assert_eq!(stake_history.get(0), None);
         assert_eq!(
-            stake_history.get(&1),
+            stake_history.get(1),
             Some(&StakeHistoryEntry {
                 activating: 1,
                 ..StakeHistoryEntry::default()

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -1,7 +1,11 @@
-//! named accounts for synthesized data accounts for bank state, etc.
+//! A type to hold data for the [`StakeHistory` sysvar][sv].
 //!
-//! this account carries history about stake activations and de-activations
+//! [sv]: https://docs.solana.com/developing/runtime-facilities/sysvars#stakehistory
 //!
+//! The sysvar ID is declared in [`sysvar::stake_history`].
+//!
+//! [`sysvar::stake_history`]: crate::sysvar::stake_history
+
 pub use crate::clock::Epoch;
 use std::ops::Deref;
 

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -12,7 +12,8 @@ use std::ops::Deref;
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
 #[repr(C)]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone)]
 pub struct StakeHistoryEntry {
     pub effective: u64,    // effective stake at this epoch
     pub activating: u64,   // sum of portion of stakes not fully warmed up
@@ -56,7 +57,8 @@ impl std::ops::Add for StakeHistoryEntry {
 }
 
 #[repr(C)]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone)]
 pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);
 
 impl StakeHistory {

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -6,7 +6,7 @@
 //!
 //! [`sysvar::stake_history`]: crate::sysvar::stake_history
 
-pub use crate::clock::Epoch;
+pub use solana_clock::Epoch;
 use std::ops::Deref;
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -84,6 +84,18 @@ impl Deref for StakeHistory {
     }
 }
 
+pub trait StakeHistoryGetEntry {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry>;
+}
+
+impl StakeHistoryGetEntry for StakeHistory {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        self.binary_search_by(|probe| epoch.cmp(&probe.0))
+            .ok()
+            .map(|index| self[index].1.clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -1,0 +1,74 @@
+//! named accounts for synthesized data accounts for bank state, etc.
+//!
+//! this account carries history about stake activations and de-activations
+//!
+pub use crate::clock::Epoch;
+
+use std::ops::Deref;
+
+pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, AbiExample)]
+pub struct StakeHistoryEntry {
+    pub effective: u64,    // effective stake at this epoch
+    pub activating: u64,   // sum of portion of stakes not fully warmed up
+    pub deactivating: u64, // requested to be cooled down, not fully deactivated yet
+}
+
+#[repr(C)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, AbiExample)]
+pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);
+
+impl StakeHistory {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn get(&self, epoch: &Epoch) -> Option<&StakeHistoryEntry> {
+        self.binary_search_by(|probe| epoch.cmp(&probe.0))
+            .ok()
+            .map(|index| &self[index].1)
+    }
+
+    pub fn add(&mut self, epoch: Epoch, entry: StakeHistoryEntry) {
+        match self.binary_search_by(|probe| epoch.cmp(&probe.0)) {
+            Ok(index) => (self.0)[index] = (epoch, entry),
+            Err(index) => (self.0).insert(index, (epoch, entry)),
+        }
+        (self.0).truncate(MAX_ENTRIES);
+    }
+}
+
+impl Deref for StakeHistory {
+    type Target = Vec<(Epoch, StakeHistoryEntry)>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stake_history() {
+        let mut stake_history = StakeHistory::default();
+
+        for i in 0..MAX_ENTRIES as u64 + 1 {
+            stake_history.add(
+                i,
+                StakeHistoryEntry {
+                    activating: i,
+                    ..StakeHistoryEntry::default()
+                },
+            );
+        }
+        assert_eq!(stake_history.len(), MAX_ENTRIES);
+        assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
+        assert_eq!(stake_history.get(&0), None);
+        assert_eq!(
+            stake_history.get(&1),
+            Some(&StakeHistoryEntry {
+                activating: 1,
+                ..StakeHistoryEntry::default()
+            })
+        );
+    }
+}

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -16,9 +16,10 @@ use {
 
 pub type StakeActivationStatus = StakeHistoryEntry;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
 #[allow(clippy::large_enum_variant)]
 pub enum StakeState {
+    #[default]
     Uninitialized,
     Initialized(Meta),
     Stake(Meta, Stake),
@@ -63,12 +64,6 @@ impl BorshSerialize for StakeState {
             }
             StakeState::RewardsPool => writer.write_all(&3u32.to_le_bytes()),
         }
-    }
-}
-
-impl Default for StakeState {
-    fn default() -> Self {
-        StakeState::Uninitialized
     }
 }
 

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -27,17 +27,17 @@ pub enum StakeState {
 }
 
 impl BorshDeserialize for StakeState {
-    fn deserialize(buf: &mut &[u8]) -> io::Result<Self> {
-        let enum_value: u32 = BorshDeserialize::deserialize(buf)?;
+    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let enum_value = u32::deserialize_reader(reader)?;
         match enum_value {
             0 => Ok(StakeState::Uninitialized),
             1 => {
-                let meta: Meta = BorshDeserialize::deserialize(buf)?;
+                let meta = Meta::deserialize_reader(reader)?;
                 Ok(StakeState::Initialized(meta))
             }
             2 => {
-                let meta: Meta = BorshDeserialize::deserialize(buf)?;
-                let stake: Stake = BorshDeserialize::deserialize(buf)?;
+                let meta = Meta::deserialize_reader(reader)?;
+                let stake = Stake::deserialize_reader(reader)?;
                 Ok(StakeState::Stake(meta, stake))
             }
             3 => Ok(StakeState::RewardsPool),

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -113,7 +113,7 @@ impl StakeState {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, AbiExample)]
 pub enum StakeAuthorize {
     Staker,
     Withdrawer,
@@ -125,6 +125,7 @@ pub enum StakeAuthorize {
     Serialize,
     Deserialize,
     PartialEq,
+    Eq,
     Clone,
     Copy,
     AbiExample,
@@ -159,6 +160,7 @@ impl Lockup {
     Serialize,
     Deserialize,
     PartialEq,
+    Eq,
     Clone,
     Copy,
     AbiExample,
@@ -238,6 +240,7 @@ impl Authorized {
     Serialize,
     Deserialize,
     PartialEq,
+    Eq,
     Clone,
     Copy,
     AbiExample,

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Remove the following `allow` when `StakeState` is removed, required to avoid
 // warnings from uses of deprecated types during trait derivations.
 #![allow(deprecated)]

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -1,4 +1,7 @@
 #![allow(clippy::integer_arithmetic)]
+// Remove the following `allow` when `StakeState` is removed, required to avoid
+// warnings from uses of deprecated types during trait derivations.
+#![allow(deprecated)]
 
 use {
     crate::{
@@ -33,14 +36,17 @@ pub fn warmup_cooldown_rate(current_epoch: Epoch, new_rate_activation_epoch: Opt
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
 #[allow(clippy::large_enum_variant)]
+#[deprecated(
+    since = "1.17.0",
+    note = "Please use `StakeStateWithFlags` instead, and match the third `StakeFlags` field when matching `StakeStateWithFlags::Stake` to resolve any breakage. For example, `if let StakeState::Stake(meta, stake)` becomes `if let StakeStateWithFlags::Stake(meta, stake, _stake_flags)`."
+)]
 pub enum StakeState {
     #[default]
     Uninitialized,
     Initialized(Meta),
-    Stake(Meta, Stake, StakeFlags),
+    Stake(Meta, Stake),
     RewardsPool,
 }
-
 impl BorshDeserialize for StakeState {
     fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
         let enum_value = u32::deserialize_reader(reader)?;
@@ -53,8 +59,7 @@ impl BorshDeserialize for StakeState {
             2 => {
                 let meta: Meta = BorshDeserialize::deserialize_reader(reader)?;
                 let stake: Stake = BorshDeserialize::deserialize_reader(reader)?;
-                let stake_flags: StakeFlags = BorshDeserialize::deserialize_reader(reader)?;
-                Ok(StakeState::Stake(meta, stake, stake_flags))
+                Ok(StakeState::Stake(meta, stake))
             }
             3 => Ok(StakeState::RewardsPool),
             _ => Err(io::Error::new(
@@ -64,7 +69,6 @@ impl BorshDeserialize for StakeState {
         }
     }
 }
-
 impl BorshSerialize for StakeState {
     fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
         match self {
@@ -73,17 +77,15 @@ impl BorshSerialize for StakeState {
                 writer.write_all(&1u32.to_le_bytes())?;
                 meta.serialize(writer)
             }
-            StakeState::Stake(meta, stake, stake_flags) => {
+            StakeState::Stake(meta, stake) => {
                 writer.write_all(&2u32.to_le_bytes())?;
                 meta.serialize(writer)?;
-                stake.serialize(writer)?;
-                stake_flags.serialize(writer)
+                stake.serialize(writer)
             }
             StakeState::RewardsPool => writer.write_all(&3u32.to_le_bytes()),
         }
     }
 }
-
 impl StakeState {
     /// The fixed number of bytes used to serialize each stake account
     pub const fn size_of() -> usize {
@@ -92,21 +94,21 @@ impl StakeState {
 
     pub fn stake(&self) -> Option<Stake> {
         match self {
-            StakeState::Stake(_meta, stake, _stake_flags) => Some(*stake),
+            StakeState::Stake(_meta, stake) => Some(*stake),
             _ => None,
         }
     }
 
     pub fn delegation(&self) -> Option<Delegation> {
         match self {
-            StakeState::Stake(_meta, stake, _stake_flags) => Some(stake.delegation),
+            StakeState::Stake(_meta, stake) => Some(stake.delegation),
             _ => None,
         }
     }
 
     pub fn authorized(&self) -> Option<Authorized> {
         match self {
-            StakeState::Stake(meta, _stake, _stake_flags) => Some(meta.authorized),
+            StakeState::Stake(meta, _stake) => Some(meta.authorized),
             StakeState::Initialized(meta) => Some(meta.authorized),
             _ => None,
         }
@@ -118,8 +120,102 @@ impl StakeState {
 
     pub fn meta(&self) -> Option<Meta> {
         match self {
-            StakeState::Stake(meta, _stake, _stake_flags) => Some(*meta),
+            StakeState::Stake(meta, _stake) => Some(*meta),
             StakeState::Initialized(meta) => Some(*meta),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+#[allow(clippy::large_enum_variant)]
+pub enum StakeStateWithFlags {
+    #[default]
+    Uninitialized,
+    Initialized(Meta),
+    Stake(Meta, Stake, StakeFlags),
+    RewardsPool,
+}
+
+impl BorshDeserialize for StakeStateWithFlags {
+    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let enum_value = u32::deserialize_reader(reader)?;
+        match enum_value {
+            0 => Ok(StakeStateWithFlags::Uninitialized),
+            1 => {
+                let meta = Meta::deserialize_reader(reader)?;
+                Ok(StakeStateWithFlags::Initialized(meta))
+            }
+            2 => {
+                let meta: Meta = BorshDeserialize::deserialize_reader(reader)?;
+                let stake: Stake = BorshDeserialize::deserialize_reader(reader)?;
+                let stake_flags: StakeFlags = BorshDeserialize::deserialize_reader(reader)?;
+                Ok(StakeStateWithFlags::Stake(meta, stake, stake_flags))
+            }
+            3 => Ok(StakeStateWithFlags::RewardsPool),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid enum value",
+            )),
+        }
+    }
+}
+
+impl BorshSerialize for StakeStateWithFlags {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        match self {
+            StakeStateWithFlags::Uninitialized => writer.write_all(&0u32.to_le_bytes()),
+            StakeStateWithFlags::Initialized(meta) => {
+                writer.write_all(&1u32.to_le_bytes())?;
+                meta.serialize(writer)
+            }
+            StakeStateWithFlags::Stake(meta, stake, stake_flags) => {
+                writer.write_all(&2u32.to_le_bytes())?;
+                meta.serialize(writer)?;
+                stake.serialize(writer)?;
+                stake_flags.serialize(writer)
+            }
+            StakeStateWithFlags::RewardsPool => writer.write_all(&3u32.to_le_bytes()),
+        }
+    }
+}
+
+impl StakeStateWithFlags {
+    /// The fixed number of bytes used to serialize each stake account
+    pub const fn size_of() -> usize {
+        200 // see test_size_of
+    }
+
+    pub fn stake(&self) -> Option<Stake> {
+        match self {
+            StakeStateWithFlags::Stake(_meta, stake, _stake_flags) => Some(*stake),
+            _ => None,
+        }
+    }
+
+    pub fn delegation(&self) -> Option<Delegation> {
+        match self {
+            StakeStateWithFlags::Stake(_meta, stake, _stake_flags) => Some(stake.delegation),
+            _ => None,
+        }
+    }
+
+    pub fn authorized(&self) -> Option<Authorized> {
+        match self {
+            StakeStateWithFlags::Stake(meta, _stake, _stake_flags) => Some(meta.authorized),
+            StakeStateWithFlags::Initialized(meta) => Some(meta.authorized),
+            _ => None,
+        }
+    }
+
+    pub fn lockup(&self) -> Option<Lockup> {
+        self.meta().map(|meta| meta.lockup)
+    }
+
+    pub fn meta(&self) -> Option<Meta> {
+        match self {
+            StakeStateWithFlags::Stake(meta, _stake, _stake_flags) => Some(*meta),
+            StakeStateWithFlags::Initialized(meta) => Some(*meta),
             _ => None,
         }
     }
@@ -615,28 +711,31 @@ mod test {
         bincode::serialize,
     };
 
-    fn check_borsh_deserialization(stake: StakeState) {
+    fn check_borsh_deserialization(stake: StakeStateWithFlags) {
         let serialized = serialize(&stake).unwrap();
-        let deserialized = StakeState::try_from_slice(&serialized).unwrap();
+        let deserialized = StakeStateWithFlags::try_from_slice(&serialized).unwrap();
         assert_eq!(stake, deserialized);
     }
 
-    fn check_borsh_serialization(stake: StakeState) {
+    fn check_borsh_serialization(stake: StakeStateWithFlags) {
         let bincode_serialized = serialize(&stake).unwrap();
-        let borsh_serialized = StakeState::try_to_vec(&stake).unwrap();
+        let borsh_serialized = StakeStateWithFlags::try_to_vec(&stake).unwrap();
         assert_eq!(bincode_serialized, borsh_serialized);
     }
 
     #[test]
     fn test_size_of() {
-        assert_eq!(StakeState::size_of(), std::mem::size_of::<StakeState>());
+        assert_eq!(
+            StakeStateWithFlags::size_of(),
+            std::mem::size_of::<StakeStateWithFlags>()
+        );
     }
 
     #[test]
     fn bincode_vs_borsh_deserialization() {
-        check_borsh_deserialization(StakeState::Uninitialized);
-        check_borsh_deserialization(StakeState::RewardsPool);
-        check_borsh_deserialization(StakeState::Initialized(Meta {
+        check_borsh_deserialization(StakeStateWithFlags::Uninitialized);
+        check_borsh_deserialization(StakeStateWithFlags::RewardsPool);
+        check_borsh_deserialization(StakeStateWithFlags::Initialized(Meta {
             rent_exempt_reserve: u64::MAX,
             authorized: Authorized {
                 staker: Pubkey::new_unique(),
@@ -644,7 +743,7 @@ mod test {
             },
             lockup: Lockup::default(),
         }));
-        check_borsh_deserialization(StakeState::Stake(
+        check_borsh_deserialization(StakeStateWithFlags::Stake(
             Meta {
                 rent_exempt_reserve: 1,
                 authorized: Authorized {
@@ -669,9 +768,9 @@ mod test {
 
     #[test]
     fn bincode_vs_borsh_serialization() {
-        check_borsh_serialization(StakeState::Uninitialized);
-        check_borsh_serialization(StakeState::RewardsPool);
-        check_borsh_serialization(StakeState::Initialized(Meta {
+        check_borsh_serialization(StakeStateWithFlags::Uninitialized);
+        check_borsh_serialization(StakeStateWithFlags::RewardsPool);
+        check_borsh_serialization(StakeStateWithFlags::Initialized(Meta {
             rent_exempt_reserve: u64::MAX,
             authorized: Authorized {
                 staker: Pubkey::new_unique(),
@@ -679,7 +778,7 @@ mod test {
             },
             lockup: Lockup::default(),
         }));
-        check_borsh_serialization(StakeState::Stake(
+        check_borsh_serialization(StakeStateWithFlags::Stake(
             Meta {
                 rent_exempt_reserve: 1,
                 authorized: Authorized {
@@ -717,13 +816,126 @@ mod test {
         ];
         // As long as we get the 4-byte enum and the first field right, then
         // we're sure the rest works out
-        let deserialized = try_from_slice_unchecked::<StakeState>(&data).unwrap();
+        let deserialized = try_from_slice_unchecked::<StakeStateWithFlags>(&data).unwrap();
         assert_matches!(
             deserialized,
-            StakeState::Initialized(Meta {
+            StakeStateWithFlags::Initialized(Meta {
                 rent_exempt_reserve: 2282880,
                 ..
             })
         );
+    }
+
+    mod deprecated {
+        use super::*;
+        fn check_borsh_deserialization(stake: StakeState) {
+            let serialized = serialize(&stake).unwrap();
+            let deserialized = StakeState::try_from_slice(&serialized).unwrap();
+            assert_eq!(stake, deserialized);
+        }
+
+        fn check_borsh_serialization(stake: StakeState) {
+            let bincode_serialized = serialize(&stake).unwrap();
+            let borsh_serialized = StakeState::try_to_vec(&stake).unwrap();
+            assert_eq!(bincode_serialized, borsh_serialized);
+        }
+
+        #[test]
+        fn test_size_of() {
+            assert_eq!(StakeState::size_of(), std::mem::size_of::<StakeState>());
+        }
+
+        #[test]
+        fn bincode_vs_borsh_deserialization() {
+            check_borsh_deserialization(StakeState::Uninitialized);
+            check_borsh_deserialization(StakeState::RewardsPool);
+            check_borsh_deserialization(StakeState::Initialized(Meta {
+                rent_exempt_reserve: u64::MAX,
+                authorized: Authorized {
+                    staker: Pubkey::new_unique(),
+                    withdrawer: Pubkey::new_unique(),
+                },
+                lockup: Lockup::default(),
+            }));
+            check_borsh_deserialization(StakeState::Stake(
+                Meta {
+                    rent_exempt_reserve: 1,
+                    authorized: Authorized {
+                        staker: Pubkey::new_unique(),
+                        withdrawer: Pubkey::new_unique(),
+                    },
+                    lockup: Lockup::default(),
+                },
+                Stake {
+                    delegation: Delegation {
+                        voter_pubkey: Pubkey::new_unique(),
+                        stake: u64::MAX,
+                        activation_epoch: Epoch::MAX,
+                        deactivation_epoch: Epoch::MAX,
+                        warmup_cooldown_rate: f64::MAX,
+                    },
+                    credits_observed: 1,
+                },
+            ));
+        }
+
+        #[test]
+        fn bincode_vs_borsh_serialization() {
+            check_borsh_serialization(StakeState::Uninitialized);
+            check_borsh_serialization(StakeState::RewardsPool);
+            check_borsh_serialization(StakeState::Initialized(Meta {
+                rent_exempt_reserve: u64::MAX,
+                authorized: Authorized {
+                    staker: Pubkey::new_unique(),
+                    withdrawer: Pubkey::new_unique(),
+                },
+                lockup: Lockup::default(),
+            }));
+            check_borsh_serialization(StakeState::Stake(
+                Meta {
+                    rent_exempt_reserve: 1,
+                    authorized: Authorized {
+                        staker: Pubkey::new_unique(),
+                        withdrawer: Pubkey::new_unique(),
+                    },
+                    lockup: Lockup::default(),
+                },
+                Stake {
+                    delegation: Delegation {
+                        voter_pubkey: Pubkey::new_unique(),
+                        stake: u64::MAX,
+                        activation_epoch: Epoch::MAX,
+                        deactivation_epoch: Epoch::MAX,
+                        warmup_cooldown_rate: f64::MAX,
+                    },
+                    credits_observed: 1,
+                },
+            ));
+        }
+
+        #[test]
+        fn borsh_deserialization_live_data() {
+            let data = [
+                1, 0, 0, 0, 128, 213, 34, 0, 0, 0, 0, 0, 133, 0, 79, 231, 141, 29, 73, 61, 232, 35,
+                119, 124, 168, 12, 120, 216, 195, 29, 12, 166, 139, 28, 36, 182, 186, 154, 246,
+                149, 224, 109, 52, 100, 133, 0, 79, 231, 141, 29, 73, 61, 232, 35, 119, 124, 168,
+                12, 120, 216, 195, 29, 12, 166, 139, 28, 36, 182, 186, 154, 246, 149, 224, 109, 52,
+                100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ];
+            // As long as we get the 4-byte enum and the first field right, then
+            // we're sure the rest works out
+            let deserialized = try_from_slice_unchecked::<StakeState>(&data).unwrap();
+            assert_matches!(
+                deserialized,
+                StakeState::Initialized(Meta {
+                    rent_exempt_reserve: 2282880,
+                    ..
+                })
+            );
+        }
     }
 }

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -580,7 +580,7 @@ impl Stake {
 #[cfg(test)]
 mod test {
     use {
-        super::*, crate::borsh::try_from_slice_unchecked, assert_matches::assert_matches,
+        super::*, crate::borsh0_10::try_from_slice_unchecked, assert_matches::assert_matches,
         bincode::serialize,
     };
 

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -11,7 +11,7 @@ use {
         },
         stake_history::{StakeHistory, StakeHistoryEntry},
     },
-    borsh::{maybestd::io, BorshDeserialize, BorshSchema},
+    borsh::{maybestd::io, BorshDeserialize, BorshSchema, BorshSerialize},
     std::collections::HashSet,
 };
 
@@ -45,6 +45,24 @@ impl BorshDeserialize for StakeState {
                 io::ErrorKind::InvalidData,
                 "Invalid enum value",
             )),
+        }
+    }
+}
+
+impl BorshSerialize for StakeState {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        match self {
+            StakeState::Uninitialized => writer.write_all(&0u32.to_le_bytes()),
+            StakeState::Initialized(meta) => {
+                writer.write_all(&1u32.to_le_bytes())?;
+                meta.serialize(writer)
+            }
+            StakeState::Stake(meta, stake) => {
+                writer.write_all(&2u32.to_le_bytes())?;
+                meta.serialize(writer)?;
+                stake.serialize(writer)
+            }
+            StakeState::RewardsPool => writer.write_all(&3u32.to_le_bytes()),
         }
     }
 }
@@ -112,6 +130,7 @@ pub enum StakeAuthorize {
     AbiExample,
     BorshDeserialize,
     BorshSchema,
+    BorshSerialize,
 )]
 pub struct Lockup {
     /// UnixTimestamp at which this stake will allow withdrawal, unless the
@@ -145,6 +164,7 @@ impl Lockup {
     AbiExample,
     BorshDeserialize,
     BorshSchema,
+    BorshSerialize,
 )]
 pub struct Authorized {
     pub staker: Pubkey,
@@ -223,6 +243,7 @@ impl Authorized {
     AbiExample,
     BorshDeserialize,
     BorshSchema,
+    BorshSerialize,
 )]
 pub struct Meta {
     pub rent_exempt_reserve: u64,
@@ -297,7 +318,16 @@ impl Meta {
 }
 
 #[derive(
-    Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample, BorshDeserialize, BorshSchema,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Clone,
+    Copy,
+    AbiExample,
+    BorshDeserialize,
+    BorshSchema,
+    BorshSerialize,
 )]
 pub struct Delegation {
     /// to whom the stake is delegated
@@ -533,6 +563,7 @@ impl Delegation {
     AbiExample,
     BorshDeserialize,
     BorshSchema,
+    BorshSerialize,
 )]
 pub struct Stake {
     pub delegation: Delegation,
@@ -587,8 +618,14 @@ mod test {
         assert_eq!(stake, deserialized);
     }
 
+    fn check_borsh_serialization(stake: StakeState) {
+        let bincode_serialized = serialize(&stake).unwrap();
+        let borsh_serialized = StakeState::try_to_vec(&stake).unwrap();
+        assert_eq!(bincode_serialized, borsh_serialized);
+    }
+
     #[test]
-    fn bincode_vs_borsh() {
+    fn bincode_vs_borsh_deserialization() {
         check_borsh_deserialization(StakeState::Uninitialized);
         check_borsh_deserialization(StakeState::RewardsPool);
         check_borsh_deserialization(StakeState::Initialized(Meta {
@@ -600,6 +637,40 @@ mod test {
             lockup: Lockup::default(),
         }));
         check_borsh_deserialization(StakeState::Stake(
+            Meta {
+                rent_exempt_reserve: 1,
+                authorized: Authorized {
+                    staker: Pubkey::new_unique(),
+                    withdrawer: Pubkey::new_unique(),
+                },
+                lockup: Lockup::default(),
+            },
+            Stake {
+                delegation: Delegation {
+                    voter_pubkey: Pubkey::new_unique(),
+                    stake: u64::MAX,
+                    activation_epoch: Epoch::MAX,
+                    deactivation_epoch: Epoch::MAX,
+                    warmup_cooldown_rate: f64::MAX,
+                },
+                credits_observed: 1,
+            },
+        ));
+    }
+
+    #[test]
+    fn bincode_vs_borsh_serialization() {
+        check_borsh_serialization(StakeState::Uninitialized);
+        check_borsh_serialization(StakeState::RewardsPool);
+        check_borsh_serialization(StakeState::Initialized(Meta {
+            rent_exempt_reserve: u64::MAX,
+            authorized: Authorized {
+                staker: Pubkey::new_unique(),
+                withdrawer: Pubkey::new_unique(),
+            },
+            lockup: Lockup::default(),
+        }));
+        check_borsh_serialization(StakeState::Stake(
             Meta {
                 rent_exempt_reserve: 1,
                 authorized: Authorized {

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -823,6 +823,45 @@ mod test {
         );
     }
 
+    #[test]
+    fn stake_flag_member_offset() {
+        const FLAG_OFFSET: usize = 196;
+        let check_flag = |flag, expected| {
+            let stake = StakeStateV2::Stake(
+                Meta {
+                    rent_exempt_reserve: 1,
+                    authorized: Authorized {
+                        staker: Pubkey::new_unique(),
+                        withdrawer: Pubkey::new_unique(),
+                    },
+                    lockup: Lockup::default(),
+                },
+                Stake {
+                    delegation: Delegation {
+                        voter_pubkey: Pubkey::new_unique(),
+                        stake: u64::MAX,
+                        activation_epoch: Epoch::MAX,
+                        deactivation_epoch: Epoch::MAX,
+                        warmup_cooldown_rate: f64::MAX,
+                    },
+                    credits_observed: 1,
+                },
+                flag,
+            );
+
+            let bincode_serialized = serialize(&stake).unwrap();
+            let borsh_serialized = StakeStateV2::try_to_vec(&stake).unwrap();
+
+            assert_eq!(bincode_serialized[FLAG_OFFSET], expected);
+            assert_eq!(borsh_serialized[FLAG_OFFSET], expected);
+        };
+        check_flag(
+            StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED,
+            1,
+        );
+        check_flag(StakeFlags::empty(), 0);
+    }
+
     mod deprecated {
         use super::*;
         fn check_borsh_deserialization(stake: StakeState) {

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -404,7 +404,7 @@ impl Delegation {
         } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
             history.and_then(|history| {
                 history
-                    .get(&self.deactivation_epoch)
+                    .get(self.deactivation_epoch)
                     .map(|cluster_stake_at_deactivation_epoch| {
                         (
                             history,
@@ -448,7 +448,7 @@ impl Delegation {
                 if current_epoch >= target_epoch {
                     break;
                 }
-                if let Some(current_cluster_stake) = history.get(&current_epoch) {
+                if let Some(current_cluster_stake) = history.get(current_epoch) {
                     prev_epoch = current_epoch;
                     prev_cluster_stake = current_cluster_stake;
                 } else {
@@ -488,7 +488,7 @@ impl Delegation {
         } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
             history.and_then(|history| {
                 history
-                    .get(&self.activation_epoch)
+                    .get(self.activation_epoch)
                     .map(|cluster_stake_at_activation_epoch| {
                         (
                             history,
@@ -533,7 +533,7 @@ impl Delegation {
                 if current_epoch >= target_epoch || current_epoch >= self.deactivation_epoch {
                     break;
                 }
-                if let Some(current_cluster_stake) = history.get(&current_epoch) {
+                if let Some(current_cluster_stake) = history.get(current_epoch) {
                     prev_epoch = current_epoch;
                     prev_cluster_stake = current_cluster_stake;
                 } else {

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -280,24 +280,6 @@ impl Meta {
         Ok(())
     }
 
-    pub fn rewrite_rent_exempt_reserve(
-        &mut self,
-        rent: &Rent,
-        data_len: usize,
-    ) -> Option<(u64, u64)> {
-        let corrected_rent_exempt_reserve = rent.minimum_balance(data_len);
-        if corrected_rent_exempt_reserve != self.rent_exempt_reserve {
-            // We forcibly update rent_excempt_reserve even
-            // if rent_exempt_reserve > account_balance, hoping user might restore
-            // rent_exempt status by depositing.
-            let (old, new) = (self.rent_exempt_reserve, corrected_rent_exempt_reserve);
-            self.rent_exempt_reserve = corrected_rent_exempt_reserve;
-            Some((old, new))
-        } else {
-            None
-        }
-    }
-
     pub fn auto(authorized: &Pubkey) -> Self {
         Self {
             authorized: Authorized::auto(authorized),

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -436,7 +436,7 @@ impl Default for Delegation {
             stake: 0,
             activation_epoch: 0,
             deactivation_epoch: std::u64::MAX,
-            warmup_cooldown_rate: 0.0,
+            warmup_cooldown_rate: DEFAULT_WARMUP_COOLDOWN_RATE,
         }
     }
 }

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -4,7 +4,6 @@ use {
         clock::{Clock, Epoch, UnixTimestamp},
         instruction::InstructionError,
         pubkey::Pubkey,
-        rent::Rent,
         stake::{
             config::Config,
             instruction::{LockupArgs, StakeError},
@@ -77,10 +76,6 @@ impl StakeState {
     /// The fixed number of bytes used to serialize each stake account
     pub const fn size_of() -> usize {
         200 // see test_size_of
-    }
-
-    pub fn get_rent_exempt_reserve(rent: &Rent) -> u64 {
-        rent.minimum_balance(Self::size_of())
     }
 
     pub fn stake(&self) -> Option<Stake> {

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -641,7 +641,7 @@ impl Delegation {
     pub fn stake(
         &self,
         epoch: Epoch,
-        history: Option<&StakeHistory>,
+        history: &StakeHistory,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> u64 {
         self.stake_activating_and_deactivating(epoch, history, new_rate_activation_epoch)
@@ -652,7 +652,7 @@ impl Delegation {
     pub fn stake_activating_and_deactivating(
         &self,
         target_epoch: Epoch,
-        history: Option<&StakeHistory>,
+        history: &StakeHistory,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> StakeActivationStatus {
         // first, calculate an effective and activating stake
@@ -673,17 +673,14 @@ impl Delegation {
         } else if target_epoch == self.deactivation_epoch {
             // can only deactivate what's activated
             StakeActivationStatus::with_deactivating(effective_stake)
-        } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
-            history.and_then(|history| {
-                history
-                    .get(self.deactivation_epoch)
-                    .map(|cluster_stake_at_deactivation_epoch| {
-                        (
-                            history,
-                            self.deactivation_epoch,
-                            cluster_stake_at_deactivation_epoch,
-                        )
-                    })
+        } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) = history
+            .get(self.deactivation_epoch)
+            .map(|cluster_stake_at_deactivation_epoch| {
+                (
+                    history,
+                    self.deactivation_epoch,
+                    cluster_stake_at_deactivation_epoch,
+                )
             })
         {
             // target_epoch > self.deactivation_epoch
@@ -742,7 +739,7 @@ impl Delegation {
     fn stake_and_activating(
         &self,
         target_epoch: Epoch,
-        history: Option<&StakeHistory>,
+        history: &StakeHistory,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> (u64, u64) {
         let delegated_stake = self.stake;
@@ -760,17 +757,14 @@ impl Delegation {
         } else if target_epoch < self.activation_epoch {
             // not yet enabled
             (0, 0)
-        } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
-            history.and_then(|history| {
-                history
-                    .get(self.activation_epoch)
-                    .map(|cluster_stake_at_activation_epoch| {
-                        (
-                            history,
-                            self.activation_epoch,
-                            cluster_stake_at_activation_epoch,
-                        )
-                    })
+        } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) = history
+            .get(self.activation_epoch)
+            .map(|cluster_stake_at_activation_epoch| {
+                (
+                    history,
+                    self.activation_epoch,
+                    cluster_stake_at_activation_epoch,
+                )
             })
         {
             // target_epoch > self.activation_epoch
@@ -926,7 +920,7 @@ impl Stake {
     pub fn stake(
         &self,
         epoch: Epoch,
-        history: Option<&StakeHistory>,
+        history: &StakeHistory,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> u64 {
         self.delegation

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -74,8 +74,13 @@ impl Default for StakeState {
 }
 
 impl StakeState {
+    /// The fixed number of bytes used to serialize each stake account
+    pub const fn size_of() -> usize {
+        200 // see test_size_of
+    }
+
     pub fn get_rent_exempt_reserve(rent: &Rent) -> u64 {
-        rent.minimum_balance(std::mem::size_of::<StakeState>())
+        rent.minimum_balance(Self::size_of())
     }
 
     pub fn stake(&self) -> Option<Stake> {
@@ -593,6 +598,11 @@ mod test {
         let bincode_serialized = serialize(&stake).unwrap();
         let borsh_serialized = StakeState::try_to_vec(&stake).unwrap();
         assert_eq!(bincode_serialized, borsh_serialized);
+    }
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(StakeState::size_of(), std::mem::size_of::<StakeState>());
     }
 
     #[test]

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -139,7 +139,7 @@ impl Authorized {
             }
             StakeAuthorize::Withdrawer => {
                 if let Some((lockup, clock, custodian)) = lockup_custodian_args {
-                    if lockup.is_in_force(&clock, None) {
+                    if lockup.is_in_force(clock, None) {
                         match custodian {
                             None => {
                                 return Err(StakeError::CustodianMissing.into());
@@ -149,7 +149,7 @@ impl Authorized {
                                     return Err(StakeError::CustodianSignatureMissing.into());
                                 }
 
-                                if lockup.is_in_force(&clock, Some(custodian)) {
+                                if lockup.is_in_force(clock, Some(custodian)) {
                                     return Err(StakeError::LockupInForce.into());
                                 }
                             }

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -24,7 +24,7 @@ pub type StakeActivationStatus = StakeHistoryEntry;
 // epoch
 pub const DEFAULT_WARMUP_COOLDOWN_RATE: f64 = 0.25;
 pub const NEW_WARMUP_COOLDOWN_RATE: f64 = 0.09;
-pub const DEFAULT_SLASH_PENALTY: u8 = ((5 * std::u8::MAX as usize) / 100) as u8;
+pub const DEFAULT_SLASH_PENALTY: u8 = ((5 * u8::MAX as usize) / 100) as u8;
 
 pub fn warmup_cooldown_rate(current_epoch: Epoch, new_rate_activation_epoch: Option<Epoch>) -> f64 {
     if current_epoch < new_rate_activation_epoch.unwrap_or(u64::MAX) {
@@ -622,7 +622,7 @@ impl Default for Delegation {
             voter_pubkey: Pubkey::default(),
             stake: 0,
             activation_epoch: 0,
-            deactivation_epoch: std::u64::MAX,
+            deactivation_epoch: u64::MAX,
             warmup_cooldown_rate: DEFAULT_WARMUP_COOLDOWN_RATE,
         }
     }
@@ -638,7 +638,7 @@ impl Delegation {
         }
     }
     pub fn is_bootstrap(&self) -> bool {
-        self.activation_epoch == std::u64::MAX
+        self.activation_epoch == u64::MAX
     }
 
     pub fn stake(
@@ -950,7 +950,7 @@ impl Stake {
     }
 
     pub fn deactivate(&mut self, epoch: Epoch) -> Result<(), StakeError> {
-        if self.delegation.deactivation_epoch != std::u64::MAX {
+        if self.delegation.deactivation_epoch != u64::MAX {
             Err(StakeError::AlreadyDeactivated)
         } else {
             self.delegation.deactivation_epoch = epoch;

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -1,0 +1,533 @@
+#![allow(clippy::integer_arithmetic)]
+use {
+    crate::{
+        clock::{Clock, Epoch, UnixTimestamp},
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        rent::Rent,
+        stake::{
+            config::Config,
+            instruction::{LockupArgs, StakeError},
+        },
+        stake_history::StakeHistory,
+    },
+    std::collections::HashSet,
+};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+#[allow(clippy::large_enum_variant)]
+pub enum StakeState {
+    Uninitialized,
+    Initialized(Meta),
+    Stake(Meta, Stake),
+    RewardsPool,
+}
+
+impl Default for StakeState {
+    fn default() -> Self {
+        StakeState::Uninitialized
+    }
+}
+
+impl StakeState {
+    pub fn get_rent_exempt_reserve(rent: &Rent) -> u64 {
+        rent.minimum_balance(std::mem::size_of::<StakeState>())
+    }
+
+    pub fn stake(&self) -> Option<Stake> {
+        match self {
+            StakeState::Stake(_meta, stake) => Some(*stake),
+            _ => None,
+        }
+    }
+
+    pub fn delegation(&self) -> Option<Delegation> {
+        match self {
+            StakeState::Stake(_meta, stake) => Some(stake.delegation),
+            _ => None,
+        }
+    }
+
+    pub fn authorized(&self) -> Option<Authorized> {
+        match self {
+            StakeState::Stake(meta, _stake) => Some(meta.authorized),
+            StakeState::Initialized(meta) => Some(meta.authorized),
+            _ => None,
+        }
+    }
+
+    pub fn lockup(&self) -> Option<Lockup> {
+        self.meta().map(|meta| meta.lockup)
+    }
+
+    pub fn meta(&self) -> Option<Meta> {
+        match self {
+            StakeState::Stake(meta, _stake) => Some(*meta),
+            StakeState::Initialized(meta) => Some(*meta),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+pub enum StakeAuthorize {
+    Staker,
+    Withdrawer,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+pub struct Lockup {
+    /// UnixTimestamp at which this stake will allow withdrawal, unless the
+    ///   transaction is signed by the custodian
+    pub unix_timestamp: UnixTimestamp,
+    /// epoch height at which this stake will allow withdrawal, unless the
+    ///   transaction is signed by the custodian
+    pub epoch: Epoch,
+    /// custodian signature on a transaction exempts the operation from
+    ///  lockup constraints
+    pub custodian: Pubkey,
+}
+
+impl Lockup {
+    pub fn is_in_force(&self, clock: &Clock, custodian: Option<&Pubkey>) -> bool {
+        if custodian == Some(&self.custodian) {
+            return false;
+        }
+        self.unix_timestamp > clock.unix_timestamp || self.epoch > clock.epoch
+    }
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+pub struct Authorized {
+    pub staker: Pubkey,
+    pub withdrawer: Pubkey,
+}
+
+impl Authorized {
+    pub fn auto(authorized: &Pubkey) -> Self {
+        Self {
+            staker: *authorized,
+            withdrawer: *authorized,
+        }
+    }
+    pub fn check(
+        &self,
+        signers: &HashSet<Pubkey>,
+        stake_authorize: StakeAuthorize,
+    ) -> Result<(), InstructionError> {
+        match stake_authorize {
+            StakeAuthorize::Staker if signers.contains(&self.staker) => Ok(()),
+            StakeAuthorize::Withdrawer if signers.contains(&self.withdrawer) => Ok(()),
+            _ => Err(InstructionError::MissingRequiredSignature),
+        }
+    }
+
+    pub fn authorize(
+        &mut self,
+        signers: &HashSet<Pubkey>,
+        new_authorized: &Pubkey,
+        stake_authorize: StakeAuthorize,
+        lockup_custodian_args: Option<(&Lockup, &Clock, Option<&Pubkey>)>,
+    ) -> Result<(), InstructionError> {
+        match stake_authorize {
+            StakeAuthorize::Staker => {
+                // Allow either the staker or the withdrawer to change the staker key
+                if !signers.contains(&self.staker) && !signers.contains(&self.withdrawer) {
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
+                self.staker = *new_authorized
+            }
+            StakeAuthorize::Withdrawer => {
+                if let Some((lockup, clock, custodian)) = lockup_custodian_args {
+                    if lockup.is_in_force(&clock, None) {
+                        match custodian {
+                            None => {
+                                return Err(StakeError::CustodianMissing.into());
+                            }
+                            Some(custodian) => {
+                                if !signers.contains(custodian) {
+                                    return Err(StakeError::CustodianSignatureMissing.into());
+                                }
+
+                                if lockup.is_in_force(&clock, Some(custodian)) {
+                                    return Err(StakeError::LockupInForce.into());
+                                }
+                            }
+                        }
+                    }
+                }
+                self.check(signers, stake_authorize)?;
+                self.withdrawer = *new_authorized
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+pub struct Meta {
+    pub rent_exempt_reserve: u64,
+    pub authorized: Authorized,
+    pub lockup: Lockup,
+}
+
+impl Meta {
+    pub fn set_lockup(
+        &mut self,
+        lockup: &LockupArgs,
+        signers: &HashSet<Pubkey>,
+        clock: Option<&Clock>,
+    ) -> Result<(), InstructionError> {
+        match clock {
+            None => {
+                // pre-stake_program_v4 behavior: custodian can set lockups at any time
+                if !signers.contains(&self.lockup.custodian) {
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
+            }
+            Some(clock) => {
+                // post-stake_program_v4 behavior:
+                // * custodian can update the lockup while in force
+                // * withdraw authority can set a new lockup
+                //
+                if self.lockup.is_in_force(clock, None) {
+                    if !signers.contains(&self.lockup.custodian) {
+                        return Err(InstructionError::MissingRequiredSignature);
+                    }
+                } else if !signers.contains(&self.authorized.withdrawer) {
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
+            }
+        }
+        if let Some(unix_timestamp) = lockup.unix_timestamp {
+            self.lockup.unix_timestamp = unix_timestamp;
+        }
+        if let Some(epoch) = lockup.epoch {
+            self.lockup.epoch = epoch;
+        }
+        if let Some(custodian) = lockup.custodian {
+            self.lockup.custodian = custodian;
+        }
+        Ok(())
+    }
+
+    pub fn rewrite_rent_exempt_reserve(
+        &mut self,
+        rent: &Rent,
+        data_len: usize,
+    ) -> Option<(u64, u64)> {
+        let corrected_rent_exempt_reserve = rent.minimum_balance(data_len);
+        if corrected_rent_exempt_reserve != self.rent_exempt_reserve {
+            // We forcibly update rent_excempt_reserve even
+            // if rent_exempt_reserve > account_balance, hoping user might restore
+            // rent_exempt status by depositing.
+            let (old, new) = (self.rent_exempt_reserve, corrected_rent_exempt_reserve);
+            self.rent_exempt_reserve = corrected_rent_exempt_reserve;
+            Some((old, new))
+        } else {
+            None
+        }
+    }
+
+    pub fn auto(authorized: &Pubkey) -> Self {
+        Self {
+            authorized: Authorized::auto(authorized),
+            ..Meta::default()
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+pub struct Delegation {
+    /// to whom the stake is delegated
+    pub voter_pubkey: Pubkey,
+    /// activated stake amount, set at delegate() time
+    pub stake: u64,
+    /// epoch at which this stake was activated, std::Epoch::MAX if is a bootstrap stake
+    pub activation_epoch: Epoch,
+    /// epoch the stake was deactivated, std::Epoch::MAX if not deactivated
+    pub deactivation_epoch: Epoch,
+    /// how much stake we can activate per-epoch as a fraction of currently effective stake
+    pub warmup_cooldown_rate: f64,
+}
+
+impl Default for Delegation {
+    fn default() -> Self {
+        Self {
+            voter_pubkey: Pubkey::default(),
+            stake: 0,
+            activation_epoch: 0,
+            deactivation_epoch: std::u64::MAX,
+            warmup_cooldown_rate: Config::default().warmup_cooldown_rate,
+        }
+    }
+}
+
+impl Delegation {
+    pub fn new(
+        voter_pubkey: &Pubkey,
+        stake: u64,
+        activation_epoch: Epoch,
+        warmup_cooldown_rate: f64,
+    ) -> Self {
+        Self {
+            voter_pubkey: *voter_pubkey,
+            stake,
+            activation_epoch,
+            warmup_cooldown_rate,
+            ..Delegation::default()
+        }
+    }
+    pub fn is_bootstrap(&self) -> bool {
+        self.activation_epoch == std::u64::MAX
+    }
+
+    pub fn stake(
+        &self,
+        epoch: Epoch,
+        history: Option<&StakeHistory>,
+        fix_stake_deactivate: bool,
+    ) -> u64 {
+        self.stake_activating_and_deactivating(epoch, history, fix_stake_deactivate)
+            .0
+    }
+
+    // returned tuple is (effective, activating, deactivating) stake
+    #[allow(clippy::comparison_chain)]
+    pub fn stake_activating_and_deactivating(
+        &self,
+        target_epoch: Epoch,
+        history: Option<&StakeHistory>,
+        fix_stake_deactivate: bool,
+    ) -> (u64, u64, u64) {
+        let delegated_stake = self.stake;
+
+        // first, calculate an effective and activating stake
+        let (effective_stake, activating_stake) =
+            self.stake_and_activating(target_epoch, history, fix_stake_deactivate);
+
+        // then de-activate some portion if necessary
+        if target_epoch < self.deactivation_epoch {
+            // not deactivated
+            (effective_stake, activating_stake, 0)
+        } else if target_epoch == self.deactivation_epoch {
+            // can only deactivate what's activated
+            (effective_stake, 0, effective_stake.min(delegated_stake))
+        } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
+            history.and_then(|history| {
+                history
+                    .get(&self.deactivation_epoch)
+                    .map(|cluster_stake_at_deactivation_epoch| {
+                        (
+                            history,
+                            self.deactivation_epoch,
+                            cluster_stake_at_deactivation_epoch,
+                        )
+                    })
+            })
+        {
+            // target_epoch > self.deactivation_epoch
+
+            // loop from my deactivation epoch until the target epoch
+            // current effective stake is updated using its previous epoch's cluster stake
+            let mut current_epoch;
+            let mut current_effective_stake = effective_stake;
+            loop {
+                current_epoch = prev_epoch + 1;
+                // if there is no deactivating stake at prev epoch, we should have been
+                // fully undelegated at this moment
+                if prev_cluster_stake.deactivating == 0 {
+                    break;
+                }
+
+                // I'm trying to get to zero, how much of the deactivation in stake
+                //   this account is entitled to take
+                let weight =
+                    current_effective_stake as f64 / prev_cluster_stake.deactivating as f64;
+
+                // portion of newly not-effective cluster stake I'm entitled to at current epoch
+                let newly_not_effective_cluster_stake =
+                    prev_cluster_stake.effective as f64 * self.warmup_cooldown_rate;
+                let newly_not_effective_stake =
+                    ((weight * newly_not_effective_cluster_stake) as u64).max(1);
+
+                current_effective_stake =
+                    current_effective_stake.saturating_sub(newly_not_effective_stake);
+                if current_effective_stake == 0 {
+                    break;
+                }
+
+                if current_epoch >= target_epoch {
+                    break;
+                }
+                if let Some(current_cluster_stake) = history.get(&current_epoch) {
+                    prev_epoch = current_epoch;
+                    prev_cluster_stake = current_cluster_stake;
+                } else {
+                    break;
+                }
+            }
+
+            // deactivating stake should equal to all of currently remaining effective stake
+            (current_effective_stake, 0, current_effective_stake)
+        } else {
+            // no history or I've dropped out of history, so assume fully deactivated
+            (0, 0, 0)
+        }
+    }
+
+    // returned tuple is (effective, activating) stake
+    fn stake_and_activating(
+        &self,
+        target_epoch: Epoch,
+        history: Option<&StakeHistory>,
+        fix_stake_deactivate: bool,
+    ) -> (u64, u64) {
+        let delegated_stake = self.stake;
+
+        if self.is_bootstrap() {
+            // fully effective immediately
+            (delegated_stake, 0)
+        } else if fix_stake_deactivate && self.activation_epoch == self.deactivation_epoch {
+            // activated but instantly deactivated; no stake at all regardless of target_epoch
+            // this must be after the bootstrap check and before all-is-activating check
+            (0, 0)
+        } else if target_epoch == self.activation_epoch {
+            // all is activating
+            (0, delegated_stake)
+        } else if target_epoch < self.activation_epoch {
+            // not yet enabled
+            (0, 0)
+        } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
+            history.and_then(|history| {
+                history
+                    .get(&self.activation_epoch)
+                    .map(|cluster_stake_at_activation_epoch| {
+                        (
+                            history,
+                            self.activation_epoch,
+                            cluster_stake_at_activation_epoch,
+                        )
+                    })
+            })
+        {
+            // target_epoch > self.activation_epoch
+
+            // loop from my activation epoch until the target epoch summing up my entitlement
+            // current effective stake is updated using its previous epoch's cluster stake
+            let mut current_epoch;
+            let mut current_effective_stake = 0;
+            loop {
+                current_epoch = prev_epoch + 1;
+                // if there is no activating stake at prev epoch, we should have been
+                // fully effective at this moment
+                if prev_cluster_stake.activating == 0 {
+                    break;
+                }
+
+                // how much of the growth in stake this account is
+                //  entitled to take
+                let remaining_activating_stake = delegated_stake - current_effective_stake;
+                let weight =
+                    remaining_activating_stake as f64 / prev_cluster_stake.activating as f64;
+
+                // portion of newly effective cluster stake I'm entitled to at current epoch
+                let newly_effective_cluster_stake =
+                    prev_cluster_stake.effective as f64 * self.warmup_cooldown_rate;
+                let newly_effective_stake =
+                    ((weight * newly_effective_cluster_stake) as u64).max(1);
+
+                current_effective_stake += newly_effective_stake;
+                if current_effective_stake >= delegated_stake {
+                    current_effective_stake = delegated_stake;
+                    break;
+                }
+
+                if current_epoch >= target_epoch || current_epoch >= self.deactivation_epoch {
+                    break;
+                }
+                if let Some(current_cluster_stake) = history.get(&current_epoch) {
+                    prev_epoch = current_epoch;
+                    prev_cluster_stake = current_cluster_stake;
+                } else {
+                    break;
+                }
+            }
+
+            (
+                current_effective_stake,
+                delegated_stake - current_effective_stake,
+            )
+        } else {
+            // no history or I've dropped out of history, so assume fully effective
+            (delegated_stake, 0)
+        }
+    }
+
+    pub fn rewrite_stake(
+        &mut self,
+        account_balance: u64,
+        rent_exempt_balance: u64,
+    ) -> Option<(u64, u64)> {
+        // note that this will intentionally overwrite innocent
+        // deactivated-then-immeditealy-withdrawn stake accounts as well
+        // this is chosen to minimize the risks from complicated logic,
+        // over some unneeded rewrites
+        let corrected_stake = account_balance.saturating_sub(rent_exempt_balance);
+        if self.stake != corrected_stake {
+            // this could result in creating a 0-staked account;
+            // rewards and staking calc can handle it.
+            let (old, new) = (self.stake, corrected_stake);
+            self.stake = corrected_stake;
+            Some((old, new))
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+pub struct Stake {
+    pub delegation: Delegation,
+    /// credits observed is credits from vote account state when delegated or redeemed
+    pub credits_observed: u64,
+}
+
+impl Stake {
+    pub fn stake(
+        &self,
+        epoch: Epoch,
+        history: Option<&StakeHistory>,
+        fix_stake_deactivate: bool,
+    ) -> u64 {
+        self.delegation.stake(epoch, history, fix_stake_deactivate)
+    }
+
+    pub fn split(
+        &mut self,
+        remaining_stake_delta: u64,
+        split_stake_amount: u64,
+    ) -> Result<Self, StakeError> {
+        if remaining_stake_delta > self.delegation.stake {
+            return Err(StakeError::InsufficientStake);
+        }
+        self.delegation.stake -= remaining_stake_delta;
+        let new = Self {
+            delegation: Delegation {
+                stake: split_stake_amount,
+                ..self.delegation
+            },
+            ..*self
+        };
+        Ok(new)
+    }
+
+    pub fn deactivate(&mut self, epoch: Epoch) -> Result<(), StakeError> {
+        if self.delegation.deactivation_epoch != std::u64::MAX {
+            Err(StakeError::AlreadyDeactivated)
+        } else {
+            self.delegation.deactivation_epoch = epoch;
+            Ok(())
+        }
+    }
+}

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -77,7 +77,8 @@ macro_rules! impl_borsh_stake_state {
         }
     };
 }
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy)]
 #[allow(clippy::large_enum_variant)]
 #[deprecated(
     since = "1.17.0",
@@ -133,7 +134,8 @@ impl StakeState {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy)]
 #[allow(clippy::large_enum_variant)]
 pub enum StakeStateV2 {
     #[default]
@@ -232,12 +234,14 @@ impl StakeStateV2 {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub enum StakeAuthorize {
     Staker,
     Withdrawer,
 }
 
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(
     Default,
     Debug,
@@ -247,7 +251,6 @@ pub enum StakeAuthorize {
     Eq,
     Clone,
     Copy,
-    AbiExample,
     BorshDeserialize,
     BorshSchema,
     BorshSerialize,
@@ -332,6 +335,7 @@ impl borsh0_10::ser::BorshSerialize for Lockup {
     }
 }
 
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(
     Default,
     Debug,
@@ -341,7 +345,6 @@ impl borsh0_10::ser::BorshSerialize for Lockup {
     Eq,
     Clone,
     Copy,
-    AbiExample,
     BorshDeserialize,
     BorshSchema,
     BorshSerialize,
@@ -465,6 +468,7 @@ impl borsh0_10::ser::BorshSerialize for Authorized {
     }
 }
 
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(
     Default,
     Debug,
@@ -474,7 +478,6 @@ impl borsh0_10::ser::BorshSerialize for Authorized {
     Eq,
     Clone,
     Copy,
-    AbiExample,
     BorshDeserialize,
     BorshSchema,
     BorshSerialize,
@@ -582,6 +585,7 @@ impl borsh0_10::ser::BorshSerialize for Meta {
     }
 }
 
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(
     Debug,
     Serialize,
@@ -589,7 +593,6 @@ impl borsh0_10::ser::BorshSerialize for Meta {
     PartialEq,
     Clone,
     Copy,
-    AbiExample,
     BorshDeserialize,
     BorshSchema,
     BorshSerialize,
@@ -896,6 +899,7 @@ impl borsh0_10::ser::BorshSerialize for Delegation {
     }
 }
 
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(
     Debug,
     Default,
@@ -904,7 +908,6 @@ impl borsh0_10::ser::BorshSerialize for Delegation {
     PartialEq,
     Clone,
     Copy,
-    AbiExample,
     BorshDeserialize,
     BorshSchema,
     BorshSerialize,

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -227,6 +227,13 @@ impl StakeStateV2 {
         }
     }
 
+    pub fn delegation_ref(&self) -> Option<&Delegation> {
+        match self {
+            StakeStateV2::Stake(_meta, stake, _stake_flags) => Some(&stake.delegation),
+            _ => None,
+        }
+    }
+
     pub fn authorized(&self) -> Option<Authorized> {
         match self {
             StakeStateV2::Stake(meta, _stake, _stake_flags) => Some(meta.authorized),

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -3,6 +3,8 @@
 // warnings from uses of deprecated types during trait derivations.
 #![allow(deprecated)]
 
+#[cfg(feature = "borsh")]
+use borsh::{io, BorshDeserialize, BorshSchema, BorshSerialize};
 use {
     crate::{
         clock::{Clock, Epoch, UnixTimestamp},
@@ -14,7 +16,6 @@ use {
         },
         stake_history::{StakeHistory, StakeHistoryEntry},
     },
-    borsh::{io, BorshDeserialize, BorshSchema, BorshSerialize},
     std::collections::HashSet,
 };
 
@@ -34,6 +35,7 @@ pub fn warmup_cooldown_rate(current_epoch: Epoch, new_rate_activation_epoch: Opt
     }
 }
 
+#[cfg(feature = "borsh")]
 macro_rules! impl_borsh_stake_state {
     ($borsh:ident) => {
         impl $borsh::BorshDeserialize for StakeState {
@@ -91,7 +93,9 @@ pub enum StakeState {
     Stake(Meta, Stake),
     RewardsPool,
 }
+#[cfg(feature = "borsh")]
 impl_borsh_stake_state!(borsh);
+#[cfg(feature = "borsh")]
 impl_borsh_stake_state!(borsh0_10);
 impl StakeState {
     /// The fixed number of bytes used to serialize each stake account
@@ -144,6 +148,7 @@ pub enum StakeStateV2 {
     Stake(Meta, Stake, StakeFlags),
     RewardsPool,
 }
+#[cfg(feature = "borsh")]
 macro_rules! impl_borsh_stake_state_v2 {
     ($borsh:ident) => {
         impl $borsh::BorshDeserialize for StakeStateV2 {
@@ -190,7 +195,9 @@ macro_rules! impl_borsh_stake_state_v2 {
         }
     };
 }
+#[cfg(feature = "borsh")]
 impl_borsh_stake_state_v2!(borsh);
+#[cfg(feature = "borsh")]
 impl_borsh_stake_state_v2!(borsh0_10);
 
 impl StakeStateV2 {
@@ -242,20 +249,12 @@ pub enum StakeAuthorize {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(
-    Default,
-    Debug,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Eq,
-    Clone,
-    Copy,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
 )]
-#[borsh(crate = "borsh")]
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub struct Lockup {
     /// UnixTimestamp at which this stake will allow withdrawal, unless the
     ///   transaction is signed by the custodian
@@ -275,6 +274,7 @@ impl Lockup {
         self.unix_timestamp > clock.unix_timestamp || self.epoch > clock.epoch
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for Lockup {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -286,6 +286,7 @@ impl borsh0_10::de::BorshDeserialize for Lockup {
         })
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for Lockup {
     fn declaration() -> borsh0_10::schema::Declaration {
         "Lockup".to_string()
@@ -323,6 +324,7 @@ impl borsh0_10::BorshSchema for Lockup {
         <Pubkey as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for Lockup {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,
@@ -336,20 +338,12 @@ impl borsh0_10::ser::BorshSerialize for Lockup {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(
-    Default,
-    Debug,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Eq,
-    Clone,
-    Copy,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
 )]
-#[borsh(crate = "borsh")]
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub struct Authorized {
     pub staker: Pubkey,
     pub withdrawer: Pubkey,
@@ -415,6 +409,7 @@ impl Authorized {
         Ok(())
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for Authorized {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -425,6 +420,7 @@ impl borsh0_10::de::BorshDeserialize for Authorized {
         })
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for Authorized {
     fn declaration() -> borsh0_10::schema::Declaration {
         "Authorized".to_string()
@@ -457,6 +453,7 @@ impl borsh0_10::BorshSchema for Authorized {
         <Pubkey as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for Authorized {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,
@@ -469,20 +466,12 @@ impl borsh0_10::ser::BorshSerialize for Authorized {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(
-    Default,
-    Debug,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Eq,
-    Clone,
-    Copy,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
 )]
-#[borsh(crate = "borsh")]
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub struct Meta {
     pub rent_exempt_reserve: u64,
     pub authorized: Authorized,
@@ -525,6 +514,7 @@ impl Meta {
         }
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for Meta {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -536,6 +526,7 @@ impl borsh0_10::de::BorshDeserialize for Meta {
         })
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for Meta {
     fn declaration() -> borsh0_10::schema::Declaration {
         "Meta".to_string()
@@ -573,6 +564,7 @@ impl borsh0_10::BorshSchema for Meta {
         <Lockup as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for Meta {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,
@@ -586,18 +578,12 @@ impl borsh0_10::ser::BorshSerialize for Meta {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(
-    Debug,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Clone,
-    Copy,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
 )]
-#[borsh(crate = "borsh")]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub struct Delegation {
     /// to whom the stake is delegated
     pub voter_pubkey: Pubkey,
@@ -825,6 +811,7 @@ impl Delegation {
         }
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for Delegation {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -838,6 +825,7 @@ impl borsh0_10::de::BorshDeserialize for Delegation {
         })
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for Delegation {
     fn declaration() -> borsh0_10::schema::Declaration {
         "Delegation".to_string()
@@ -885,6 +873,7 @@ impl borsh0_10::BorshSchema for Delegation {
         <f64 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for Delegation {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,
@@ -900,19 +889,12 @@ impl borsh0_10::ser::BorshSerialize for Delegation {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(
-    Debug,
-    Default,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Clone,
-    Copy,
-    BorshDeserialize,
-    BorshSchema,
-    BorshSerialize,
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize, BorshSchema),
+    borsh(crate = "borsh")
 )]
-#[borsh(crate = "borsh")]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub struct Stake {
     pub delegation: Delegation,
     /// credits observed is credits from vote account state when delegated or redeemed
@@ -958,6 +940,7 @@ impl Stake {
         }
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::de::BorshDeserialize for Stake {
     fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
         reader: &mut R,
@@ -968,6 +951,7 @@ impl borsh0_10::de::BorshDeserialize for Stake {
         })
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::BorshSchema for Stake {
     fn declaration() -> borsh0_10::schema::Declaration {
         "Stake".to_string()
@@ -1000,6 +984,7 @@ impl borsh0_10::BorshSchema for Stake {
         <u64 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+#[cfg(feature = "borsh")]
 impl borsh0_10::ser::BorshSerialize for Stake {
     fn serialize<W: borsh0_10::maybestd::io::Write>(
         &self,
@@ -1013,28 +998,31 @@ impl borsh0_10::ser::BorshSerialize for Stake {
 
 #[cfg(test)]
 mod test {
-    use {
-        super::*, crate::borsh1::try_from_slice_unchecked, assert_matches::assert_matches,
-        bincode::serialize,
-    };
+    #[cfg(feature = "borsh")]
+    use crate::borsh1::try_from_slice_unchecked;
+    use {super::*, assert_matches::assert_matches, bincode::serialize};
 
+    #[cfg(feature = "borsh")]
     fn check_borsh_deserialization(stake: StakeStateV2) {
         let serialized = serialize(&stake).unwrap();
         let deserialized = StakeStateV2::try_from_slice(&serialized).unwrap();
         assert_eq!(stake, deserialized);
     }
 
+    #[cfg(feature = "borsh")]
     fn check_borsh_serialization(stake: StakeStateV2) {
         let bincode_serialized = serialize(&stake).unwrap();
         let borsh_serialized = borsh::to_vec(&stake).unwrap();
         assert_eq!(bincode_serialized, borsh_serialized);
     }
 
+    #[cfg(feature = "borsh")]
     #[test]
     fn test_size_of() {
         assert_eq!(StakeStateV2::size_of(), std::mem::size_of::<StakeStateV2>());
     }
 
+    #[cfg(feature = "borsh")]
     #[test]
     fn bincode_vs_borsh_deserialization() {
         check_borsh_deserialization(StakeStateV2::Uninitialized);
@@ -1070,6 +1058,7 @@ mod test {
         ));
     }
 
+    #[cfg(feature = "borsh")]
     #[test]
     fn bincode_vs_borsh_serialization() {
         check_borsh_serialization(StakeStateV2::Uninitialized);
@@ -1105,6 +1094,7 @@ mod test {
         ));
     }
 
+    #[cfg(feature = "borsh")]
     #[test]
     fn borsh_deserialization_live_data() {
         let data = [
@@ -1171,12 +1161,14 @@ mod test {
 
     mod deprecated {
         use super::*;
+        #[cfg(feature = "borsh")]
         fn check_borsh_deserialization(stake: StakeState) {
             let serialized = serialize(&stake).unwrap();
             let deserialized = StakeState::try_from_slice(&serialized).unwrap();
             assert_eq!(stake, deserialized);
         }
 
+        #[cfg(feature = "borsh")]
         fn check_borsh_serialization(stake: StakeState) {
             let bincode_serialized = serialize(&stake).unwrap();
             let borsh_serialized = borsh::to_vec(&stake).unwrap();
@@ -1188,6 +1180,7 @@ mod test {
             assert_eq!(StakeState::size_of(), std::mem::size_of::<StakeState>());
         }
 
+        #[cfg(feature = "borsh")]
         #[test]
         fn bincode_vs_borsh_deserialization() {
             check_borsh_deserialization(StakeState::Uninitialized);
@@ -1222,6 +1215,7 @@ mod test {
             ));
         }
 
+        #[cfg(feature = "borsh")]
         #[test]
         fn bincode_vs_borsh_serialization() {
             check_borsh_serialization(StakeState::Uninitialized);
@@ -1256,6 +1250,7 @@ mod test {
             ));
         }
 
+        #[cfg(feature = "borsh")]
         #[test]
         fn borsh_deserialization_live_data() {
             let data = [

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -8,7 +8,6 @@
 use borsh::{io, BorshDeserialize, BorshSchema, BorshSerialize};
 use {
     crate::{
-        clock::{Clock, Epoch, UnixTimestamp},
         instruction::InstructionError,
         pubkey::Pubkey,
         stake::{
@@ -17,6 +16,7 @@ use {
         },
         stake_history::{StakeHistoryEntry, StakeHistoryGetEntry},
     },
+    solana_clock::{Clock, Epoch, UnixTimestamp},
     std::collections::HashSet,
 };
 

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -213,6 +213,13 @@ impl StakeStateV2 {
         }
     }
 
+    pub fn stake_ref(&self) -> Option<&Stake> {
+        match self {
+            StakeStateV2::Stake(_meta, stake, _stake_flags) => Some(stake),
+            _ => None,
+        }
+    }
+
     pub fn delegation(&self) -> Option<Delegation> {
         match self {
             StakeStateV2::Stake(_meta, stake, _stake_flags) => Some(stake.delegation),

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -1071,6 +1071,7 @@ mod test {
             },
             lockup: Lockup::default(),
         }));
+        #[allow(deprecated)]
         check_borsh_serialization(StakeStateV2::Stake(
             Meta {
                 rent_exempt_reserve: 1,
@@ -1152,6 +1153,7 @@ mod test {
             assert_eq!(bincode_serialized[FLAG_OFFSET], expected);
             assert_eq!(borsh_serialized[FLAG_OFFSET], expected);
         };
+        #[allow(deprecated)]
         check_flag(
             StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED,
             1,

--- a/interface/src/tools.rs
+++ b/interface/src/tools.rs
@@ -28,7 +28,7 @@ fn get_minimum_delegation_return_data() -> Result<u64, ProgramError> {
         .ok_or(ProgramError::InvalidInstructionData)
         .and_then(|(program_id, return_data)| {
             (program_id == super::program::id())
-                .then(|| return_data)
+                .then_some(return_data)
                 .ok_or(ProgramError::IncorrectProgramId)
         })
         .and_then(|return_data| {

--- a/interface/src/tools.rs
+++ b/interface/src/tools.rs
@@ -28,7 +28,7 @@ fn get_minimum_delegation_return_data() -> Result<u64, ProgramError> {
         .ok_or(ProgramError::InvalidInstructionData)
         .and_then(|(program_id, return_data)| {
             (program_id == super::program::id())
-                .then_some(return_data)
+                .then(|| return_data)
                 .ok_or(ProgramError::IncorrectProgramId)
         })
         .and_then(|return_data| {

--- a/interface/src/tools.rs
+++ b/interface/src/tools.rs
@@ -1,5 +1,7 @@
 //! Utility functions
-use crate::program_error::ProgramError;
+use crate::{
+    clock::Epoch, program_error::ProgramError, stake::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION,
+};
 
 /// Helper function for programs to call [`GetMinimumDelegation`] and then fetch the return data
 ///
@@ -35,4 +37,118 @@ fn get_minimum_delegation_return_data() -> Result<u64, ProgramError> {
                 .or(Err(ProgramError::InvalidInstructionData))
         })
         .map(u64::from_le_bytes)
+}
+
+// Check if the provided `epoch_credits` demonstrate active voting over the previous
+// `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION`
+pub fn acceptable_reference_epoch_credits(
+    epoch_credits: &[(Epoch, u64, u64)],
+    current_epoch: Epoch,
+) -> bool {
+    if let Some(epoch_index) = epoch_credits
+        .len()
+        .checked_sub(MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION)
+    {
+        let mut epoch = current_epoch;
+        for (vote_epoch, ..) in epoch_credits[epoch_index..].iter().rev() {
+            if *vote_epoch != epoch {
+                return false;
+            }
+            epoch = epoch.saturating_sub(1);
+        }
+        true
+    } else {
+        false
+    }
+}
+
+// Check if the provided `epoch_credits` demonstrate delinquency over the previous
+// `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION`
+pub fn eligible_for_deactivate_delinquent(
+    epoch_credits: &[(Epoch, u64, u64)],
+    current_epoch: Epoch,
+) -> bool {
+    match epoch_credits.last() {
+        None => true,
+        Some((epoch, ..)) => {
+            if let Some(minimum_epoch) =
+                current_epoch.checked_sub(MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION as Epoch)
+            {
+                *epoch <= minimum_epoch
+            } else {
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_acceptable_reference_epoch_credits() {
+        let epoch_credits = [];
+        assert!(!acceptable_reference_epoch_credits(&epoch_credits, 0));
+
+        let epoch_credits = [(0, 42, 42), (1, 42, 42), (2, 42, 42), (3, 42, 42)];
+        assert!(!acceptable_reference_epoch_credits(&epoch_credits, 3));
+
+        let epoch_credits = [
+            (0, 42, 42),
+            (1, 42, 42),
+            (2, 42, 42),
+            (3, 42, 42),
+            (4, 42, 42),
+        ];
+        assert!(!acceptable_reference_epoch_credits(&epoch_credits, 3));
+        assert!(acceptable_reference_epoch_credits(&epoch_credits, 4));
+
+        let epoch_credits = [
+            (1, 42, 42),
+            (2, 42, 42),
+            (3, 42, 42),
+            (4, 42, 42),
+            (5, 42, 42),
+        ];
+        assert!(acceptable_reference_epoch_credits(&epoch_credits, 5));
+
+        let epoch_credits = [
+            (0, 42, 42),
+            (2, 42, 42),
+            (3, 42, 42),
+            (4, 42, 42),
+            (5, 42, 42),
+        ];
+        assert!(!acceptable_reference_epoch_credits(&epoch_credits, 5));
+    }
+
+    #[test]
+    fn test_eligible_for_deactivate_delinquent() {
+        let epoch_credits = [];
+        assert!(eligible_for_deactivate_delinquent(&epoch_credits, 42));
+
+        let epoch_credits = [(0, 42, 42)];
+        assert!(!eligible_for_deactivate_delinquent(&epoch_credits, 0));
+
+        let epoch_credits = [(0, 42, 42)];
+        assert!(!eligible_for_deactivate_delinquent(
+            &epoch_credits,
+            MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION as Epoch - 1
+        ));
+        assert!(eligible_for_deactivate_delinquent(
+            &epoch_credits,
+            MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION as Epoch
+        ));
+
+        let epoch_credits = [(100, 42, 42)];
+        assert!(!eligible_for_deactivate_delinquent(
+            &epoch_credits,
+            100 + MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION as Epoch - 1
+        ));
+        assert!(eligible_for_deactivate_delinquent(
+            &epoch_credits,
+            100 + MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION as Epoch
+        ));
+    }
 }

--- a/interface/src/tools.rs
+++ b/interface/src/tools.rs
@@ -1,0 +1,38 @@
+//! Utility functions
+use crate::program_error::ProgramError;
+
+/// Helper function for programs to call [`GetMinimumDelegation`] and then fetch the return data
+///
+/// This fn handles performing the CPI to call the [`GetMinimumDelegation`] function, and then
+/// calls [`get_return_data()`] to fetch the return data.
+///
+/// [`GetMinimumDelegation`]: super::instruction::StakeInstruction::GetMinimumDelegation
+/// [`get_return_data()`]: crate::program::get_return_data
+pub fn get_minimum_delegation() -> Result<u64, ProgramError> {
+    let instruction = super::instruction::get_minimum_delegation();
+    crate::program::invoke_unchecked(&instruction, &[])?;
+    get_minimum_delegation_return_data()
+}
+
+/// Helper function for programs to get the return data after calling [`GetMinimumDelegation`]
+///
+/// This fn handles calling [`get_return_data()`], ensures the result is from the correct
+/// program, and returns the correct type.
+///
+/// [`GetMinimumDelegation`]: super::instruction::StakeInstruction::GetMinimumDelegation
+/// [`get_return_data()`]: crate::program::get_return_data
+fn get_minimum_delegation_return_data() -> Result<u64, ProgramError> {
+    crate::program::get_return_data()
+        .ok_or(ProgramError::InvalidInstructionData)
+        .and_then(|(program_id, return_data)| {
+            (program_id == super::program::id())
+                .then(|| return_data)
+                .ok_or(ProgramError::IncorrectProgramId)
+        })
+        .and_then(|return_data| {
+            return_data
+                .try_into()
+                .or(Err(ProgramError::InvalidInstructionData))
+        })
+        .map(u64::from_le_bytes)
+}

--- a/interface/src/tools.rs
+++ b/interface/src/tools.rs
@@ -1,6 +1,7 @@
 //! Utility functions
-use crate::{
-    clock::Epoch, program_error::ProgramError, stake::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION,
+use {
+    crate::{program_error::ProgramError, stake::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION},
+    solana_clock::Epoch,
 };
 
 /// Helper function for programs to call [`GetMinimumDelegation`] and then fetch the return data


### PR DESCRIPTION
### Problem

PR #12 was "squashed & merged", which does not preserve the history.

### Solution

This PR re-adds the files so they can be "rebased & merged" instead. PR #15 reverted #12.