### PR TITLE
fix: parseWithdrawInstruction if statement

### DIFF
--- a/clients/js/src/generated/instructions/withdraw.ts
+++ b/clients/js/src/generated/instructions/withdraw.ts
@@ -247,9 +247,9 @@ export function parseWithdrawInstruction<
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
 ): ParsedWithdrawInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 6) {
+  if (instruction.accounts.length < 5 || instruction.accounts.length > 6) {
     // TODO: Coded error.
-    throw new Error('Not enough accounts');
+    throw new Error('Withdraw Instruction expects 5 or 6 accounts');
   }
   let accountIndex = 0;
   const getNextAccount = () => {


### PR DESCRIPTION
Seems like the `lockupAuthority` is optional, which means that the number of accounts available must be strictly 5 or 6 otherwise it should throw an error. Please let me know if I may be missing something because the previous version was throwing an error when 5 accounts were available and that should have been a valid use case.

If the change is accepted, when will the next version of the library be released? 