### PR TITLE
`StakeInstructionBuilder` as replacement for individual fns

### DIFF
--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -329,6 +329,7 @@ pub struct AuthorizeCheckedWithSeedArgs {
     pub authority_owner: Pubkey,
 }
 
+#[deprecated(since = "1.2.0", note = "Please use `StakeInstructionBuilder` instead")]
 #[cfg(feature = "bincode")]
 pub fn initialize(stake_pubkey: &Pubkey, authorized: &Authorized, lockup: &Lockup) -> Instruction {
     Instruction::new_with_bincode(
@@ -341,6 +342,7 @@ pub fn initialize(stake_pubkey: &Pubkey, authorized: &Authorized, lockup: &Locku
     )
 }
 
+#[deprecated(since = "1.2.0", note = "Please use `StakeInstructionBuilder` instead")]
 #[cfg(feature = "bincode")]
 pub fn initialize_checked(stake_pubkey: &Pubkey, authorized: &Authorized) -> Instruction {
     Instruction::new_with_bincode(
@@ -457,6 +459,7 @@ fn _split(
     Instruction::new_with_bincode(ID, &StakeInstruction::Split(lamports), account_metas)
 }
 
+#[deprecated(since = "1.2.0", note = "Please use `StakeInstructionBuilder` instead")]
 #[cfg(feature = "bincode")]
 pub fn split(
     stake_pubkey: &Pubkey,
@@ -479,6 +482,7 @@ pub fn split(
     ]
 }
 
+#[deprecated(since = "1.2.0", note = "Please use `StakeInstructionBuilder` instead")]
 #[cfg(feature = "bincode")]
 pub fn split_with_seed(
     stake_pubkey: &Pubkey,

--- a/interface/src/instruction_builder/initialize.rs
+++ b/interface/src/instruction_builder/initialize.rs
@@ -1,0 +1,141 @@
+use {
+    crate::instruction::StakeInstruction,
+    crate::program::ID,
+    crate::state::{Authorized, Lockup, StakeStateV2},
+    solana_instruction::{AccountMeta, Instruction},
+    solana_pubkey::Pubkey,
+};
+
+#[derive(Debug, Clone)]
+struct CreateAccountArgs<'a> {
+    from_pubkey: &'a Pubkey,
+    lamports: u64,
+}
+
+#[derive(Debug, Clone)]
+struct CreateAccountWithSeedArgs<'a> {
+    from_pubkey: &'a Pubkey,
+    base: &'a Pubkey,
+    seed: &'a str,
+    lamports: u64,
+}
+
+#[derive(Debug, Clone)]
+enum CreationInfo<'a> {
+    None,
+    Simple(CreateAccountArgs<'a>),
+    WithSeed(CreateAccountWithSeedArgs<'a>),
+}
+
+#[derive(Debug, Clone)]
+pub struct InitializeBuilder<'a> {
+    stake_pubkey: &'a Pubkey,
+    authorized: &'a Authorized,
+    lockup: &'a Lockup,
+    creation_info: CreationInfo<'a>,
+}
+
+impl<'a> InitializeBuilder<'a> {
+    pub fn new(stake_pubkey: &'a Pubkey, authorized: &'a Authorized, lockup: &'a Lockup) -> Self {
+        Self {
+            stake_pubkey,
+            authorized,
+            lockup,
+            creation_info: CreationInfo::None,
+        }
+    }
+
+    pub fn create_account(&mut self, from_pubkey: &'a Pubkey, lamports: u64) -> &mut Self {
+        self.creation_info = CreationInfo::Simple(CreateAccountArgs {
+            from_pubkey,
+            lamports,
+        });
+        self
+    }
+
+    pub fn create_account_with_seed(
+        &mut self,
+        from_pubkey: &'a Pubkey,
+        base: &'a Pubkey,
+        seed: &'a str,
+        lamports: u64,
+    ) -> &mut Self {
+        self.creation_info = CreationInfo::WithSeed(CreateAccountWithSeedArgs {
+            from_pubkey,
+            base,
+            seed,
+            lamports,
+        });
+        self
+    }
+
+    pub fn build(&self) -> Vec<Instruction> {
+        let mut ixs = Vec::new();
+
+        match &self.creation_info {
+            CreationInfo::Simple(args) => {
+                ixs.push(solana_system_interface::instruction::create_account(
+                    args.from_pubkey,
+                    self.stake_pubkey,
+                    args.lamports,
+                    StakeStateV2::size_of() as u64,
+                    &ID,
+                ));
+            }
+            CreationInfo::WithSeed(args) => {
+                ixs.push(
+                    solana_system_interface::instruction::create_account_with_seed(
+                        args.from_pubkey,
+                        self.stake_pubkey,
+                        args.base,
+                        args.seed,
+                        args.lamports,
+                        StakeStateV2::size_of() as u64,
+                        &ID,
+                    ),
+                );
+            }
+            CreationInfo::None => {}
+        }
+
+        let initialize_ix = Instruction::new_with_bincode(
+            ID,
+            &StakeInstruction::Initialize(*self.authorized, *self.lockup),
+            vec![
+                AccountMeta::new(*self.stake_pubkey, false),
+                AccountMeta::new_readonly(crate::instruction_builder::RENT_ID, false),
+            ],
+        );
+        ixs.push(initialize_ix);
+
+        ixs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instruction_builder::StakeInstructionBuilder;
+
+    #[test]
+    fn test_works() {
+        let from_pubkey = Pubkey::new_unique();
+        let stake_pubkey = Pubkey::new_unique();
+        let authorized = Authorized {
+            staker: from_pubkey,
+            withdrawer: from_pubkey,
+        };
+        let lockup = Lockup::default();
+        let lamports = 1_000_000_000;
+
+        let ixs = StakeInstructionBuilder::initialize(&stake_pubkey, &authorized, &lockup).build();
+
+        assert_eq!(ixs.len(), 1);
+
+        let ixs = StakeInstructionBuilder::initialize(&stake_pubkey, &authorized, &lockup)
+            .create_account(&from_pubkey, lamports)
+            .build();
+
+        assert_eq!(ixs.len(), 2);
+    }
+}

--- a/interface/src/instruction_builder/mod.rs
+++ b/interface/src/instruction_builder/mod.rs
@@ -1,0 +1,46 @@
+use {
+    crate::instruction_builder::initialize::InitializeBuilder,
+    crate::instruction_builder::split::SplitBuilder,
+    crate::state::{Authorized, Lockup},
+    solana_pubkey::Pubkey,
+};
+
+mod initialize;
+mod split;
+
+const RENT_ID: Pubkey = Pubkey::from_str_const("SysvarRent111111111111111111111111111111111");
+
+/// The entry point for building Stake Program instructions
+pub struct StakeInstructionBuilder;
+
+impl StakeInstructionBuilder {
+    pub fn initialize<'a>(
+        stake_pubkey: &'a Pubkey,
+        authorized: &'a Authorized,
+        lockup: &'a Lockup,
+    ) -> InitializeBuilder<'a> {
+        InitializeBuilder::new(stake_pubkey, authorized, lockup)
+    }
+
+    pub fn split<'a>(
+        stake_pubkey: &'a Pubkey,
+        stake_authority_pubkey: &'a Pubkey,
+        split_stake_pubkey: &'a Pubkey,
+        lamports: u64,
+    ) -> SplitBuilder<'a> {
+        SplitBuilder::new(
+            stake_pubkey,
+            stake_authority_pubkey,
+            split_stake_pubkey,
+            lamports,
+        )
+    }
+
+    // Would continue this pattern for all instructions
+    // ...
+    // ...
+    // ...
+    // ...
+    // ...
+    // ...
+}

