### PR TITLE
Revert version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "1.2.0"
+version = "1.1.0"
 dependencies = [
  "assert_matches",
  "bincode",

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-stake-interface"
-version = "1.2.0"
+version = "1.1.0"
 description = "Instructions and constructors for the Stake program"
 readme = "README.md"
 authors = { workspace = true }


### PR DESCRIPTION
### Problem

The refactored "publish-rust-crate" workflow uses `cargo release` to bump the version of the crate before publishing. Since the `solana-stake-interface` crate version was already bump manually, using the workflow would bump the version again.

### Solution

Revert the manual version bump so the workflow can be used to publish the next `solana-stake-interface` crate.