### PR TITLE
Use omitted optional account strategy on IDL

### DIFF
--- a/clients/js/src/generated/instructions/authorize.ts
+++ b/clients/js/src/generated/instructions/authorize.ts
@@ -195,7 +195,7 @@ export function getAuthorizeInstruction<
       getAccountMeta(accounts.clockSysvar),
       getAccountMeta(accounts.authority),
       getAccountMeta(accounts.lockupAuthority),
-    ].filter(<T,>(x: T | undefined): x is T => x !== undefined),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
     programAddress,
     data: getAuthorizeInstructionDataEncoder().encode(
       args as AuthorizeInstructionDataArgs

--- a/clients/js/src/generated/instructions/authorizeChecked.ts
+++ b/clients/js/src/generated/instructions/authorizeChecked.ts
@@ -201,7 +201,7 @@ export function getAuthorizeCheckedInstruction<
       getAccountMeta(accounts.authority),
       getAccountMeta(accounts.newAuthority),
       getAccountMeta(accounts.lockupAuthority),
-    ].filter(<T,>(x: T | undefined): x is T => x !== undefined),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
     programAddress,
     data: getAuthorizeCheckedInstructionDataEncoder().encode(
       args as AuthorizeCheckedInstructionDataArgs

--- a/clients/js/src/generated/instructions/authorizeChecked.ts
+++ b/clients/js/src/generated/instructions/authorizeChecked.ts
@@ -50,7 +50,10 @@ export type AuthorizeCheckedInstruction<
     | IAccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
   TAccountAuthority extends string | IAccountMeta<string> = string,
   TAccountNewAuthority extends string | IAccountMeta<string> = string,
-  TAccountLockupAuthority extends string | IAccountMeta<string> = string,
+  TAccountLockupAuthority extends
+    | string
+    | IAccountMeta<string>
+    | undefined = undefined,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -70,10 +73,14 @@ export type AuthorizeCheckedInstruction<
         ? ReadonlySignerAccount<TAccountNewAuthority> &
             IAccountSignerMeta<TAccountNewAuthority>
         : TAccountNewAuthority,
-      TAccountLockupAuthority extends string
-        ? ReadonlySignerAccount<TAccountLockupAuthority> &
-            IAccountSignerMeta<TAccountLockupAuthority>
-        : TAccountLockupAuthority,
+      ...(TAccountLockupAuthority extends undefined
+        ? []
+        : [
+            TAccountLockupAuthority extends string
+              ? ReadonlySignerAccount<TAccountLockupAuthority> &
+                  IAccountSignerMeta<TAccountLockupAuthority>
+              : TAccountLockupAuthority,
+          ]),
       ...TRemainingAccounts,
     ]
   >;
@@ -186,7 +193,7 @@ export function getAuthorizeCheckedInstruction<
       'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
   }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.stake),
@@ -194,7 +201,7 @@ export function getAuthorizeCheckedInstruction<
       getAccountMeta(accounts.authority),
       getAccountMeta(accounts.newAuthority),
       getAccountMeta(accounts.lockupAuthority),
-    ],
+    ].filter(<T,>(x: T | undefined): x is T => x !== undefined),
     programAddress,
     data: getAuthorizeCheckedInstructionDataEncoder().encode(
       args as AuthorizeCheckedInstructionDataArgs
@@ -239,7 +246,7 @@ export function parseAuthorizeCheckedInstruction<
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
 ): ParsedAuthorizeCheckedInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 5) {
+  if (instruction.accounts.length < 4) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -249,11 +256,11 @@ export function parseAuthorizeCheckedInstruction<
     accountIndex += 1;
     return accountMeta;
   };
