### PR TITLE
ci: Refactor publish rust crate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,78 +144,6 @@ jobs:
           path: ./**/*.so
           key: ${{ runner.os }}-build-${{ github.sha }}
 
-  test_interface:
-    name: Test Interface
-    runs-on: ubuntu-latest
-    needs: format_and_lint_interface
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup
-        with:
-          toolchain: test
-          cargo-cache-key: cargo-interface
-          solana: true
-
-      - name: Test Interface
-        run: pnpm interface:test
-
-  format_and_lint_program:
-    name: Format & Lint Program
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup
-        with:
-          toolchain: format, lint
-
-      - name: Format
-        run: pnpm program:format
-
-      - name: Lint / Clippy
-        run: pnpm program:lint:clippy
-
-      - name: Lint / Docs
-        run: pnpm program:lint:docs
-
-      - name: Lint / Features
-        run: pnpm program:lint:features
-
-  build_program:
-    name: Build program
-    runs-on: ubuntu-latest
-    needs: format_and_lint_program
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup
-        with:
-          cargo-cache-key: cargo-program
-          solana: true
-
-      - name: Build Program
-        run: pnpm program:build
-
-      - name: Upload Program Build
-        uses: actions/upload-artifact@v4
-        with:
-          name: program-builds
-          path: ./target/deploy/*.so
-          if-no-files-found: error
-
-      - name: Save Program Builds For Client Jobs
-        uses: actions/cache/save@v4
-        with:
-          path: ./**/*.so
-          key: ${{ runner.os }}-build-${{ github.sha }}
-
   #generate_clients:
   #  name: Check Client Generation
   #  runs-on: ubuntu-latest
@@ -252,8 +180,8 @@ jobs:
       - name: Lint Client JS
         run: pnpm js:lint
 
-  test_client_rust:
-    name: Test Client Rust
+  test_client_js:
+    name: Test Client JS
     runs-on: ubuntu-latest
     needs: [format_and_lint_client_js, build_program]
     steps:
@@ -263,8 +191,6 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          cargo-cache-key: cargo-rust-client
-          toolchain: test
           solana: true
 
       - name: Restore Program Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,8 +180,8 @@ jobs:
       - name: Lint Client JS
         run: pnpm js:lint
 
-  test_client_js:
-    name: Test Client JS
+  test_client_rust:
+    name: Test Client Rust
     runs-on: ubuntu-latest
     needs: [format_and_lint_client_js, build_program]
     steps:
@@ -191,6 +191,8 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
+          cargo-cache-key: cargo-rust-client
+          toolchain: test
           solana: true
 
       - name: Restore Program Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,36 @@ jobs:
       - name: Lint / Features
         run: pnpm interface:lint:features
 
+  build_program:
+    name: Build program
+    runs-on: ubuntu-latest
+    needs: format_and_lint_program
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          cargo-cache-key: cargo-program
+          solana: true
+
+      - name: Build Program
+        run: pnpm program:build
+
+      - name: Upload Program Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: program-builds
+          path: ./target/deploy/*.so
+          if-no-files-found: error
+
+      - name: Save Program Builds For Client Jobs
+        uses: actions/cache/save@v4
+        with:
+          path: ./**/*.so
+          key: ${{ runner.os }}-build-${{ github.sha }}
+
   test_interface:
     name: Test Interface
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,48 @@ jobs:
       - name: Lint / Features
         run: pnpm interface:lint:features
 
+  test_interface:
+    name: Test Interface
+    runs-on: ubuntu-latest
+    needs: format_and_lint_interface
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          toolchain: test
+          cargo-cache-key: cargo-interface
+          solana: true
+
+      - name: Test Interface
+        run: pnpm interface:test
+
+  format_and_lint_program:
+    name: Format & Lint Program
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          toolchain: format, lint
+
+      - name: Format
+        run: pnpm program:format
+
+      - name: Lint / Clippy
+        run: pnpm program:lint:clippy
+
+      - name: Lint / Docs
+        run: pnpm program:lint:docs
+
+      - name: Lint / Features
+        run: pnpm program:lint:features
+
   build_program:
     name: Build program
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -37,7 +37,7 @@ on:
         default: true
 
 jobs:
-  test_interface:
+  test:
     name: Test Rust Crate
     runs-on: ubuntu-latest
     steps:
@@ -64,10 +64,10 @@ jobs:
       - name: Test
         run: tsx ./scripts/rust.mts test "${{ inputs.crate_path }}"
 
-  publish_rust:
+  publish:
     name: Publish Rust Crate
     runs-on: ubuntu-latest
-    needs: test_interface
+    needs: test
     permissions:
       contents: write
     steps:
@@ -125,4 +125,4 @@ jobs:
         if: github.event.inputs.create_release == 'true' && github.event.inputs.dry_run != 'true'
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.publish.outputs.crate_name }}@v${{ steps.publish.outputs.new_version }}
+          tag: ${{ steps.publish.outputs.crate_type }}@v${{ steps.publish.outputs.new_version }}

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -1,8 +1,12 @@
-name: Publish Rust Client
+name: Publish Rust Crate
 
 on:
   workflow_dispatch:
     inputs:
