### PR TITLE
publish: Fix workflow

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -22,4 +22,4 @@ This will add the `solana-stake-interface` dependency with the `bincode` feature
 
 ## Documentation
 
-Read more about the Stake program on the crate [documentation](https://docs.rs/solana-stake-interface/latest/solana-stake-interface/).
+Read more about the Stake program on the crate [documentation](https://docs.rs/solana-stake-interface/latest/solana_stake_interface/).

--- a/scripts/rust.mts
+++ b/scripts/rust.mts
@@ -110,8 +110,8 @@ async function publish() {
   }
 
   // Get the crate information.
-  const toml = getCargo(manifestPath);
-  const crateType = path.basename(manifestPath);
+  const toml = getCargo(libraryPath);
+  const crateType = path.basename(libraryPath);
   const newVersion = toml.package['version'];
 
   // Expose the new version to CI if needed.

--- a/scripts/rust.mts
+++ b/scripts/rust.mts
@@ -110,7 +110,7 @@ async function publish() {
   }
 
   // Get the crate information.
-  const toml = getCargo(path.dirname(manifestPath));
+  const toml = getCargo(manifestPath);
   const crateType = path.basename(manifestPath);
   const newVersion = toml.package['version'];
 


### PR DESCRIPTION
#### Problem

While the `publish-rust-crate` can successfully publish a crate, it fails to create a git tag and GitHub release due to using the wrong path to look up the `Cargo.toml` file.

#### Solution

Fix the `Cargo.toml` look up by using the correct value. It also fixes the docs link on the `README.md` of the interface crate.