+  let optionalAccountsRemaining = instruction.accounts.length - 4;
   const getNextOptionalAccount = () => {
-    const accountMeta = getNextAccount();
-    return accountMeta.address === STAKE_PROGRAM_ADDRESS
-      ? undefined
-      : accountMeta;
+    if (optionalAccountsRemaining === 0) return undefined;
+    optionalAccountsRemaining -= 1;
+    return getNextAccount();
   };
   return {
     programAddress: instruction.programAddress,

--- a/clients/js/src/generated/instructions/authorizeCheckedWithSeed.ts
+++ b/clients/js/src/generated/instructions/authorizeCheckedWithSeed.ts
@@ -222,7 +222,7 @@ export function getAuthorizeCheckedWithSeedInstruction<
       getAccountMeta(accounts.clockSysvar),
       getAccountMeta(accounts.newAuthority),
       getAccountMeta(accounts.lockupAuthority),
-    ].filter(<T,>(x: T | undefined): x is T => x !== undefined),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
     programAddress,
     data: getAuthorizeCheckedWithSeedInstructionDataEncoder().encode(
       args as AuthorizeCheckedWithSeedInstructionDataArgs

--- a/clients/js/src/generated/instructions/authorizeCheckedWithSeed.ts
+++ b/clients/js/src/generated/instructions/authorizeCheckedWithSeed.ts
@@ -56,7 +56,10 @@ export type AuthorizeCheckedWithSeedInstruction<
     | string
     | IAccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
   TAccountNewAuthority extends string | IAccountMeta<string> = string,
-  TAccountLockupAuthority extends string | IAccountMeta<string> = string,
+  TAccountLockupAuthority extends
+    | string
+    | IAccountMeta<string>
+    | undefined = undefined,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -75,10 +78,14 @@ export type AuthorizeCheckedWithSeedInstruction<
         ? ReadonlySignerAccount<TAccountNewAuthority> &
             IAccountSignerMeta<TAccountNewAuthority>
         : TAccountNewAuthority,
-      TAccountLockupAuthority extends string
-        ? ReadonlySignerAccount<TAccountLockupAuthority> &
-            IAccountSignerMeta<TAccountLockupAuthority>
-        : TAccountLockupAuthority,
+      ...(TAccountLockupAuthority extends undefined
+        ? []
+        : [
+            TAccountLockupAuthority extends string
+              ? ReadonlySignerAccount<TAccountLockupAuthority> &
+                  IAccountSignerMeta<TAccountLockupAuthority>
+              : TAccountLockupAuthority,
+          ]),
       ...TRemainingAccounts,
     ]
   >;
@@ -207,7 +214,7 @@ export function getAuthorizeCheckedWithSeedInstruction<
       'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
   }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.stake),
@@ -215,7 +222,7 @@ export function getAuthorizeCheckedWithSeedInstruction<
       getAccountMeta(accounts.clockSysvar),
       getAccountMeta(accounts.newAuthority),
       getAccountMeta(accounts.lockupAuthority),
-    ],
+    ].filter(<T,>(x: T | undefined): x is T => x !== undefined),
     programAddress,
     data: getAuthorizeCheckedWithSeedInstructionDataEncoder().encode(
       args as AuthorizeCheckedWithSeedInstructionDataArgs
@@ -260,7 +267,7 @@ export function parseAuthorizeCheckedWithSeedInstruction<
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
 ): ParsedAuthorizeCheckedWithSeedInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 5) {
+  if (instruction.accounts.length < 4) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -270,11 +277,11 @@ export function parseAuthorizeCheckedWithSeedInstruction<
     accountIndex += 1;
     return accountMeta;
   };