+      crate_path:
+        description: Path to directory with crate to release
+        required: true
+        type: string
       level:
         description: Level
         required: true
@@ -33,8 +37,8 @@ on:
         default: true
 
 jobs:
-  test_rust:
-    name: Test Rust client
+  test_interface:
+    name: Test Rust Crate
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
@@ -43,27 +47,27 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          cargo-cache-key: cargo-rust-client
-          clippy: true
-          rustfmt: true
+          cargo-cache-key: cargo-test-publish-${{ inputs.crate_path }}
+          cargo-cache-fallback-key: cargo-test-publish
+          toolchain: format, lint, test
           solana: true
 
-      - name: Format Rust Client
-        run: pnpm clients:rust:format
+      - name: Format
+        run: tsx ./scripts/rust.mts format "${{ inputs.crate_path }}"
 
-      - name: Lint Rust Client
-        run: pnpm clients:rust:lint
+      - name: Lint
+        run: tsx ./scripts/rust.mts lint "${{ inputs.crate_path }}"
 
-      - name: Build Programs
-        run: pnpm programs:build
+      - name: Build Program
+        run: pnpm program:build
 
-      - name: Test Rust Client
-        run: pnpm clients:rust:test
+      - name: Test
+        run: tsx ./scripts/rust.mts test "${{ inputs.crate_path }}"
 
   publish_rust:
-    name: Publish Rust Client
+    name: Publish Rust Crate
     runs-on: ubuntu-latest
-    needs: test_rust
+    needs: test_interface
     permissions:
       contents: write
     steps:
@@ -73,10 +77,9 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          cargo-cache-key: cargo-publish-rust-client
-          cargo-cache-fallback-key: cargo-rust-client
-          clippy: true
-          rustfmt: true
+          cargo-cache-key: cargo-test-publish-${{ inputs.crate_path }}
+          cargo-cache-fallback-key: cargo-test-publish
+          toolchain: build
 
       - name: Install Cargo Release
         run: which cargo-release || cargo install cargo-release
@@ -92,8 +95,8 @@ jobs:
 
       - name: Set Git Author
         run: |
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "github-actions"
 
       - name: Publish Rust Client
         id: publish
@@ -112,7 +115,7 @@ jobs:
             OPTIONS=""
           fi
 
-          pnpm clients:rust:publish $LEVEL $OPTIONS
+          tsx ./scripts/rust.mts publish ${{ inputs.crate_path }} $LEVEL $OPTIONS
 
       - name: Push Commit and Tag
         if: github.event.inputs.dry_run != 'true'
@@ -122,4 +125,4 @@ jobs:
         if: github.event.inputs.create_release == 'true' && github.event.inputs.dry_run != 'true'
         uses: ncipollo/release-action@v1
         with:
-          tag: rust@v${{ steps.publish.outputs.new_version }}
+          tag: ${{ steps.publish.outputs.crate_name }}@v${{ steps.publish.outputs.new_version }}

--- a/scripts/rust.mts
+++ b/scripts/rust.mts
@@ -92,7 +92,7 @@ async function publish() {
   const dryRun = argv['dry-run'] ?? false;
   const [level] = args;
   if (!level) {
-    throw new Error('A version level — e.g. "path" — must be provided.');
+    throw new Error('A version level — e.g. "patch" — must be provided.');
   }
 
   // Go to the client directory and install the dependencies.
@@ -111,12 +111,12 @@ async function publish() {
 
   // Get the crate information.
   const toml = getCargo(path.dirname(manifestPath));
-  const crateName = toml.package['name'];
+  const crateType = path.basename(manifestPath);
   const newVersion = toml.package['version'];
 
   // Expose the new version to CI if needed.
   if (process.env.CI) {
-    await $`echo "crate_name=${crateName}" >> $GITHUB_OUTPUT`;
+    await $`echo "crate_type=${crateType}" >> $GITHUB_OUTPUT`;
     await $`echo "new_version=${newVersion}" >> $GITHUB_OUTPUT`;
   }
 
@@ -124,10 +124,10 @@ async function publish() {
   await $`git reset --soft HEAD~1`;
 
   // Commit the new version.
-  await $`git commit -am "Publish ${crateName} v${newVersion}"`;
+  await $`git commit -am "Publish ${crateType} v${newVersion}"`;
 
   // Tag the new version.
-  await $`git tag -a ${crateName}@v${newVersion} -m "${crateName} v${newVersion}"`;
+  await $`git tag -a ${crateType}@v${newVersion} -m "${crateType} v${newVersion}"`;
 }
 
 switch (command) {

--- a/scripts/rust.mts
+++ b/scripts/rust.mts
@@ -116,6 +116,7 @@ async function publish() {
 
   // Expose the new version to CI if needed.
   if (process.env.CI) {
+    await $`echo "crate_name=${crateName}" >> $GITHUB_OUTPUT`;
     await $`echo "new_version=${newVersion}" >> $GITHUB_OUTPUT`;
   }
 


### PR DESCRIPTION
This PR refactors the `publish-rust-client` to allow publishing rust crates for the repository (e.g., `interface`, `clients/rust`).