--- a/interface/src/instruction_builder/split.rs
+++ b/interface/src/instruction_builder/split.rs
@@ -1,0 +1,96 @@
+use {
+    crate::instruction::StakeInstruction,
+    crate::program::ID,
+    crate::state::StakeStateV2,
+    solana_instruction::{AccountMeta, Instruction},
+    solana_pubkey::Pubkey,
+};
+
+#[derive(Debug, Clone)]
+struct AllocateWithSeedArgs<'a> {
+    base: &'a Pubkey,
+    seed: &'a str,
+}
+
+#[derive(Debug, Clone)]
+enum CreationInfo<'a> {
+    None,
+    AllocateAndAssign,
+    AllocateWithSeed(AllocateWithSeedArgs<'a>),
+}
+
+#[derive(Debug, Clone)]
+pub struct SplitBuilder<'a> {
+    stake_pubkey: &'a Pubkey,
+    stake_authority_pubkey: &'a Pubkey,
+    split_stake_pubkey: &'a Pubkey,
+    lamports: u64,
+    creation_info: CreationInfo<'a>,
+}
+
+impl<'a> SplitBuilder<'a> {
+    pub fn new(
+        stake_pubkey: &'a Pubkey,
+        stake_authority_pubkey: &'a Pubkey,
+        split_stake_pubkey: &'a Pubkey,
+        lamports: u64,
+    ) -> Self {
+        Self {
+            stake_pubkey,
+            stake_authority_pubkey,
+            split_stake_pubkey,
+            lamports,
+            creation_info: CreationInfo::None,
+        }
+    }
+
+    pub fn with_allocate_and_assign(&mut self) -> &mut Self {
+        self.creation_info = CreationInfo::AllocateAndAssign;
+        self
+    }
+
+    pub fn with_allocate_with_seed(&mut self, base: &'a Pubkey, seed: &'a str) -> &mut Self {
+        self.creation_info = CreationInfo::AllocateWithSeed(AllocateWithSeedArgs { base, seed });
+        self
+    }
+
+    pub fn build(&self) -> Vec<Instruction> {
+        let mut ixs = Vec::new();
+
+        match &self.creation_info {
+            CreationInfo::AllocateAndAssign => {
+                ixs.push(solana_system_interface::instruction::allocate(
+                    self.split_stake_pubkey,
+                    StakeStateV2::size_of() as u64,
+                ));
+                ixs.push(solana_system_interface::instruction::assign(
+                    self.split_stake_pubkey,
+                    &ID,
+                ));
+            }
+            CreationInfo::AllocateWithSeed(args) => {
+                ixs.push(solana_system_interface::instruction::allocate_with_seed(
+                    self.split_stake_pubkey,
+                    args.base,
+                    args.seed,
+                    StakeStateV2::size_of() as u64,
+                    &ID,
+                ));
+            }
+            CreationInfo::None => {}
+        }
+
+        let split_ix = Instruction::new_with_bincode(
+            ID,
+            &StakeInstruction::Split(self.lamports),
+            vec![
+                AccountMeta::new(*self.stake_pubkey, false),
+                AccountMeta::new(*self.split_stake_pubkey, false),
+                AccountMeta::new_readonly(*self.stake_authority_pubkey, true),
+            ],
+        );
+        ixs.push(split_ix);
+
+        ixs
+    }
+}

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -7,6 +7,8 @@
 pub mod config;
 pub mod error;
 pub mod instruction;
+#[cfg(feature = "bincode")]
+pub mod instruction_builder;
 pub mod stake_flags;
 pub mod stake_history;
 pub mod state;


### PR DESCRIPTION
Proposal to move the stake program's instruction building to a builder pattern allowing for more flexibility w/ variants.

```rust
StakeInstructionBuilder::initialize(&stake_pubkey, &authorized, &lockup)
  .create_account(&from_pubkey, lamports)
  .build();

StakeInstructionBuilder::split(&stake_pubkey, &stake_authority_pubkey, &split_stake_pubkey, split_lamports)
  .with_allocate_with_seed(&base, seed)
  .build()
```

== In progress ==