+  let optionalAccountsRemaining = instruction.accounts.length - 4;
   const getNextOptionalAccount = () => {
-    const accountMeta = getNextAccount();
-    return accountMeta.address === STAKE_PROGRAM_ADDRESS
-      ? undefined
-      : accountMeta;
+    if (optionalAccountsRemaining === 0) return undefined;
+    optionalAccountsRemaining -= 1;
+    return getNextAccount();
   };
   return {
     programAddress: instruction.programAddress,

--- a/clients/js/src/generated/instructions/authorizeWithSeed.ts
+++ b/clients/js/src/generated/instructions/authorizeWithSeed.ts
@@ -211,7 +211,7 @@ export function getAuthorizeWithSeedInstruction<
       getAccountMeta(accounts.base),
       getAccountMeta(accounts.clockSysvar),
       getAccountMeta(accounts.lockupAuthority),
-    ].filter(<T,>(x: T | undefined): x is T => x !== undefined),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
     programAddress,
     data: getAuthorizeWithSeedInstructionDataEncoder().encode(
       args as AuthorizeWithSeedInstructionDataArgs

--- a/clients/js/src/generated/instructions/authorizeWithSeed.ts
+++ b/clients/js/src/generated/instructions/authorizeWithSeed.ts
@@ -55,7 +55,10 @@ export type AuthorizeWithSeedInstruction<
   TAccountClockSysvar extends
     | string
     | IAccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
-  TAccountLockupAuthority extends string | IAccountMeta<string> = string,
+  TAccountLockupAuthority extends
+    | string
+    | IAccountMeta<string>
+    | undefined = undefined,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -70,10 +73,14 @@ export type AuthorizeWithSeedInstruction<
       TAccountClockSysvar extends string
         ? ReadonlyAccount<TAccountClockSysvar>
         : TAccountClockSysvar,
-      TAccountLockupAuthority extends string
-        ? ReadonlySignerAccount<TAccountLockupAuthority> &
-            IAccountSignerMeta<TAccountLockupAuthority>
-        : TAccountLockupAuthority,
+      ...(TAccountLockupAuthority extends undefined
+        ? []
+        : [
+            TAccountLockupAuthority extends string
+              ? ReadonlySignerAccount<TAccountLockupAuthority> &
+                  IAccountSignerMeta<TAccountLockupAuthority>
+              : TAccountLockupAuthority,
+          ]),
       ...TRemainingAccounts,
     ]
   >;
@@ -197,14 +204,14 @@ export function getAuthorizeWithSeedInstruction<
       'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
   }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.stake),
       getAccountMeta(accounts.base),
       getAccountMeta(accounts.clockSysvar),
       getAccountMeta(accounts.lockupAuthority),
-    ],
+    ].filter(<T,>(x: T | undefined): x is T => x !== undefined),
     programAddress,
     data: getAuthorizeWithSeedInstructionDataEncoder().encode(
       args as AuthorizeWithSeedInstructionDataArgs
@@ -246,7 +253,7 @@ export function parseAuthorizeWithSeedInstruction<
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
 ): ParsedAuthorizeWithSeedInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 4) {
+  if (instruction.accounts.length < 3) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -256,11 +263,11 @@ export function parseAuthorizeWithSeedInstruction<
     accountIndex += 1;
     return accountMeta;
   };
+  let optionalAccountsRemaining = instruction.accounts.length - 3;
   const getNextOptionalAccount = () => {
-    const accountMeta = getNextAccount();
-    return accountMeta.address === STAKE_PROGRAM_ADDRESS
-      ? undefined
-      : accountMeta;
+    if (optionalAccountsRemaining === 0) return undefined;
+    optionalAccountsRemaining -= 1;
+    return getNextAccount();
   };
   return {
     programAddress: instruction.programAddress,

--- a/clients/js/src/generated/instructions/deactivate.ts
+++ b/clients/js/src/generated/instructions/deactivate.ts
@@ -138,7 +138,7 @@ export function getDeactivateInstruction<
       'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
   }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.stake),

--- a/clients/js/src/generated/instructions/deactivateDelinquent.ts
+++ b/clients/js/src/generated/instructions/deactivateDelinquent.ts
@@ -129,7 +129,7 @@ export function getDeactivateDelinquentInstruction<
     ResolvedAccount
   >;
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.stake),

--- a/clients/js/src/generated/instructions/delegateStake.ts
+++ b/clients/js/src/generated/instructions/delegateStake.ts
@@ -171,7 +171,7 @@ export function getDelegateStakeInstruction<
       'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
   }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.stake),

