### PR TITLE
Bump JS client to 0.1.0

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana-program/stake",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "JavaScript client for the Stake program",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",


### PR DESCRIPTION
Version 0.1.0 of the JS client was published on NPM in the "Publish JS Client" GitHub Action. However, because of branch protection rules, the Action failed to push the version change to the `main` branch. I'm investigating ways to bypass some protection rules for some Actions but, in the meantime, the record needs to be set straight on the JS client version.