### PR TITLE
use correct program ID in solana_stake_interface::instruction

### DIFF
--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -10,9 +10,8 @@ use {
 };
 #[cfg(feature = "bincode")]
 use {
-    crate::{config, state::StakeStateV2},
+    crate::{config, program::ID, state::StakeStateV2},
     solana_instruction::{AccountMeta, Instruction},
-    solana_system_interface::program::ID,
 };
 
 // Inline some constants to avoid dependencies.


### PR DESCRIPTION
This module was incorrectly using the system program ID instead of the stake program ID