### PR TITLE
ci: Fix publish workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,6 +126,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           cargo-cache-key: cargo-program
+          toolchain: build
           solana: true
 
       - name: Build Program

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       crate_path:
-        description: Path to directory with crate to release
+        description: Path to crate
         required: true
         type: string
       level:

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -53,16 +53,16 @@ jobs:
           solana: true
 
       - name: Format
-        run: npx tsx ./scripts/rust.mts format "${{ inputs.crate_path }}"
+        run: pnpm tsx ./scripts/rust.mts format "${{ inputs.crate_path }}"
 
       - name: Lint
-        run: npx tsx ./scripts/rust.mts lint "${{ inputs.crate_path }}"
+        run: pnpm tsx ./scripts/rust.mts lint "${{ inputs.crate_path }}"
 
       - name: Build Program
         run: pnpm program:build
 
       - name: Test
-        run: npx tsx ./scripts/rust.mts test "${{ inputs.crate_path }}"
+        run: pnpm tsx ./scripts/rust.mts test "${{ inputs.crate_path }}"
 
   publish:
     name: Publish Rust Crate
@@ -115,7 +115,7 @@ jobs:
             OPTIONS=""
           fi
 
-          npx tsx ./scripts/rust.mts publish ${{ inputs.crate_path }} $LEVEL $OPTIONS
+          pnpm tsx ./scripts/rust.mts publish ${{ inputs.crate_path }} $LEVEL $OPTIONS
 
       - name: Push Commit and Tag
         if: github.event.inputs.dry_run != 'true'

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -53,16 +53,16 @@ jobs:
           solana: true
 
       - name: Format
-        run: tsx ./scripts/rust.mts format "${{ inputs.crate_path }}"
+        run: npx tsx ./scripts/rust.mts format "${{ inputs.crate_path }}"
 
       - name: Lint
-        run: tsx ./scripts/rust.mts lint "${{ inputs.crate_path }}"
+        run: npx tsx ./scripts/rust.mts lint "${{ inputs.crate_path }}"
 
       - name: Build Program
         run: pnpm program:build
 
       - name: Test
-        run: tsx ./scripts/rust.mts test "${{ inputs.crate_path }}"
+        run: npx tsx ./scripts/rust.mts test "${{ inputs.crate_path }}"
 
   publish:
     name: Publish Rust Crate
@@ -115,7 +115,7 @@ jobs:
             OPTIONS=""
           fi
 
-          tsx ./scripts/rust.mts publish ${{ inputs.crate_path }} $LEVEL $OPTIONS
+          npx tsx ./scripts/rust.mts publish ${{ inputs.crate_path }} $LEVEL $OPTIONS
 
       - name: Push Commit and Tag
         if: github.event.inputs.dry_run != 'true'

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           cargo-cache-key: cargo-test-publish-${{ inputs.crate_path }}
           cargo-cache-fallback-key: cargo-test-publish
-          toolchain: format, lint, test
+          toolchain: build, format, lint, test
           solana: true
 
       - name: Format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2021"
 solana = "2.1.0"
 
 [workspace.metadata.toolchains]
+build = "1.81.0"
 format = "nightly-2024-08-08"
 lint = "nightly-2024-08-08"
 test = "nightly-2024-08-08"


### PR DESCRIPTION
### Problem

The "publish" workflow is missing a `npx` command in order to run the `tsx` scripts; additionally, the `build` toolchain is not being set.

### Solution

Add the missing command and toolchain definition.

A "dry-run" of the workflow now works: https://github.com/solana-program/stake/actions/runs/13001907231