--- a/clients/js/src/generated/instructions/initialize.ts
+++ b/clients/js/src/generated/instructions/initialize.ts
@@ -146,7 +146,7 @@ export function getInitializeInstruction<
       'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
   }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.stake),

--- a/clients/js/src/generated/instructions/initializeChecked.ts
+++ b/clients/js/src/generated/instructions/initializeChecked.ts
@@ -152,7 +152,7 @@ export function getInitializeCheckedInstruction<
       'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
   }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.stake),

--- a/clients/js/src/generated/instructions/merge.ts
+++ b/clients/js/src/generated/instructions/merge.ts
@@ -163,7 +163,7 @@ export function getMergeInstruction<
       'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
   }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.destinationStake),

--- a/clients/js/src/generated/instructions/moveLamports.ts
+++ b/clients/js/src/generated/instructions/moveLamports.ts
@@ -147,7 +147,7 @@ export function getMoveLamportsInstruction<
   // Original args.
   const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.sourceStake),

--- a/clients/js/src/generated/instructions/moveStake.ts
+++ b/clients/js/src/generated/instructions/moveStake.ts
@@ -144,7 +144,7 @@ export function getMoveStakeInstruction<
   // Original args.
   const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.sourceStake),

--- a/clients/js/src/generated/instructions/setLockup.ts
+++ b/clients/js/src/generated/instructions/setLockup.ts
@@ -146,7 +146,7 @@ export function getSetLockupInstruction<
   // Original args.
   const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.stake),

--- a/clients/js/src/generated/instructions/setLockupChecked.ts
+++ b/clients/js/src/generated/instructions/setLockupChecked.ts
@@ -171,7 +171,7 @@ export function getSetLockupCheckedInstruction<
       getAccountMeta(accounts.stake),
       getAccountMeta(accounts.authority),
       getAccountMeta(accounts.newAuthority),
-    ].filter(<T,>(x: T | undefined): x is T => x !== undefined),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
     programAddress,
     data: getSetLockupCheckedInstructionDataEncoder().encode(
       args as SetLockupCheckedInstructionDataArgs

--- a/clients/js/src/generated/instructions/split.ts
+++ b/clients/js/src/generated/instructions/split.ts
@@ -137,7 +137,7 @@ export function getSplitInstruction<
   // Original args.
   const args = { ...input };
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.stake),

--- a/clients/js/src/generated/instructions/withdraw.ts
+++ b/clients/js/src/generated/instructions/withdraw.ts
@@ -206,7 +206,7 @@ export function getWithdrawInstruction<
       getAccountMeta(accounts.stakeHistory),
       getAccountMeta(accounts.withdrawAuthority),
       getAccountMeta(accounts.lockupAuthority),
-    ].filter(<T,>(x: T | undefined): x is T => x !== undefined),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
     programAddress,
     data: getWithdrawInstructionDataEncoder().encode(
       args as WithdrawInstructionDataArgs

--- a/clients/js/src/generated/instructions/withdraw.ts
+++ b/clients/js/src/generated/instructions/withdraw.ts
@@ -47,7 +47,10 @@ export type WithdrawInstruction<
     | IAccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
   TAccountStakeHistory extends string | IAccountMeta<string> = string,
   TAccountWithdrawAuthority extends string | IAccountMeta<string> = string,
-  TAccountLockupAuthority extends string | IAccountMeta<string> = string,
+  TAccountLockupAuthority extends
+    | string
+    | IAccountMeta<string>
+    | undefined = undefined,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -69,10 +72,14 @@ export type WithdrawInstruction<
         ? ReadonlySignerAccount<TAccountWithdrawAuthority> &
             IAccountSignerMeta<TAccountWithdrawAuthority>
         : TAccountWithdrawAuthority,
-      TAccountLockupAuthority extends string
-        ? ReadonlySignerAccount<TAccountLockupAuthority> &
-            IAccountSignerMeta<TAccountLockupAuthority>
-        : TAccountLockupAuthority,
+      ...(TAccountLockupAuthority extends undefined
+        ? []
+        : [
+            TAccountLockupAuthority extends string
+              ? ReadonlySignerAccount<TAccountLockupAuthority> &
+                  IAccountSignerMeta<TAccountLockupAuthority>
+              : TAccountLockupAuthority,
+          ]),
       ...TRemainingAccounts,
     ]
   >;
