### PR TITLE
update versions, fix mollusk tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,28 +2363,29 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm"
-version = "0.0.13"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceaf67fe3f95a9478f4f5b0d71e77c073eee7a795a74d6143317a22454c289"
+checksum = "95e7c0b51a00d234774b61bf829aa75316eb3a5ebf30bd622010bd046daa287a"
 dependencies = [
  "bincode",
  "mollusk-svm-error",
  "mollusk-svm-keys",
  "solana-bpf-loader-program",
  "solana-compute-budget",
+ "solana-log-collector",
  "solana-logger",
  "solana-program-runtime",
  "solana-sdk",
- "solana-stake-program 2.1.0",
+ "solana-stake-program 2.1.9",
  "solana-system-program",
  "solana-timings",
 ]
 
 [[package]]
 name = "mollusk-svm-error"
-version = "0.0.13"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8738bc85a52d123012209a573f17faffa1db440493396ae2e1f64fbb8f3579bf"
+checksum = "92d7892725c98a376b55e03ccbea44a0d2111c8f7bab0432b42ea689f3f612e7"
 dependencies = [
  "solana-sdk",
  "thiserror 1.0.69",
@@ -2392,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-keys"
-version = "0.0.13"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a7656d86d743de0a9788ce4c0e9ff63028a42e350131ebe67c476cdde6ac9f"
+checksum = "dd18816096707d148467889844ae57384ab4cbbe50ed24fd03139e6e34d61301"
 dependencies = [
  "mollusk-svm-error",
  "solana-sdk",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -23,14 +23,14 @@ thiserror = "1.0.63"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-mollusk-svm = { version = "=0.0.13", features = ["all-builtins"] }
-solana-account = { version = "=2.1.0", features = ["bincode"] }
-solana-program-test = "=2.1.0"
-solana-program-runtime = "=2.1.0"
-solana-config-program = "=2.1.0"
-solana-vote-program = "=2.1.0"
-solana-sdk = "=2.1.0"
-solana-feature-set = "=2.1.0"
+mollusk-svm = { version = "=0.0.15", features = ["all-builtins"] }
+solana-account = { version = "2.1", features = ["bincode"] }
+solana-program-test = "2.1"
+solana-program-runtime = "2.1"
+solana-config-program = "2.1"
+solana-vote-program = "2.1"
+solana-sdk = "2.1"
+solana-feature-set = "2.1"
 test-case = "3.3.1"
 
 [lib]

--- a/program/tests/stake_instruction.rs
+++ b/program/tests/stake_instruction.rs
@@ -127,13 +127,19 @@ fn process_instruction(
         Err(e) => Check::err(e),
     };
 
-    let result =
-        mollusk.process_and_validate_instruction(&instruction, &transaction_accounts, &[check]);
+    let result = mollusk.process_and_validate_instruction(
+        &instruction,
+        &transaction_accounts
+            .into_iter()
+            .map(|(key, account)| (key, account.into()))
+            .collect::<Vec<_>>(),
+        &[check],
+    );
 
     result
         .resulting_accounts
         .into_iter()
-        .map(|(_, account)| account)
+        .map(|(_, account)| account.into())
         .collect()
 }
 
@@ -6499,7 +6505,10 @@ fn test_stake_get_minimum_delegation(mollusk: Mollusk) {
     let stake_account = create_default_stake_account();
     let minimum_delegation = crate::get_minimum_delegation();
     let instruction_data = serialize(&StakeInstruction::GetMinimumDelegation).unwrap();
-    let transaction_accounts = vec![(stake_address, stake_account)];
+    let transaction_accounts = vec![(stake_address, stake_account)]
+        .into_iter()
+        .map(|(key, account)| (key, account.into()))
+        .collect::<Vec<_>>();
     let instruction_accounts = vec![AccountMeta {
         pubkey: stake_address,
         is_signer: false,
@@ -6517,7 +6526,7 @@ fn test_stake_get_minimum_delegation(mollusk: Mollusk) {
         &transaction_accounts,
         &[
             Check::success(),
-            Check::return_data(minimum_delegation.to_le_bytes().to_vec()),
+            Check::return_data(&minimum_delegation.to_le_bytes()),
         ],
     );
 }


### PR DESCRIPTION
bpf stake program presently does not build due to versioning issues. this relaxes the solana version locks in `dev-dependencies` (necessary because of matching version locks in mollusk 0.0.13 which have themselves been relaxed in 0.0.15) and fixes some things to update mollusk versions

mollusk wants `Account` rather than `AccountSharedData` now so rather than a gigantic changelog reworking all the tests i just covert on ingress and egress

unrelated note but the `ProgramTest` tests are all broken due to [simd170](https://github.com/solana-foundation/solana-improvement-documents/pull/170) restricting native programs to 3k cus. there is some machinery i will have to look at to see how to make `ProgramTest` tell the cost model our bpf program is no longer "native"

once we fix the tests we need to set up ci properly and hopefully get looped into monorepo ci to prevent breakage in the future