### PR TITLE
fix bincode feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5197,7 +5197,10 @@ checksum = "94d7c18cb1a91c6be5f5a8ac9276a1d7c737e39a21beba9ea710ab4b9c63bc90"
 dependencies = [
  "js-sys",
  "num-traits",
+ "serde",
+ "serde_derive",
  "solana-decode-error",
+ "solana-instruction",
  "solana-pubkey",
  "wasm-bindgen",
 ]

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -51,6 +51,7 @@ bincode = [
     "dep:solana-program-error",
     "solana-instruction/bincode",
     "solana-instruction/serde",
+    "solana-system-interface/bincode",
     "serde"
 ]
 borsh = [


### PR DESCRIPTION
Currently the interface crate doesn't compile with `cargo build -F bincode` because it's missing `solana-system-interface/bincode`