### PR TITLE
interface: Bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "assert_matches",
  "bincode",

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-stake-interface"
-version = "1.0.0"
+version = "1.1.0"
 description = "Instructions and constructors for the Stake program"
 readme = "README.md"
 authors = { workspace = true }


### PR DESCRIPTION
This PR bumps the `interface` crate version to `1.1` since a new dependency was added.