### PR TITLE
publish: Fix crate name parsing

### DIFF
--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -125,4 +125,4 @@ jobs:
         if: github.event.inputs.create_release == 'true' && github.event.inputs.dry_run != 'true'
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.publish.outputs.crate_type }}@v${{ steps.publish.outputs.new_version }}
+          tag: ${{ steps.publish.outputs.crate }}@v${{ steps.publish.outputs.new_version }}

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -82,7 +82,7 @@ jobs:
           toolchain: build
 
       - name: Install Cargo Release
-        run: which cargo-release || cargo install cargo-release
+        run: which cargo-release || cargo install cargo-release@0.25.15
 
       - name: Ensure CARGO_REGISTRY_TOKEN variable is set
         env:

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       crate_path:
-        description: Path to crate
+        description: Crate to publish
         required: true
-        type: string
+        type: choice
+        options:
+          - clients/rust
+          - interface
+          - program
       level:
         description: Level
         required: true

--- a/scripts/helpers/utils.mts
+++ b/scripts/helpers/utils.mts
@@ -146,6 +146,7 @@ export async function getInstalledSolanaVersion(): Promise<string | undefined> {
 
 export function parseCliArguments(): {
   command: string;
+  relativePath: string;
   libraryPath: string;
   args: string[];
 } {
@@ -162,6 +163,7 @@ export function parseCliArguments(): {
 
   return {
     command,
+    relativePath,
     libraryPath: path.join(workingDirectory, relativePath),
     args,
   };

--- a/scripts/helpers/utils.mts
+++ b/scripts/helpers/utils.mts
@@ -77,7 +77,7 @@ export function getAllProgramFolders(): string[] {
 export function getCargo(folder?: string): JsonMap {
   return parseToml(
     fs.readFileSync(
-      path.join(workingDirectory, folder ? folder : '.', 'Cargo.toml'),
+      path.resolve(workingDirectory, path.join(folder ? folder : '.', 'Cargo.toml')),
       'utf8'
     )
   );
@@ -146,7 +146,6 @@ export async function getInstalledSolanaVersion(): Promise<string | undefined> {
 
 export function parseCliArguments(): {
   command: string;
-  relativePath: string;
   libraryPath: string;
   args: string[];
 } {
@@ -163,7 +162,6 @@ export function parseCliArguments(): {
 
   return {
     command,
-    relativePath,
     libraryPath: path.join(workingDirectory, relativePath),
     args,
   };

--- a/scripts/rust.mts
+++ b/scripts/rust.mts
@@ -104,11 +104,6 @@ async function publish() {
     : ['--no-push', '--no-tag', '--no-confirm', '--execute'];
   await $`cargo release ${level} ${releaseArgs}`;
 
-  // Stop here if this is a dry run.
-  if (dryRun) {
-    process.exit(0);
-  }
-
   // Get the crate information.
   const toml = getCargo(libraryPath);
   const crate = path.basename(libraryPath);
@@ -118,6 +113,11 @@ async function publish() {
   if (process.env.CI) {
     await $`echo "crate=${crate}" >> $GITHUB_OUTPUT`;
     await $`echo "new_version=${newVersion}" >> $GITHUB_OUTPUT`;
+  }
+
+  // Stop here if this is a dry run.
+  if (dryRun) {
+    process.exit(0);
   }
 
   // Soft reset the last commit so we can create our own commit and tag.

--- a/scripts/rust.mts
+++ b/scripts/rust.mts
@@ -24,7 +24,7 @@ enum Command {
   Publish = 'publish',
 }
 
-const { command, relativePath, libraryPath, args } = parseCliArguments();
+const { command, libraryPath, args } = parseCliArguments();
 const manifestPath = path.join(libraryPath, 'Cargo.toml');
 
 async function cargo(
@@ -110,8 +110,8 @@ async function publish() {
   }
 
   // Get the crate information.
-  const toml = getCargo(relativePath);
-  const crate = path.basename(relativePath);
+  const toml = getCargo(libraryPath);
+  const crate = path.basename(libraryPath);
   const newVersion = toml.package['version'];
 
   // Expose the new version to CI if needed.

--- a/scripts/rust.mts
+++ b/scripts/rust.mts
@@ -24,7 +24,7 @@ enum Command {
   Publish = 'publish',
 }
 
-const { command, libraryPath, args } = parseCliArguments();
+const { command, relativePath, libraryPath, args } = parseCliArguments();
 const manifestPath = path.join(libraryPath, 'Cargo.toml');
 
 async function cargo(
@@ -110,13 +110,13 @@ async function publish() {
   }
 
   // Get the crate information.
-  const toml = getCargo(libraryPath);
-  const crateType = path.basename(libraryPath);
+  const toml = getCargo(relativePath);
+  const crate = path.basename(relativePath);
   const newVersion = toml.package['version'];
 
   // Expose the new version to CI if needed.
   if (process.env.CI) {
-    await $`echo "crate_type=${crateType}" >> $GITHUB_OUTPUT`;
+    await $`echo "crate=${crate}" >> $GITHUB_OUTPUT`;
     await $`echo "new_version=${newVersion}" >> $GITHUB_OUTPUT`;
   }
 
@@ -124,10 +124,10 @@ async function publish() {
   await $`git reset --soft HEAD~1`;
 
   // Commit the new version.
-  await $`git commit -am "Publish ${crateType} v${newVersion}"`;
+  await $`git commit -am "Publish ${crate} v${newVersion}"`;
 
   // Tag the new version.
-  await $`git tag -a ${crateType}@v${newVersion} -m "${crateType} v${newVersion}"`;
+  await $`git tag -a ${crate}@v${newVersion} -m "${crate} v${newVersion}"`;
 }
 
 switch (command) {


### PR DESCRIPTION
#### Problem

Currently there is a problem in how the crate name parsing is done on the publish crate workflow – it fails to determine the correct path for the crate, which prevents the script to parse the name and version of the crate.

#### Solution

Modify the `parseCliArguments` to return the original `relativePath` value so that the script can parse the name and version of the crate.