### PR TITLE
use bpf-entrypoint feature

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-no-entrypoint = []
+bpf-entrypoint = []
 test-sbf = []
 
 [dependencies]

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -1,7 +1,5 @@
 //! Program entrypoint
 
-#![cfg(not(feature = "no-entrypoint"))]
-
 use {
     crate::processor::Processor,
     solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey},

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -3,7 +3,7 @@ use solana_program::native_token::LAMPORTS_PER_SOL;
 pub mod helpers;
 pub mod processor;
 
-#[cfg(not(feature = "no-entrypoint"))]
+#[cfg(feature = "bpf-entrypoint")]
 pub mod entrypoint;
 
 pub use solana_program;

--- a/scripts/program/test.mjs
+++ b/scripts/program/test.mjs
@@ -11,7 +11,7 @@ import './dump.mjs';
 
 // Configure additional arguments here, e.g.:
 // ['--arg1', '--arg2', ...cliArguments()]
-const testArgs = cliArguments();
+const testArgs = ['--features', 'bpf-entrypoint', ...cliArguments()];
 
 const hasSolfmt = await which('solfmt', { nothrow: true });
 


### PR DESCRIPTION
The rest of the programs we've written in BPF have swapped `no-entrypoint` for `bpf-entrypoint`, where the feature is now _additive_ to enable the program ELF's entrypoint binding.

This change brings the Stake program into that same pattern.