### PR TITLE
interface: Bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "assert_matches",
  "bincode",

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-stake-interface"
-version = "1.1.0"
+version = "1.2.0"
 description = "Instructions and constructors for the Stake program"
 readme = "README.md"
 authors = { workspace = true }


### PR DESCRIPTION
#### Problem

The interface crate version is out-of-sync with the version on crates.io since the workflow failed to commit and create a git tag when it was first used.

#### Solution

Update the interface version to be the same as the latest version published on [crates.io](https://crates.io/crates/solana-stake-interface).