### PR TITLE
interface: Bump version to `v1.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "assert_matches",
  "bincode",

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-stake-interface"
-version = "1.1.0"
+version = "1.2.0"
 description = "Instructions and constructors for the Stake program"
 readme = "README.md"
 authors = { workspace = true }
@@ -27,7 +27,7 @@ solana-cpi = { version = "^2.1", optional = true }
 solana-frozen-abi = { version = "^2.1", features = ["frozen-abi"], optional = true }
 solana-frozen-abi-macro = { version = "^2.1", features = ["frozen-abi"], optional = true }
 solana-instruction = "^2.1"
-solana-program-error = { version = "^2.1" }
+solana-program-error = "^2.1"
 solana-pubkey = { version = "^2.1", default-features = false }
 solana-system-interface = "^1.0"
 solana-sysvar-id = "2.1"


### PR DESCRIPTION
This PR bumps the interface crate version to `1.2` since the `solana-program-error` dependency is not optional anymore. It is required since `StakeError` implements the `From` trait to convert an error to a `ProgramError`.