### PR TITLE
Add interface crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5191,15 +5191,13 @@ dependencies = [
 
 [[package]]
 name = "solana-system-interface"
-version = "0.0.1"
-source = "git+https://github.com/solana-program/system.git#77ed21c763096f7ecee974ddbd4ab2ecbbde78f4"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d7c18cb1a91c6be5f5a8ac9276a1d7c737e39a21beba9ea710ab4b9c63bc90"
 dependencies = [
  "js-sys",
  "num-traits",
- "serde",
- "serde_derive",
  "solana-decode-error",
- "solana-instruction",
  "solana-pubkey",
  "wasm-bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "aquamarine"
@@ -292,7 +292,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -305,7 +305,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -369,7 +369,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -505,11 +505,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+checksum = "2506947f73ad44e344215ccd6403ac2ae18cd8e046e581a441bf8d199f257f03"
 dependencies = [
- "borsh-derive 1.5.1",
+ "borsh-derive 1.5.3",
  "cfg_aliases",
 ]
 
@@ -528,16 +528,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+checksum = "c2593a3b8b938bd68373196c9832f516be11fa487ef4ae745eb282e6a56a7244"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.83",
- "syn_derive",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -625,7 +624,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -668,14 +667,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -708,7 +707,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -786,7 +785,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "unicode-width",
+ "unicode-width 0.1.14",
  "windows-sys 0.52.0",
 ]
 
@@ -834,9 +833,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -959,7 +958,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -983,7 +982,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -994,7 +993,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1101,7 +1100,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1124,7 +1123,7 @@ checksum = "a6cbae11b3de8fce2a456e8ea3dada226b35fe791f0dc1d360c0941f0bb681f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1200,9 +1199,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -1224,7 +1223,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1237,7 +1236,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1298,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "feature-probe"
@@ -1343,9 +1342,9 @@ checksum = "94474d15a76982be62ca8a39570dccce148d98c238ebb7408b0a21b2c4bdddc4"
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1437,7 +1436,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1600,9 +1599,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "heck"
@@ -1769,6 +1768,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,12 +1893,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1843,21 +1971,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
 dependencies = [
  "console",
- "instant",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
+ "web-time",
 ]
 
 [[package]]
@@ -1867,15 +1995,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1918,7 +2037,7 @@ dependencies = [
  "combine 4.6.7",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
 ]
 
@@ -1978,9 +2097,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libredox"
@@ -2050,7 +2169,7 @@ dependencies = [
  "ark-bn254",
  "ark-ff",
  "num-bigint 0.4.6",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2058,6 +2177,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -2332,7 +2457,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2404,7 +2529,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2465,7 +2590,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2538,29 +2663,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -2705,7 +2830,7 @@ checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2725,46 +2850,50 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.15",
+ "rustls 0.23.16",
  "socket2",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
+ "getrandom 0.2.15",
  "rand 0.8.5",
  "ring",
  "rustc-hash",
- "rustls 0.23.15",
+ "rustls 0.23.16",
+ "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror",
+ "thiserror 2.0.3",
  "tinyvec",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 dependencies = [
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
@@ -2913,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2984,7 +3113,7 @@ dependencies = [
  "reqwest",
  "serde",
  "task-local-extensions",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3034,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3059,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.15"
+version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
  "once_cell",
  "ring",
@@ -3107,26 +3236,29 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
+checksum = "a4c7dc240fec5517e6c4eab3310438636cfe6391dfc345ba013109909a90d136"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.15",
+ "rustls 0.23.16",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
  "security-framework",
  "security-framework-sys",
- "webpki-roots 0.26.6",
- "winapi",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3224,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3249,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.213"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
@@ -3267,13 +3399,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.213"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3327,7 +3459,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3482,7 +3614,7 @@ dependencies = [
  "spl-token-2022",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "thiserror",
+ "thiserror 1.0.69",
  "zstd",
 ]
 
@@ -3558,7 +3690,7 @@ dependencies = [
  "static_assertions",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3577,7 +3709,7 @@ dependencies = [
  "solana-program",
  "solana-program-runtime",
  "solana-sdk",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3595,13 +3727,13 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f857fb6590467d433f40eee507666ca496ec67907e50b7d530b6c04f6541875"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "futures",
  "solana-banks-interface",
  "solana-program",
  "solana-sdk",
  "tarpc",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-serde",
 ]
@@ -3662,7 +3794,7 @@ dependencies = [
  "ark-serialize",
  "bytemuck",
  "solana-program",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3672,7 +3804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5d526f3525ab22a3ada3f9a1d642664dafac00dc9208326b701a2045514eb04"
 dependencies = [
  "borsh 0.10.4",
- "borsh 1.5.1",
+ "borsh 1.5.3",
 ]
 
 [[package]]
@@ -3699,7 +3831,7 @@ dependencies = [
  "solana-timings",
  "solana-type-overrides",
  "solana_rbpf",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3769,7 +3901,7 @@ dependencies = [
  "solana-thin-client",
  "solana-tpu-client",
  "solana-udp-client",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -3836,7 +3968,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -3883,7 +4015,7 @@ dependencies = [
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
  "solana-program",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3959,12 +4091,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-frozen-abi"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "935d1e27a61b8456a18078647599825c0062fa3ece9484ab5eb4557edea49c33"
+dependencies = [
+ "bs58",
+ "bv",
+ "generic-array",
+ "im",
+ "log",
+ "memmap2",
+ "serde",
+ "serde_derive",
+ "serde_with",
+ "sha2 0.10.8",
+ "solana-frozen-abi-macro",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "solana-frozen-abi-macro"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a876e62a2ca32100f99c466bd8bb7ea611ccffbcc00386e1686a0136d2b2d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "solana-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1807bc4e9e1d25271514167d5a1e698ce5a330bce547a368242dd63b355b5faa"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bs58",
  "bytemuck",
  "bytemuck_derive",
@@ -4003,13 +4166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfef689e06e5c7cb6206d4dc61ac77733de4f72d754e0d531393206abc27dbe4"
 dependencies = [
  "bincode",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "getrandom 0.2.15",
  "js-sys",
  "num-traits",
  "serde",
  "serde_derive",
  "solana-define-syscall",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
  "solana-pubkey",
  "wasm-bindgen",
 ]
@@ -4092,7 +4257,7 @@ dependencies = [
  "log",
  "reqwest",
  "solana-sdk",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4185,7 +4350,7 @@ dependencies = [
  "ark-bn254",
  "light-poseidon",
  "solana-define-syscall",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4209,7 +4374,7 @@ dependencies = [
  "bitflags 2.6.0",
  "blake3",
  "borsh 0.10.4",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bs58",
  "bv",
  "bytemuck",
@@ -4266,7 +4431,7 @@ dependencies = [
  "solana-slot-history",
  "solana-stable-layout",
  "solana-transaction-error",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
 ]
 
@@ -4288,7 +4453,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd089caeef26dd07bd12b7b67d45e92faddc2fc67a960f316df7ae4776a2f3d5"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "num-traits",
  "serde",
  "serde_derive",
@@ -4350,7 +4515,7 @@ dependencies = [
  "solana-type-overrides",
  "solana-vote",
  "solana_rbpf",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4385,7 +4550,7 @@ dependencies = [
  "solana-timings",
  "solana-vote-program",
  "solana_rbpf",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -4396,7 +4561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bea3215775fcedf200d47590c7e2ce9a3a46bc2b7d3f77d0eae9c6edf0a39aec"
 dependencies = [
  "borsh 0.10.4",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bs58",
  "bytemuck",
  "bytemuck_derive",
@@ -4411,6 +4576,8 @@ dependencies = [
  "solana-atomic-u64",
  "solana-decode-error",
  "solana-define-syscall",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
  "solana-sanitize",
  "solana-sha256-hasher",
  "wasm-bindgen",
@@ -4433,7 +4600,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-rpc-client-api",
  "solana-sdk",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -4455,7 +4622,7 @@ dependencies = [
  "log",
  "quinn",
  "quinn-proto",
- "rustls 0.23.15",
+ "rustls 0.23.16",
  "solana-connection-cache",
  "solana-measure",
  "solana-metrics",
@@ -4463,7 +4630,7 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-sdk",
  "solana-streamer",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -4536,7 +4703,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status-client-types",
  "solana-version",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4547,7 +4714,7 @@ checksum = "7f0ab2d1ca3769c5058c689b438d35eb1cb7d2a32fc4b2b7c16fe72fa187927c"
 dependencies = [
  "solana-rpc-client",
  "solana-sdk",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4635,7 +4802,7 @@ dependencies = [
  "symlink",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "zstd",
 ]
 
@@ -4652,7 +4819,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sdk",
  "solana-svm-transaction",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4669,7 +4836,7 @@ checksum = "524604d94185c189616296e5b7da1014cc96d1e446bd2b26f247f00708b9225a"
 dependencies = [
  "bincode",
  "bitflags 2.6.0",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bs58",
  "bytemuck",
  "bytemuck_derive",
@@ -4720,7 +4887,7 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-transaction-error",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
 ]
 
@@ -4733,7 +4900,7 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4742,10 +4909,10 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2eef5a00a75648273c3fb6e3d85b0c8c02fcc1e36c4271664dcc39b6b128d41"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "libsecp256k1",
  "solana-define-syscall",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4871,7 +5038,34 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "solana-stake-interface"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "bincode",
+ "borsh 0.10.4",
+ "borsh 1.5.3",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-borsh",
+ "solana-clock",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-instruction",
+ "solana-program",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-system-interface",
+ "static_assertions",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4880,7 +5074,7 @@ version = "1.0.0"
 dependencies = [
  "arrayref",
  "bincode",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "num-derive 0.4.2",
  "num-traits",
  "num_enum",
@@ -4889,7 +5083,7 @@ dependencies = [
  "solana-sdk",
  "solana-vote-program",
  "test-case",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4933,7 +5127,7 @@ dependencies = [
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
- "rustls 0.23.15",
+ "rustls 0.23.16",
  "smallvec",
  "socket2",
  "solana-measure",
@@ -4941,7 +5135,7 @@ dependencies = [
  "solana-perf",
  "solana-sdk",
  "solana-transaction-metrics-tracker",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util 0.7.12",
  "x509-parser",
@@ -4974,7 +5168,7 @@ dependencies = [
  "solana-timings",
  "solana-type-overrides",
  "solana-vote",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4993,6 +5187,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38a8533576cb7beca4a44b976ac27df9865bbf8c4cbca2ee8f4f3469cdd8175f"
 dependencies = [
  "solana-sdk",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "0.0.1"
+source = "git+https://github.com/solana-program/system.git#77ed21c763096f7ecee974ddbd4ab2ecbbde78f4"
+dependencies = [
+ "js-sys",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-pubkey",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5056,7 +5265,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-sdk",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -5097,7 +5306,7 @@ dependencies = [
  "Inflector",
  "base64 0.22.1",
  "bincode",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bs58",
  "lazy_static",
  "log",
@@ -5113,7 +5322,7 @@ dependencies = [
  "spl-token-2022",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5131,7 +5340,7 @@ dependencies = [
  "solana-account-decoder-client-types",
  "solana-sdk",
  "solana-signature",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5155,7 +5364,7 @@ dependencies = [
  "solana-net-utils",
  "solana-sdk",
  "solana-streamer",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -5184,7 +5393,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5204,7 +5413,7 @@ dependencies = [
  "solana-program",
  "solana-program-runtime",
  "solana-sdk",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5249,7 +5458,7 @@ dependencies = [
  "solana-program",
  "solana-sdk",
  "subtle",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -5298,7 +5507,7 @@ dependencies = [
  "solana-program",
  "solana-sdk",
  "subtle",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -5316,7 +5525,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc-demangle",
  "scroll",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
 ]
 
@@ -5342,13 +5551,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68034596cf4804880d265f834af1ff2f821ad5293e41fa0f8f59086c181fc38e"
 dependencies = [
  "assert_matches",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
  "spl-token",
  "spl-token-2022",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5370,7 +5579,7 @@ checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5382,8 +5591,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.8",
- "syn 2.0.83",
- "thiserror",
+ "syn 2.0.87",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5401,7 +5610,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c704c88fc457fa649ba3aabe195c79d885c3f26709efaddc453c8de352c90b87"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bytemuck",
  "bytemuck_derive",
  "solana-program",
@@ -5419,7 +5628,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-program-error-derive",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5431,7 +5640,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.8",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5460,7 +5669,7 @@ dependencies = [
  "num-traits",
  "num_enum",
  "solana-program",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5484,7 +5693,7 @@ dependencies = [
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5506,7 +5715,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c2318ddff97e006ed9b1291ebec0750a78547f870f62a69c56fe3b46a5d8fc"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "solana-program",
  "spl-discriminator",
  "spl-pod",
@@ -5542,6 +5751,12 @@ dependencies = [
  "spl-pod",
  "spl-program-error",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -5602,25 +5817,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.83"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01680f5d178a369f817f43f3d399650272873a8e7588a7872f7e90edc71d60a3"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.83",
 ]
 
 [[package]]
@@ -5639,6 +5842,17 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5664,9 +5878,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
+checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
 dependencies = [
  "filetime",
  "libc",
@@ -5689,7 +5903,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "tarpc-plugins",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-serde",
  "tokio-util 0.6.10",
@@ -5719,9 +5933,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -5763,7 +5977,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5774,28 +5988,48 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
  "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.65"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.65"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5840,6 +6074,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5856,9 +6100,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5880,7 +6124,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6015,7 +6259,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6073,7 +6317,7 @@ dependencies = [
  "rand 0.8.5",
  "rustls 0.21.12",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
  "webpki-roots 0.24.0",
@@ -6092,31 +6336,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -6161,9 +6396,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -6175,6 +6410,18 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valuable"
@@ -6247,7 +6494,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -6281,7 +6528,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6303,6 +6550,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c6dfa3ac045bc517de14c7b1384298de1dbd229d38e08e169d9ae8c170937c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6316,15 +6582,6 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
-dependencies = [
- "rustls-pki-types",
-]
 
 [[package]]
 name = "winapi"
@@ -6534,6 +6791,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "x509-parser"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6547,7 +6816,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -6560,6 +6829,30 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -6580,7 +6873,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -6600,7 +6914,29 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.83",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,13 @@
 resolver = "2"
 members = [
     "clients/rust",
+    "interface",
     "program",
 ]
 
 [workspace.metadata.cli]
-solana = "edge"
+solana = "2.1.0"
 
-# Specify Rust toolchains for rustfmt, clippy, and build.
-# Any unprovided toolchains default to stable.
 [workspace.metadata.toolchains]
 format = "nightly-2024-08-08"
 lint = "nightly-2024-08-08"

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "../LICENSE"
 borsh = { version = "1.5.1", features = ["derive", "unstable__schema"], optional = true }
 borsh0-10 = { package = "borsh", version = "0.10.3", optional = true }
 num-traits = "0.2"
-serde = { version = "1.0.210", features = ["derive"], optional = true }
+serde = { version = "1.0.210", optional = true }
 serde_derive = { version = "1.0.210", optional = true }
 solana-decode-error = "^2.1"
 solana-clock = "^2.1"
@@ -21,7 +21,7 @@ solana-frozen-abi-macro = { version = "^2.1", features = ["frozen-abi"], optiona
 solana-instruction = "^2.1"
 solana-program-error = { version = "^2.1", optional = true }
 solana-pubkey = { version = "^2.1", default-features = false }
-solana-system-interface = { version = "0.0.1", git = "https://github.com/solana-program/system.git" }
+solana-system-interface = "^1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
@@ -34,6 +34,8 @@ strum_macros = "0.24"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 bincode = [

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "solana-stake-interface"
+version = "0.1.0"
+description = "Instructions and constructors for the Stake program"
+repository = "https://github.com/solana-program/stake"
+edition = "2021"
+readme = "README.md"
+license-file = "../LICENSE"
+
+[dependencies]
+borsh = { version = "1.5.1", features = ["derive", "unstable__schema"], optional=true }
+borsh0-10 = { package = "borsh", version = "0.10.3", optional=true }
+num-traits = "0.2"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_derive = "1.0.210"
+solana-decode-error = "^2.1"
+solana-clock = "^2.1"
+solana-cpi = "^2.1"
+solana-frozen-abi = { version = "^2.1", features = ["frozen-abi"], optional = true }
+solana-frozen-abi-macro = { version = "^2.1", features = ["frozen-abi"], optional = true }
+solana-instruction = { version = "^2.1", features = ["bincode", "std"] }
+solana-program-error = "^2.1"
+solana-pubkey = { version = "^2.1", default-features = false, features = ["serde"] }
+solana-system-interface = { version = "0.0.1", git = "https://github.com/solana-program/system.git" }
+
+[dev-dependencies]
+assert_matches = "1.5.0"
+bincode = "1.3.3"
+solana-borsh = "^2.1"
+solana-program = { version = "^2.1", default-features = false }
+static_assertions = "1.1.0"
+strum = "0.24"
+strum_macros = "0.24"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+borsh = [
+    "dep:borsh",
+    "dep:borsh0-10",
+    "solana-instruction/borsh",
+    "solana-program-error/borsh",
+    "solana-pubkey/borsh"
+]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-instruction/frozen-abi",
+    "solana-pubkey/frozen-abi"
+]

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -8,19 +8,19 @@ readme = "README.md"
 license-file = "../LICENSE"
 
 [dependencies]
-borsh = { version = "1.5.1", features = ["derive", "unstable__schema"], optional=true }
-borsh0-10 = { package = "borsh", version = "0.10.3", optional=true }
+borsh = { version = "1.5.1", features = ["derive", "unstable__schema"], optional = true }
+borsh0-10 = { package = "borsh", version = "0.10.3", optional = true }
 num-traits = "0.2"
-serde = { version = "1.0.210", features = ["derive"] }
-serde_derive = "1.0.210"
+serde = { version = "1.0.210", features = ["derive"], optional = true }
+serde_derive = { version = "1.0.210", optional = true }
 solana-decode-error = "^2.1"
 solana-clock = "^2.1"
-solana-cpi = "^2.1"
+solana-cpi = { version = "^2.1", optional = true }
 solana-frozen-abi = { version = "^2.1", features = ["frozen-abi"], optional = true }
 solana-frozen-abi-macro = { version = "^2.1", features = ["frozen-abi"], optional = true }
-solana-instruction = { version = "^2.1", features = ["bincode", "std"] }
-solana-program-error = "^2.1"
-solana-pubkey = { version = "^2.1", default-features = false, features = ["serde"] }
+solana-instruction = "^2.1"
+solana-program-error = { version = "^2.1", optional = true }
+solana-pubkey = { version = "^2.1", default-features = false }
 solana-system-interface = { version = "0.0.1", git = "https://github.com/solana-program/system.git" }
 
 [dev-dependencies]
@@ -36,6 +36,13 @@ strum_macros = "0.24"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
+bincode = [
+    "dep:solana-cpi",
+    "dep:solana-program-error",
+    "solana-instruction/bincode",
+    "solana-instruction/serde",
+    "serde"
+]
 borsh = [
     "dep:borsh",
     "dep:borsh0-10",
@@ -49,3 +56,4 @@ frozen-abi = [
     "solana-instruction/frozen-abi",
     "solana-pubkey/frozen-abi"
 ]
+serde = ["dep:serde", "dep:serde_derive", "solana-pubkey/serde"]

--- a/interface/src/config.rs
+++ b/interface/src/config.rs
@@ -7,10 +7,7 @@
     note = "Please use `crate::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE}` instead"
 )]
 pub use super::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE};
-use {
-    serde_derive::{Deserialize, Serialize},
-    solana_pubkey::declare_deprecated_id,
-};
+use solana_pubkey::declare_deprecated_id;
 
 // stake config ID
 declare_deprecated_id!("StakeConfig11111111111111111111111111111111");
@@ -19,7 +16,11 @@ declare_deprecated_id!("StakeConfig11111111111111111111111111111111");
     since = "1.16.7",
     note = "Please use `crate::state::warmup_cooldown_rate()` instead"
 )]
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Config {
     /// how much stake we can activate/deactivate per-epoch as a fraction of currently effective stake
     pub warmup_cooldown_rate: f64,

--- a/interface/src/config.rs
+++ b/interface/src/config.rs
@@ -1,19 +1,23 @@
-//! config for staking
-//!  carries variables that the stake program cares about
+//! Config for staking.
+//!
+//! It carries variables that the stake program cares about.
 
 #[deprecated(
     since = "1.16.7",
-    note = "Please use `solana_sdk::stake::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE}` instead"
+    note = "Please use `crate::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE}` instead"
 )]
 pub use super::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE};
-use serde_derive::{Deserialize, Serialize};
+use {
+    serde_derive::{Deserialize, Serialize},
+    solana_pubkey::declare_deprecated_id,
+};
 
 // stake config ID
-crate::declare_deprecated_id!("StakeConfig11111111111111111111111111111111");
+declare_deprecated_id!("StakeConfig11111111111111111111111111111111");
 
 #[deprecated(
     since = "1.16.7",
-    note = "Please use `solana_sdk::stake::state::warmup_cooldown_rate()` instead"
+    note = "Please use `crate::state::warmup_cooldown_rate()` instead"
 )]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 pub struct Config {

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -5,6 +5,10 @@ use {
 
 /// Reasons the Stake might have had an error.
 #[cfg_attr(test, derive(strum_macros::FromRepr, strum_macros::EnumIter))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum StakeError {
     // 0
@@ -201,7 +205,10 @@ impl<E> DecodeError<E> for StakeError {
 
 #[cfg(test)]
 mod tests {
-    use {super::StakeError, num_traits::FromPrimitive, strum::IntoEnumIterator};
+    use {
+        super::StakeError, num_traits::FromPrimitive, solana_decode_error::DecodeError,
+        solana_instruction::error::InstructionError, strum::IntoEnumIterator,
+    };
 
     #[test]
     fn test_stake_error_from_primitive_exhaustive() {
@@ -211,7 +218,6 @@ mod tests {
                 StakeError::from_repr(variant_i64 as usize),
                 StakeError::from_i64(variant_i64)
             );
-            assert_eq!(StakeError::from(variant_i64 as u64), variant);
         }
     }
 

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -1,0 +1,242 @@
+use {
+    num_traits::{FromPrimitive, ToPrimitive},
+    solana_decode_error::DecodeError,
+};
+
+/// Reasons the Stake might have had an error.
+#[cfg_attr(test, derive(strum_macros::FromRepr, strum_macros::EnumIter))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StakeError {
+    // 0
+    /// Not enough credits to redeem.
+    NoCreditsToRedeem,
+
+    /// Lockup has not yet expired.
+    LockupInForce,
+
+    /// Stake already deactivated.
+    AlreadyDeactivated,
+
+    /// One re-delegation permitted per epoch.
+    TooSoonToRedelegate,
+
+    /// Split amount is more than is staked.
+    InsufficientStake,
+
+    // 5
+    /// Stake account with transient stake cannot be merged.
+    MergeTransientStake,
+
+    /// Stake account merge failed due to different authority, lockups or state.
+    MergeMismatch,
+
+    /// Custodian address not present.
+    CustodianMissing,
+
+    /// Custodian signature not present.
+    CustodianSignatureMissing,
+
+    /// Insufficient voting activity in the reference vote account.
+    InsufficientReferenceVotes,
+
+    // 10
+    /// Stake account is not delegated to the provided vote account.
+    VoteAddressMismatch,
+
+    /// Stake account has not been delinquent for the minimum epochs required
+    /// for deactivation.
+    MinimumDelinquentEpochsForDeactivationNotMet,
+
+    /// Delegation amount is less than the minimum.
+    InsufficientDelegation,
+
+    /// Stake account with transient or inactive stake cannot be redelegated.
+    RedelegateTransientOrInactiveStake,
+
+    /// Stake redelegation to the same vote account is not permitted.
+    RedelegateToSameVoteAccount,
+
+    // 15
+    /// Redelegated stake must be fully activated before deactivation.
+    RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted,
+
+    /// Stake action is not permitted while the epoch rewards period is active.
+    EpochRewardsActive,
+}
+
+impl FromPrimitive for StakeError {
+    #[inline]
+    fn from_i64(n: i64) -> Option<Self> {
+        if n == Self::NoCreditsToRedeem as i64 {
+            Some(Self::NoCreditsToRedeem)
+        } else if n == Self::LockupInForce as i64 {
+            Some(Self::LockupInForce)
+        } else if n == Self::AlreadyDeactivated as i64 {
+            Some(Self::AlreadyDeactivated)
+        } else if n == Self::TooSoonToRedelegate as i64 {
+            Some(Self::TooSoonToRedelegate)
+        } else if n == Self::InsufficientStake as i64 {
+            Some(Self::InsufficientStake)
+        } else if n == Self::MergeTransientStake as i64 {
+            Some(Self::MergeTransientStake)
+        } else if n == Self::MergeMismatch as i64 {
+            Some(Self::MergeMismatch)
+        } else if n == Self::CustodianMissing as i64 {
+            Some(Self::CustodianMissing)
+        } else if n == Self::CustodianSignatureMissing as i64 {
+            Some(Self::CustodianSignatureMissing)
+        } else if n == Self::InsufficientReferenceVotes as i64 {
+            Some(Self::InsufficientReferenceVotes)
+        } else if n == Self::VoteAddressMismatch as i64 {
+            Some(Self::VoteAddressMismatch)
+        } else if n == Self::MinimumDelinquentEpochsForDeactivationNotMet as i64 {
+            Some(Self::MinimumDelinquentEpochsForDeactivationNotMet)
+        } else if n == Self::InsufficientDelegation as i64 {
+            Some(Self::InsufficientDelegation)
+        } else if n == Self::RedelegateTransientOrInactiveStake as i64 {
+            Some(Self::RedelegateTransientOrInactiveStake)
+        } else if n == Self::RedelegateToSameVoteAccount as i64 {
+            Some(Self::RedelegateToSameVoteAccount)
+        } else if n == Self::RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted as i64 {
+            Some(Self::RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted)
+        } else if n == Self::EpochRewardsActive as i64 {
+            Some(Self::EpochRewardsActive)
+        } else {
+            None
+        }
+    }
+    #[inline]
+    fn from_u64(n: u64) -> Option<Self> {
+        Self::from_i64(n as i64)
+    }
+}
+
+impl ToPrimitive for StakeError {
+    #[inline]
+    fn to_i64(&self) -> Option<i64> {
+        Some(match *self {
+            Self::NoCreditsToRedeem => Self::NoCreditsToRedeem as i64,
+            Self::LockupInForce => Self::LockupInForce as i64,
+            Self::AlreadyDeactivated => Self::AlreadyDeactivated as i64,
+            Self::TooSoonToRedelegate => Self::TooSoonToRedelegate as i64,
+            Self::InsufficientStake => Self::InsufficientStake as i64,
+            Self::MergeTransientStake => Self::MergeTransientStake as i64,
+            Self::MergeMismatch => Self::MergeMismatch as i64,
+            Self::CustodianMissing => Self::CustodianMissing as i64,
+            Self::CustodianSignatureMissing => Self::CustodianSignatureMissing as i64,
+            Self::InsufficientReferenceVotes => Self::InsufficientReferenceVotes as i64,
+            Self::VoteAddressMismatch => Self::VoteAddressMismatch as i64,
+            Self::MinimumDelinquentEpochsForDeactivationNotMet => {
+                Self::MinimumDelinquentEpochsForDeactivationNotMet as i64
+            }
+            Self::InsufficientDelegation => Self::InsufficientDelegation as i64,
+            Self::RedelegateTransientOrInactiveStake => {
+                Self::RedelegateTransientOrInactiveStake as i64
+            }
+            Self::RedelegateToSameVoteAccount => Self::RedelegateToSameVoteAccount as i64,
+            Self::RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted => {
+                Self::RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted as i64
+            }
+            Self::EpochRewardsActive => Self::EpochRewardsActive as i64,
+        })
+    }
+    #[inline]
+    fn to_u64(&self) -> Option<u64> {
+        self.to_i64().map(|x| x as u64)
+    }
+}
+
+impl std::error::Error for StakeError {}
+
+impl core::fmt::Display for StakeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            StakeError::NoCreditsToRedeem => f.write_str("not enough credits to redeem"),
+            StakeError::LockupInForce => f.write_str("lockup has not yet expired"),
+            StakeError::AlreadyDeactivated => f.write_str("stake already deactivated"),
+            StakeError::TooSoonToRedelegate => f.write_str("one re-delegation permitted per epoch"),
+            StakeError::InsufficientStake => f.write_str("split amount is more than is staked"),
+            StakeError::MergeTransientStake => {
+                f.write_str("stake account with transient stake cannot be merged")
+            }
+            StakeError::MergeMismatch => f.write_str(
+                "stake account merge failed due to different authority, lockups or state",
+            ),
+            StakeError::CustodianMissing => f.write_str("custodian address not present"),
+            StakeError::CustodianSignatureMissing => f.write_str("custodian signature not present"),
+            StakeError::InsufficientReferenceVotes => {
+                f.write_str("insufficient voting activity in the reference vote account")
+            }
+            StakeError::VoteAddressMismatch => {
+                f.write_str("stake account is not delegated to the provided vote account")
+            }
+            StakeError::MinimumDelinquentEpochsForDeactivationNotMet => f.write_str(
+                "stake account has not been delinquent for the minimum epochs required for \
+                     deactivation",
+            ),
+            StakeError::InsufficientDelegation => {
+                f.write_str("delegation amount is less than the minimum")
+            }
+            StakeError::RedelegateTransientOrInactiveStake => {
+                f.write_str("stake account with transient or inactive stake cannot be redelegated")
+            }
+            StakeError::RedelegateToSameVoteAccount => {
+                f.write_str("stake redelegation to the same vote account is not permitted")
+            }
+            StakeError::RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted => {
+                f.write_str("redelegated stake must be fully activated before deactivation")
+            }
+            StakeError::EpochRewardsActive => f.write_str(
+                "stake action is not permitted while the epoch rewards period is active",
+            ),
+        }
+    }
+}
+
+impl<E> DecodeError<E> for StakeError {
+    fn type_of() -> &'static str {
+        "StakeError"
+    }
+}
+
+impl From<u64> for StakeError {
+    fn from(error: u64) -> Self {
+        match error {
+            0 => StakeError::NoCreditsToRedeem,
+            1 => StakeError::LockupInForce,
+            2 => StakeError::AlreadyDeactivated,
+            3 => StakeError::TooSoonToRedelegate,
+            4 => StakeError::InsufficientStake,
+            5 => StakeError::MergeTransientStake,
+            6 => StakeError::MergeMismatch,
+            7 => StakeError::CustodianMissing,
+            8 => StakeError::CustodianSignatureMissing,
+            9 => StakeError::InsufficientReferenceVotes,
+            10 => StakeError::VoteAddressMismatch,
+            11 => StakeError::MinimumDelinquentEpochsForDeactivationNotMet,
+            12 => StakeError::InsufficientDelegation,
+            13 => StakeError::RedelegateTransientOrInactiveStake,
+            14 => StakeError::RedelegateToSameVoteAccount,
+            15 => StakeError::RedelegatedStakeMustFullyActivateBeforeDeactivationIsPermitted,
+            16 => StakeError::EpochRewardsActive,
+            _ => panic!("unsupported error code"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::StakeError, num_traits::FromPrimitive, strum::IntoEnumIterator};
+
+    #[test]
+    fn test_stake_error_from_primitive_exhaustive() {
+        for variant in StakeError::iter() {
+            let variant_i64 = variant.clone() as i64;
+            assert_eq!(
+                StakeError::from_repr(variant_i64 as usize),
+                StakeError::from_i64(variant_i64)
+            );
+            assert_eq!(StakeError::from(variant_i64 as u64), variant);
+        }
+    }
+}

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -3,20 +3,39 @@
 // Required to avoid warnings from uses of deprecated types during trait derivations.
 #![allow(deprecated)]
 
+#[cfg(feature = "bincode")]
 use {
-    crate::{
-        config,
-        state::{Authorized, Lockup, StakeAuthorize, StakeStateV2},
-        CLOCK_ID, RENT_ID, STAKE_HISTORY_ID,
-    },
-    serde::{Deserialize, Serialize},
-    solana_clock::{Epoch, UnixTimestamp},
+    crate::{config, state::StakeStateV2},
     solana_instruction::{AccountMeta, Instruction},
-    solana_pubkey::Pubkey,
-    solana_system_interface::program::{id, ID},
+    solana_system_interface::program::ID,
 };
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+use {
+    crate::state::{Authorized, Lockup, StakeAuthorize},
+    solana_clock::{Epoch, UnixTimestamp},
+    solana_pubkey::Pubkey,
+};
+
+// Inline some constants to avoid dependencies.
+//
+// Note: replace these inline IDs with the corresponding value from
+// `solana_sdk_ids` once the version is updated to 2.2.0.
+
+#[cfg(feature = "bincode")]
+const CLOCK_ID: Pubkey = Pubkey::from_str_const("SysvarC1ock11111111111111111111111111111111");
+
+#[cfg(feature = "bincode")]
+const RENT_ID: Pubkey = Pubkey::from_str_const("SysvarRent111111111111111111111111111111111");
+
+#[cfg(feature = "bincode")]
+const STAKE_HISTORY_ID: Pubkey =
+    Pubkey::from_str_const("SysvarStakeHistory1111111111111111111111111");
+
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum StakeInstruction {
     /// Initialize a stake with lockup and authorization information
     ///
@@ -269,20 +288,32 @@ pub enum StakeInstruction {
     MoveLamports(u64),
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct LockupArgs {
     pub unix_timestamp: Option<UnixTimestamp>,
     pub epoch: Option<Epoch>,
     pub custodian: Option<Pubkey>,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct LockupCheckedArgs {
     pub unix_timestamp: Option<UnixTimestamp>,
     pub epoch: Option<Epoch>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AuthorizeWithSeedArgs {
     pub new_authorized_pubkey: Pubkey,
     pub stake_authorize: StakeAuthorize,
@@ -290,13 +321,18 @@ pub struct AuthorizeWithSeedArgs {
     pub authority_owner: Pubkey,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AuthorizeCheckedWithSeedArgs {
     pub stake_authorize: StakeAuthorize,
     pub authority_seed: String,
     pub authority_owner: Pubkey,
 }
 
+#[cfg(feature = "bincode")]
 pub fn initialize(stake_pubkey: &Pubkey, authorized: &Authorized, lockup: &Lockup) -> Instruction {
     Instruction::new_with_bincode(
         ID,
@@ -308,9 +344,10 @@ pub fn initialize(stake_pubkey: &Pubkey, authorized: &Authorized, lockup: &Locku
     )
 }
 
+#[cfg(feature = "bincode")]
 pub fn initialize_checked(stake_pubkey: &Pubkey, authorized: &Authorized) -> Instruction {
     Instruction::new_with_bincode(
-        id(),
+        ID,
         &StakeInstruction::InitializeChecked,
         vec![
             AccountMeta::new(*stake_pubkey, false),
@@ -321,6 +358,7 @@ pub fn initialize_checked(stake_pubkey: &Pubkey, authorized: &Authorized) -> Ins
     )
 }
 
+#[cfg(feature = "bincode")]
 pub fn create_account_with_seed(
     from_pubkey: &Pubkey,
     stake_pubkey: &Pubkey,
@@ -338,12 +376,13 @@ pub fn create_account_with_seed(
             seed,
             lamports,
             StakeStateV2::size_of() as u64,
-            &id(),
+            &ID,
         ),
         initialize(stake_pubkey, authorized, lockup),
     ]
 }
 
+#[cfg(feature = "bincode")]
 pub fn create_account(
     from_pubkey: &Pubkey,
     stake_pubkey: &Pubkey,
@@ -357,12 +396,13 @@ pub fn create_account(
             stake_pubkey,
             lamports,
             StakeStateV2::size_of() as u64,
-            &id(),
+            &ID,
         ),
         initialize(stake_pubkey, authorized, lockup),
     ]
 }
 
+#[cfg(feature = "bincode")]
 pub fn create_account_with_seed_checked(
     from_pubkey: &Pubkey,
     stake_pubkey: &Pubkey,
@@ -379,12 +419,13 @@ pub fn create_account_with_seed_checked(
             seed,
             lamports,
             StakeStateV2::size_of() as u64,
-            &id(),
+            &ID,
         ),
         initialize_checked(stake_pubkey, authorized),
     ]
 }
 
+#[cfg(feature = "bincode")]
 pub fn create_account_checked(
     from_pubkey: &Pubkey,
     stake_pubkey: &Pubkey,
@@ -397,12 +438,13 @@ pub fn create_account_checked(
             stake_pubkey,
             lamports,
             StakeStateV2::size_of() as u64,
-            &id(),
+            &ID,
         ),
         initialize_checked(stake_pubkey, authorized),
     ]
 }
 
+#[cfg(feature = "bincode")]
 fn _split(
     stake_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
@@ -415,9 +457,10 @@ fn _split(
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
 
-    Instruction::new_with_bincode(id(), &StakeInstruction::Split(lamports), account_metas)
+    Instruction::new_with_bincode(ID, &StakeInstruction::Split(lamports), account_metas)
 }
 
+#[cfg(feature = "bincode")]
 pub fn split(
     stake_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
@@ -429,7 +472,7 @@ pub fn split(
             split_stake_pubkey,
             StakeStateV2::size_of() as u64,
         ),
-        solana_system_interface::instruction::assign(split_stake_pubkey, &id()),
+        solana_system_interface::instruction::assign(split_stake_pubkey, &ID),
         _split(
             stake_pubkey,
             authorized_pubkey,
@@ -439,6 +482,7 @@ pub fn split(
     ]
 }
 
+#[cfg(feature = "bincode")]
 pub fn split_with_seed(
     stake_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
@@ -453,7 +497,7 @@ pub fn split_with_seed(
             base,
             seed,
             StakeStateV2::size_of() as u64,
-            &id(),
+            &ID,
         ),
         _split(
             stake_pubkey,
@@ -464,6 +508,7 @@ pub fn split_with_seed(
     ]
 }
 
+#[cfg(feature = "bincode")]
 pub fn merge(
     destination_stake_pubkey: &Pubkey,
     source_stake_pubkey: &Pubkey,
@@ -478,12 +523,13 @@ pub fn merge(
     ];
 
     vec![Instruction::new_with_bincode(
-        id(),
+        ID,
         &StakeInstruction::Merge,
         account_metas,
     )]
 }
 
+#[cfg(feature = "bincode")]
 pub fn create_account_and_delegate_stake(
     from_pubkey: &Pubkey,
     stake_pubkey: &Pubkey,
@@ -501,6 +547,7 @@ pub fn create_account_and_delegate_stake(
     instructions
 }
 
+#[cfg(feature = "bincode")]
 #[allow(clippy::too_many_arguments)]
 pub fn create_account_with_seed_and_delegate_stake(
     from_pubkey: &Pubkey,
@@ -529,6 +576,7 @@ pub fn create_account_with_seed_and_delegate_stake(
     instructions
 }
 
+#[cfg(feature = "bincode")]
 pub fn authorize(
     stake_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
@@ -547,12 +595,13 @@ pub fn authorize(
     }
 
     Instruction::new_with_bincode(
-        id(),
+        ID,
         &StakeInstruction::Authorize(*new_authorized_pubkey, stake_authorize),
         account_metas,
     )
 }
 
+#[cfg(feature = "bincode")]
 pub fn authorize_checked(
     stake_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
@@ -572,12 +621,13 @@ pub fn authorize_checked(
     }
 
     Instruction::new_with_bincode(
-        id(),
+        ID,
         &StakeInstruction::AuthorizeChecked(stake_authorize),
         account_metas,
     )
 }
 
+#[cfg(feature = "bincode")]
 pub fn authorize_with_seed(
     stake_pubkey: &Pubkey,
     authority_base: &Pubkey,
@@ -605,12 +655,13 @@ pub fn authorize_with_seed(
     };
 
     Instruction::new_with_bincode(
-        id(),
+        ID,
         &StakeInstruction::AuthorizeWithSeed(args),
         account_metas,
     )
 }
 
+#[cfg(feature = "bincode")]
 pub fn authorize_checked_with_seed(
     stake_pubkey: &Pubkey,
     authority_base: &Pubkey,
@@ -638,12 +689,13 @@ pub fn authorize_checked_with_seed(
     };
 
     Instruction::new_with_bincode(
-        id(),
+        ID,
         &StakeInstruction::AuthorizeCheckedWithSeed(args),
         account_metas,
     )
 }
 
+#[cfg(feature = "bincode")]
 pub fn delegate_stake(
     stake_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
@@ -658,9 +710,10 @@ pub fn delegate_stake(
         AccountMeta::new_readonly(config::ID, false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
-    Instruction::new_with_bincode(id(), &StakeInstruction::DelegateStake, account_metas)
+    Instruction::new_with_bincode(ID, &StakeInstruction::DelegateStake, account_metas)
 }
 
+#[cfg(feature = "bincode")]
 pub fn withdraw(
     stake_pubkey: &Pubkey,
     withdrawer_pubkey: &Pubkey,
@@ -680,18 +733,20 @@ pub fn withdraw(
         account_metas.push(AccountMeta::new_readonly(*custodian_pubkey, true));
     }
 
-    Instruction::new_with_bincode(id(), &StakeInstruction::Withdraw(lamports), account_metas)
+    Instruction::new_with_bincode(ID, &StakeInstruction::Withdraw(lamports), account_metas)
 }
 
+#[cfg(feature = "bincode")]
 pub fn deactivate_stake(stake_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new_readonly(CLOCK_ID, false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
-    Instruction::new_with_bincode(id(), &StakeInstruction::Deactivate, account_metas)
+    Instruction::new_with_bincode(ID, &StakeInstruction::Deactivate, account_metas)
 }
 
+#[cfg(feature = "bincode")]
 pub fn set_lockup(
     stake_pubkey: &Pubkey,
     lockup: &LockupArgs,
@@ -701,9 +756,10 @@ pub fn set_lockup(
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new_readonly(*custodian_pubkey, true),
     ];
-    Instruction::new_with_bincode(id(), &StakeInstruction::SetLockup(*lockup), account_metas)
+    Instruction::new_with_bincode(ID, &StakeInstruction::SetLockup(*lockup), account_metas)
 }
 
+#[cfg(feature = "bincode")]
 pub fn set_lockup_checked(
     stake_pubkey: &Pubkey,
     lockup: &LockupArgs,
@@ -722,20 +778,18 @@ pub fn set_lockup_checked(
         account_metas.push(AccountMeta::new_readonly(new_custodian, true));
     }
     Instruction::new_with_bincode(
-        id(),
+        ID,
         &StakeInstruction::SetLockupChecked(lockup_checked),
         account_metas,
     )
 }
 
+#[cfg(feature = "bincode")]
 pub fn get_minimum_delegation() -> Instruction {
-    Instruction::new_with_bincode(
-        id(),
-        &StakeInstruction::GetMinimumDelegation,
-        Vec::default(),
-    )
+    Instruction::new_with_bincode(ID, &StakeInstruction::GetMinimumDelegation, Vec::default())
 }
 
+#[cfg(feature = "bincode")]
 pub fn deactivate_delinquent_stake(
     stake_account: &Pubkey,
     delinquent_vote_account: &Pubkey,
@@ -746,9 +800,10 @@ pub fn deactivate_delinquent_stake(
         AccountMeta::new_readonly(*delinquent_vote_account, false),
         AccountMeta::new_readonly(*reference_vote_account, false),
     ];
-    Instruction::new_with_bincode(id(), &StakeInstruction::DeactivateDelinquent, account_metas)
+    Instruction::new_with_bincode(ID, &StakeInstruction::DeactivateDelinquent, account_metas)
 }
 
+#[cfg(feature = "bincode")]
 fn _redelegate(
     stake_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
@@ -760,12 +815,13 @@ fn _redelegate(
         AccountMeta::new(*uninitialized_stake_pubkey, false),
         AccountMeta::new_readonly(*vote_pubkey, false),
         // For backwards compatibility we pass the stake config, although this account is unused
-        AccountMeta::new_readonly(config::id(), false),
+        AccountMeta::new_readonly(config::ID, false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
-    Instruction::new_with_bincode(id(), &StakeInstruction::Redelegate, account_metas)
+    Instruction::new_with_bincode(ID, &StakeInstruction::Redelegate, account_metas)
 }
 
+#[cfg(feature = "bincode")]
 #[deprecated(since = "2.1.0", note = "Redelegate will not be enabled")]
 pub fn redelegate(
     stake_pubkey: &Pubkey,
@@ -778,7 +834,7 @@ pub fn redelegate(
             uninitialized_stake_pubkey,
             StakeStateV2::size_of() as u64,
         ),
-        solana_system_interface::instruction::assign(uninitialized_stake_pubkey, &id()),
+        solana_system_interface::instruction::assign(uninitialized_stake_pubkey, &ID),
         _redelegate(
             stake_pubkey,
             authorized_pubkey,
@@ -788,6 +844,7 @@ pub fn redelegate(
     ]
 }
 
+#[cfg(feature = "bincode")]
 #[deprecated(since = "2.1.0", note = "Redelegate will not be enabled")]
 pub fn redelegate_with_seed(
     stake_pubkey: &Pubkey,
@@ -803,7 +860,7 @@ pub fn redelegate_with_seed(
             base,
             seed,
             StakeStateV2::size_of() as u64,
-            &id(),
+            &ID,
         ),
         _redelegate(
             stake_pubkey,
@@ -814,6 +871,7 @@ pub fn redelegate_with_seed(
     ]
 }
 
+#[cfg(feature = "bincode")]
 pub fn move_stake(
     source_stake_pubkey: &Pubkey,
     destination_stake_pubkey: &Pubkey,
@@ -826,9 +884,10 @@ pub fn move_stake(
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
 
-    Instruction::new_with_bincode(id(), &StakeInstruction::MoveStake(lamports), account_metas)
+    Instruction::new_with_bincode(ID, &StakeInstruction::MoveStake(lamports), account_metas)
 }
 
+#[cfg(feature = "bincode")]
 pub fn move_lamports(
     source_stake_pubkey: &Pubkey,
     destination_stake_pubkey: &Pubkey,
@@ -841,9 +900,24 @@ pub fn move_lamports(
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
 
-    Instruction::new_with_bincode(
-        id(),
-        &StakeInstruction::MoveLamports(lamports),
-        account_metas,
-    )
+    Instruction::new_with_bincode(ID, &StakeInstruction::MoveLamports(lamports), account_metas)
+}
+
+#[cfg(feature = "bincode")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(deprecated)]
+    #[test]
+    fn test_constants() {
+        // Ensure that the constants are in sync with the solana program.
+        assert_eq!(CLOCK_ID, solana_program::sysvar::clock::ID);
+
+        // Ensure that the constants are in sync with the solana program.
+        assert_eq!(STAKE_HISTORY_ID, solana_program::sysvar::stake_history::ID);
+
+        // Ensure that the constants are in sync with the solana rent.
+        assert_eq!(RENT_ID, solana_program::sysvar::rent::ID);
+    }
 }

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -193,11 +193,11 @@ pub enum StakeInstruction {
     /// Programs can use the [`get_minimum_delegation()`] helper function to invoke and
     /// retrieve the return value for this instruction.
     ///
-    /// [`get_minimum_delegation()`]: super::tools::get_minimum_delegation
+    /// [`get_minimum_delegation()`]: crate::tools::get_minimum_delegation
     GetMinimumDelegation,
 
     /// Deactivate stake delegated to a vote account that has been delinquent for at least
-    /// [`super::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION`] epochs.
+    /// [`crate::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION`] epochs.
     ///
     /// No signer is required for this instruction as it is a common good to deactivate abandoned
     /// stake.
@@ -206,7 +206,7 @@ pub enum StakeInstruction {
     ///   0. `[WRITE]` Delegated stake account
     ///   1. `[]` Delinquent vote account for the delegated stake account
     ///   2. `[]` Reference vote account that has voted at least once in the last
-    ///      [`super::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION`] epochs
+    ///      [`crate::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION`] epochs
     DeactivateDelinquent,
 
     /// Redelegate activated stake to another vote account.
@@ -846,38 +846,4 @@ pub fn move_lamports(
         &StakeInstruction::MoveLamports(lamports),
         account_metas,
     )
-}
-
-#[cfg(test)]
-mod tests {
-    use {
-        crate::error::StakeError, solana_decode_error::DecodeError,
-        solana_instruction::error::InstructionError,
-    };
-
-    #[test]
-    fn test_custom_error_decode() {
-        use num_traits::FromPrimitive;
-        fn pretty_err<T>(err: InstructionError) -> String
-        where
-            T: 'static + std::error::Error + DecodeError<T> + FromPrimitive,
-        {
-            if let InstructionError::Custom(code) = err {
-                let specific_error: T = T::decode_custom_error_to_enum(code).unwrap();
-                format!(
-                    "{:?}: {}::{:?} - {}",
-                    err,
-                    T::type_of(),
-                    specific_error,
-                    specific_error,
-                )
-            } else {
-                "".to_string()
-            }
-        }
-        assert_eq!(
-            "Custom(0): StakeError::NoCreditsToRedeem - not enough credits to redeem",
-            pretty_err::<StakeError>(StakeError::NoCreditsToRedeem.into())
-        )
-    }
 }

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -3,8 +3,6 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-use solana_pubkey::Pubkey;
-
 #[allow(deprecated)]
 pub mod config;
 pub mod error;
@@ -21,33 +19,3 @@ pub mod program {
 /// The minimum number of epochs before stake account that is delegated to a delinquent vote
 /// account may be unstaked with `StakeInstruction::DeactivateDelinquent`
 pub const MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION: usize = 5;
-
-// Inline some constants to avoid dependencies.
-//
-// Note: replace these inline IDs with the corresponding value from
-// `solana_sdk_ids` once the version is updated to 2.2.0.
-
-const CLOCK_ID: Pubkey = Pubkey::from_str_const("SysvarC1ock11111111111111111111111111111111");
-
-const RENT_ID: Pubkey = Pubkey::from_str_const("SysvarRent111111111111111111111111111111111");
-
-const STAKE_HISTORY_ID: Pubkey =
-    Pubkey::from_str_const("SysvarStakeHistory1111111111111111111111111");
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[allow(deprecated)]
-    #[test]
-    fn test_constants() {
-        // Ensure that the constants are in sync with the solana program.
-        assert_eq!(CLOCK_ID, solana_program::sysvar::clock::ID);
-
-        // Ensure that the constants are in sync with the solana program.
-        assert_eq!(STAKE_HISTORY_ID, solana_program::sysvar::stake_history::ID);
-
-        // Ensure that the constants are in sync with the solana rent.
-        assert_eq!(RENT_ID, solana_program::sysvar::rent::ID);
-    }
-}

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1,18 +1,53 @@
-//! The [stake native program][np].
-//!
-//! [np]: https://docs.solanalabs.com/runtime/sysvars#stakehistory
+//! The Stake program interface.
+
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+use solana_pubkey::Pubkey;
 
 #[allow(deprecated)]
 pub mod config;
+pub mod error;
 pub mod instruction;
 pub mod stake_flags;
+pub mod stake_history;
 pub mod state;
 pub mod tools;
 
 pub mod program {
-    crate::declare_id!("Stake11111111111111111111111111111111111111");
+    solana_pubkey::declare_id!("Stake11111111111111111111111111111111111111");
 }
 
 /// The minimum number of epochs before stake account that is delegated to a delinquent vote
 /// account may be unstaked with `StakeInstruction::DeactivateDelinquent`
 pub const MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION: usize = 5;
+
+// Inline some constants to avoid dependencies.
+//
+// Note: replace these inline IDs with the corresponding value from
+// `solana_sdk_ids` once the version is updated to 2.2.0.
+
+const CLOCK_ID: Pubkey = Pubkey::from_str_const("SysvarC1ock11111111111111111111111111111111");
+
+const RENT_ID: Pubkey = Pubkey::from_str_const("SysvarRent111111111111111111111111111111111");
+
+const STAKE_HISTORY_ID: Pubkey =
+    Pubkey::from_str_const("SysvarStakeHistory1111111111111111111111111");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(deprecated)]
+    #[test]
+    fn test_constants() {
+        // Ensure that the constants are in sync with the solana program.
+        assert_eq!(CLOCK_ID, solana_program::sysvar::clock::ID);
+
+        // Ensure that the constants are in sync with the solana program.
+        assert_eq!(STAKE_HISTORY_ID, solana_program::sysvar::stake_history::ID);
+
+        // Ensure that the constants are in sync with the solana rent.
+        assert_eq!(RENT_ID, solana_program::sysvar::rent::ID);
+    }
+}

--- a/interface/src/stake_flags.rs
+++ b/interface/src/stake_flags.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 /// Additional flags for stake state.
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
@@ -9,7 +8,11 @@ use serde::{Deserialize, Serialize};
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
     borsh(crate = "borsh")
 )]
-#[derive(Serialize, Deserialize, Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
 pub struct StakeFlags {
     bits: u8,
 }

--- a/interface/src/stake_flags.rs
+++ b/interface/src/stake_flags.rs
@@ -1,8 +1,9 @@
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use serde::{Deserialize, Serialize};
 
 /// Additional flags for stake state.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(
     feature = "borsh",
     derive(BorshSerialize, BorshDeserialize, BorshSchema),

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -1,18 +1,17 @@
 //! A type to hold data for the [`StakeHistory` sysvar][sv].
 //!
 //! [sv]: https://docs.solanalabs.com/runtime/sysvars#stakehistory
-//!
-//! The sysvar ID is declared in [`sysvar::stake_history`].
-//!
-//! [`sysvar::stake_history`]: crate::sysvar::stake_history
 
 pub use solana_clock::Epoch;
-use std::ops::Deref;
+use {
+    serde::{Deserialize, Serialize},
+    std::ops::Deref,
+};
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
 #[repr(C)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone)]
 pub struct StakeHistoryEntry {
     pub effective: u64,    // effective stake at this epoch
@@ -57,7 +56,7 @@ impl std::ops::Add for StakeHistoryEntry {
 }
 
 #[repr(C)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone)]
 pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);
 

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -3,16 +3,17 @@
 //! [sv]: https://docs.solanalabs.com/runtime/sysvars#stakehistory
 
 pub use solana_clock::Epoch;
-use {
-    serde::{Deserialize, Serialize},
-    std::ops::Deref,
-};
+use std::ops::Deref;
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
 #[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct StakeHistoryEntry {
     pub effective: u64,    // effective stake at this epoch
     pub activating: u64,   // sum of portion of stakes not fully warmed up
@@ -57,7 +58,11 @@ impl std::ops::Add for StakeHistoryEntry {
 
 #[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);
 
 impl StakeHistory {

--- a/interface/src/tools.rs
+++ b/interface/src/tools.rs
@@ -1,7 +1,9 @@
 //! Utility functions
 use {
-    crate::{program_error::ProgramError, stake::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION},
+    crate::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION,
     solana_clock::Epoch,
+    solana_cpi::{get_return_data, invoke_unchecked},
+    solana_program_error::ProgramError,
 };
 
 /// Helper function for programs to call [`GetMinimumDelegation`] and then fetch the return data
@@ -10,10 +12,10 @@ use {
 /// calls [`get_return_data()`] to fetch the return data.
 ///
 /// [`GetMinimumDelegation`]: super::instruction::StakeInstruction::GetMinimumDelegation
-/// [`get_return_data()`]: crate::program::get_return_data
+/// [`get_return_data()`]: solana_cpi::get_return_data
 pub fn get_minimum_delegation() -> Result<u64, ProgramError> {
     let instruction = super::instruction::get_minimum_delegation();
-    crate::program::invoke_unchecked(&instruction, &[])?;
+    invoke_unchecked(&instruction, &[])?;
     get_minimum_delegation_return_data()
 }
 
@@ -23,9 +25,9 @@ pub fn get_minimum_delegation() -> Result<u64, ProgramError> {
 /// program, and returns the correct type.
 ///
 /// [`GetMinimumDelegation`]: super::instruction::StakeInstruction::GetMinimumDelegation
-/// [`get_return_data()`]: crate::program::get_return_data
+/// [`get_return_data()`]: solana_cpi::get_return_data
 fn get_minimum_delegation_return_data() -> Result<u64, ProgramError> {
-    crate::program::get_return_data()
+    get_return_data()
         .ok_or(ProgramError::InvalidInstructionData)
         .and_then(|(program_id, return_data)| {
             (program_id == super::program::id())
@@ -40,8 +42,8 @@ fn get_minimum_delegation_return_data() -> Result<u64, ProgramError> {
         .map(u64::from_le_bytes)
 }
 
-// Check if the provided `epoch_credits` demonstrate active voting over the previous
-// `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION`
+/// Check if the provided `epoch_credits` demonstrate active voting over the previous
+/// [`MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION`].
 pub fn acceptable_reference_epoch_credits(
     epoch_credits: &[(Epoch, u64, u64)],
     current_epoch: Epoch,
@@ -63,8 +65,8 @@ pub fn acceptable_reference_epoch_credits(
     }
 }
 
-// Check if the provided `epoch_credits` demonstrate delinquency over the previous
-// `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION`
+/// Check if the provided `epoch_credits` demonstrate delinquency over the previous
+/// [`MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION`].
 pub fn eligible_for_deactivate_delinquent(
     epoch_credits: &[(Epoch, u64, u64)],
     current_epoch: Epoch,

--- a/interface/src/tools.rs
+++ b/interface/src/tools.rs
@@ -11,10 +11,10 @@ use {
 /// This fn handles performing the CPI to call the [`GetMinimumDelegation`] function, and then
 /// calls [`get_return_data()`] to fetch the return data.
 ///
-/// [`GetMinimumDelegation`]: super::instruction::StakeInstruction::GetMinimumDelegation
+/// [`GetMinimumDelegation`]: crate::instruction::StakeInstruction::GetMinimumDelegation
 /// [`get_return_data()`]: solana_cpi::get_return_data
 pub fn get_minimum_delegation() -> Result<u64, ProgramError> {
-    let instruction = super::instruction::get_minimum_delegation();
+    let instruction = crate::instruction::get_minimum_delegation();
     invoke_unchecked(&instruction, &[])?;
     get_minimum_delegation_return_data()
 }
@@ -24,13 +24,13 @@ pub fn get_minimum_delegation() -> Result<u64, ProgramError> {
 /// This fn handles calling [`get_return_data()`], ensures the result is from the correct
 /// program, and returns the correct type.
 ///
-/// [`GetMinimumDelegation`]: super::instruction::StakeInstruction::GetMinimumDelegation
+/// [`GetMinimumDelegation`]: crate::instruction::StakeInstruction::GetMinimumDelegation
 /// [`get_return_data()`]: solana_cpi::get_return_data
 fn get_minimum_delegation_return_data() -> Result<u64, ProgramError> {
     get_return_data()
         .ok_or(ProgramError::InvalidInstructionData)
         .and_then(|(program_id, return_data)| {
-            (program_id == super::program::id())
+            (program_id == crate::program::id())
                 .then_some(return_data)
                 .ok_or(ProgramError::IncorrectProgramId)
         })

--- a/interface/src/tools.rs
+++ b/interface/src/tools.rs
@@ -1,7 +1,7 @@
 //! Utility functions
+use {crate::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION, solana_clock::Epoch};
+#[cfg(feature = "bincode")]
 use {
-    crate::MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION,
-    solana_clock::Epoch,
     solana_cpi::{get_return_data, invoke_unchecked},
     solana_program_error::ProgramError,
 };
@@ -13,6 +13,7 @@ use {
 ///
 /// [`GetMinimumDelegation`]: crate::instruction::StakeInstruction::GetMinimumDelegation
 /// [`get_return_data()`]: solana_cpi::get_return_data
+#[cfg(feature = "bincode")]
 pub fn get_minimum_delegation() -> Result<u64, ProgramError> {
     let instruction = crate::instruction::get_minimum_delegation();
     invoke_unchecked(&instruction, &[])?;
@@ -26,6 +27,7 @@ pub fn get_minimum_delegation() -> Result<u64, ProgramError> {
 ///
 /// [`GetMinimumDelegation`]: crate::instruction::StakeInstruction::GetMinimumDelegation
 /// [`get_return_data()`]: solana_cpi::get_return_data
+#[cfg(feature = "bincode")]
 fn get_minimum_delegation_return_data() -> Result<u64, ProgramError> {
     get_return_data()
         .ok_or(ProgramError::InvalidInstructionData)


### PR DESCRIPTION
### Problem

While the repository contains the source files for the Stake interface, it does not define the interface crate.

### Solution

This PR adds the interface `Cargo.toml` configuration and updates its dependencies to use the individual crates.

There are 2 aspects that will be handled in separate PRs:

1. Interface scripts for the CI: this will be added once https://github.com/solana-program/system/pull/23 is merged, since it will follow a similar pattern.
2. Move the [`StakeHistory`](https://github.com/anza-xyz/agave/blob/master/sdk/program/src/sysvar/stake_history.rs) sysvar into this repository.