@@ -190,7 +197,7 @@ export function getWithdrawInstruction<
       'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
   }
 
-  const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+  const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.stake),
@@ -199,7 +206,7 @@ export function getWithdrawInstruction<
       getAccountMeta(accounts.stakeHistory),
       getAccountMeta(accounts.withdrawAuthority),
       getAccountMeta(accounts.lockupAuthority),
-    ],
+    ].filter(<T,>(x: T | undefined): x is T => x !== undefined),
     programAddress,
     data: getWithdrawInstructionDataEncoder().encode(
       args as WithdrawInstructionDataArgs
@@ -247,7 +254,7 @@ export function parseWithdrawInstruction<
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
 ): ParsedWithdrawInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 6) {
+  if (instruction.accounts.length < 5) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -257,11 +264,11 @@ export function parseWithdrawInstruction<
     accountIndex += 1;
     return accountMeta;
   };
+  let optionalAccountsRemaining = instruction.accounts.length - 5;
   const getNextOptionalAccount = () => {
-    const accountMeta = getNextAccount();
-    return accountMeta.address === STAKE_PROGRAM_ADDRESS
-      ? undefined
-      : accountMeta;
+    if (optionalAccountsRemaining === 0) return undefined;
+    optionalAccountsRemaining -= 1;
+    return getNextAccount();
   };
   return {
     programAddress: instruction.programAddress,

--- a/clients/rust/src/generated/instructions/authorize.rs
+++ b/clients/rust/src/generated/instructions/authorize.rs
@@ -54,11 +54,6 @@ impl Authorize {
                 lockup_authority,
                 true,
             ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
-            ));
         }
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&AuthorizeInstructionData::new()).unwrap();
@@ -290,11 +285,6 @@ impl<'a, 'b> AuthorizeCpi<'a, 'b> {
             accounts.push(solana_program::instruction::AccountMeta::new_readonly(
                 *lockup_authority.key,
                 true,
-            ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
             ));
         }
         remaining_accounts.iter().for_each(|remaining_account| {

--- a/clients/rust/src/generated/instructions/authorize_checked.rs
+++ b/clients/rust/src/generated/instructions/authorize_checked.rs
@@ -59,11 +59,6 @@ impl AuthorizeChecked {
                 lockup_authority,
                 true,
             ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
-            ));
         }
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&AuthorizeCheckedInstructionData::new()).unwrap();
@@ -308,11 +303,6 @@ impl<'a, 'b> AuthorizeCheckedCpi<'a, 'b> {
             accounts.push(solana_program::instruction::AccountMeta::new_readonly(
                 *lockup_authority.key,
                 true,
-            ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
             ));
         }
         remaining_accounts.iter().for_each(|remaining_account| {

--- a/clients/rust/src/generated/instructions/authorize_checked_with_seed.rs
+++ b/clients/rust/src/generated/instructions/authorize_checked_with_seed.rs
@@ -59,11 +59,6 @@ impl AuthorizeCheckedWithSeed {
                 lockup_authority,
                 true,
             ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
-            ));
         }
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&AuthorizeCheckedWithSeedInstructionData::new()).unwrap();
@@ -330,11 +325,6 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpi<'a, 'b> {
             accounts.push(solana_program::instruction::AccountMeta::new_readonly(
                 *lockup_authority.key,
                 true,
-            ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
             ));
         }
         remaining_accounts.iter().for_each(|remaining_account| {

--- a/clients/rust/src/generated/instructions/authorize_with_seed.rs
+++ b/clients/rust/src/generated/instructions/authorize_with_seed.rs
@@ -53,11 +53,6 @@ impl AuthorizeWithSeed {
                 lockup_authority,
                 true,
             ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
-            ));
         }
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&AuthorizeWithSeedInstructionData::new()).unwrap();
@@ -317,11 +312,6 @@ impl<'a, 'b> AuthorizeWithSeedCpi<'a, 'b> {
             accounts.push(solana_program::instruction::AccountMeta::new_readonly(
                 *lockup_authority.key,
                 true,
-            ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
             ));
         }
         remaining_accounts.iter().for_each(|remaining_account| {

--- a/clients/rust/src/generated/instructions/set_lockup_checked.rs
+++ b/clients/rust/src/generated/instructions/set_lockup_checked.rs
@@ -44,11 +44,6 @@ impl SetLockupChecked {
                 new_authority,
                 true,
             ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
-            ));
         }
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&SetLockupCheckedInstructionData::new()).unwrap();
@@ -261,11 +256,6 @@ impl<'a, 'b> SetLockupCheckedCpi<'a, 'b> {
             accounts.push(solana_program::instruction::AccountMeta::new_readonly(
                 *new_authority.key,
                 true,
-            ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
             ));
         }
         remaining_accounts.iter().for_each(|remaining_account| {

--- a/clients/rust/src/generated/instructions/withdraw.rs
+++ b/clients/rust/src/generated/instructions/withdraw.rs
@@ -62,11 +62,6 @@ impl Withdraw {
                 lockup_authority,
                 true,
             ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
-            ));
         }
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&WithdrawInstructionData::new()).unwrap();
@@ -331,11 +326,6 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
             accounts.push(solana_program::instruction::AccountMeta::new_readonly(
                 *lockup_authority.key,
                 true,
-            ));
-        } else {
-            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-                crate::STAKE_ID,
-                false,
             ));
         }
         remaining_accounts.iter().for_each(|remaining_account| {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "solana:check": "tsx ./scripts/helpers/check-solana-version.mts",
     "solana:link": "tsx ./scripts/helpers/link-solana-version.mts",
     "generate": "pnpm generate:clients",
-    "generate:clients": "tsx ./scripts/helpers/generate-clients.mts",
+    "generate:clients": "tsx ./scripts/helpers/generate-clients.mts && (cd clients/js && pnpm format:fix)",
     "validator:start": "tsx ./scripts/helpers/start-validator.mts",
     "validator:restart": "pnpm validator:start --restart",
     "validator:stop": "tsx ./scripts/helpers/stop-validator.mts",

--- a/scripts/helpers/generate-clients.mts
+++ b/scripts/helpers/generate-clients.mts
@@ -189,6 +189,14 @@ codama.update(
         };
       },
     },
+    {
+      // Use omitted optional account strategy for all instructions.
+      select: '[instructionNode]',
+      transform: (node) => {
+        c.assertIsNode(node, 'instructionNode');
+        return { ...node, optionalAccountStrategy: 'omitted' };
+      },
+    },
   ])
 );
 


### PR DESCRIPTION
When converting an Anchor IDL to a Codama IDL, the adapter defaults to using the `"programId"` optional account strategy for all instructions. This allows positional optional accounts as introduced in Anchor which means when an account is not provided, it is replaced by the program ID to only used a single byte in the transaction.

However, this is not the appropriate optional account strategy for the stake account as it simply omits optional accounts. Therefore, this PR replaces the `optionalAccountStrategy` of all instructions to the `"omitted"` strategy.

This in turns updates the generated code to be more accurate when creating and parsing instructions.

Note that, I've had to adjust the `generate:clients` script slightly so it calls `pnpm format:fix` because the Prettier used post-generation is slightly different now then the one we use in the `pnpm format` script. I'm not too sure why though, they both should use the same prettier configs but at least this brings us back to green on CI.