### PR TITLE
add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,53 @@
-# Stake
+# Stake Program
 
-<a href="https://github.com/solana-program/stake/actions/workflows/main.yml"><img src="https://img.shields.io/github/actions/workflow/status/solana-program/stake/main.yml?logo=GitHub" /></a>
-<a href="https://explorer.solana.com/address/Stake11111111111111111111111111111111111111"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolana-program%2Fstake%2Fmain%2Fprogram%2Fidl.json&query=%24.version&label=program&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzEzIiBoZWlnaHQ9IjI4MSIgdmlld0JveD0iMCAwIDMxMyAyODEiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMF80NzZfMjQzMCkiPgo8cGF0aCBkPSJNMzExLjMxOCAyMjEuMDU3TDI1OS42NiAyNzYuNTU4QzI1OC41MzcgMjc3Ljc2NCAyNTcuMTc4IDI3OC43MjUgMjU1LjY2OSAyNzkuMzgyQzI1NC4xNTkgMjgwLjAzOSAyNTIuNTMgMjgwLjM3OCAyNTAuODg0IDI4MC4zNzdINS45OTcxOUM0LjgyODcgMjgwLjM3NyAzLjY4NTY4IDI4MC4wMzUgMi43MDg1NSAyNzkuMzkzQzEuNzMxNDMgMjc4Ljc1MSAwLjk2Mjc3MSAyNzcuODM3IDAuNDk3MDIgMjc2Ljc2NEMwLjAzMTI2OTEgMjc1LjY5IC0wLjExMTI4NiAyNzQuNTA0IDAuMDg2ODcxMiAyNzMuMzVDMC4yODUwMjggMjcyLjE5NiAwLjgxNTI2NSAyNzEuMTI2IDEuNjEyNDMgMjcwLjI3TDUzLjMwOTkgMjE0Ljc2OUM1NC40Mjk5IDIxMy41NjYgNTUuNzg0MyAyMTIuNjA3IDU3LjI4OTMgMjExLjk1QzU4Ljc5NDMgMjExLjI5MyA2MC40MTc4IDIxMC45NTMgNjIuMDU5NSAyMTAuOTVIMzA2LjkzM0MzMDguMTAxIDIxMC45NSAzMDkuMjQ0IDIxMS4yOTIgMzEwLjIyMSAyMTEuOTM0QzMxMS4xOTkgMjEyLjU3NiAzMTEuOTY3IDIxMy40OSAzMTIuNDMzIDIxNC41NjRDMzEyLjg5OSAyMTUuNjM3IDMxMy4wNDEgMjE2LjgyNCAzMTIuODQzIDIxNy45NzdDMzEyLjY0NSAyMTkuMTMxIDMxMi4xMTUgMjIwLjIwMSAzMTEuMzE4IDIyMS4wNTdaTTI1OS42NiAxMDkuMjk0QzI1OC41MzcgMTA4LjA4OCAyNTcuMTc4IDEwNy4xMjcgMjU1LjY2OSAxMDYuNDdDMjU0LjE1OSAxMDUuODEzIDI1Mi41MyAxMDUuNDc0IDI1MC44ODQgMTA1LjQ3NUg1Ljk5NzE5QzQuODI4NyAxMDUuNDc1IDMuNjg1NjggMTA1LjgxNyAyLjcwODU1IDEwNi40NTlDMS43MzE0MyAxMDcuMTAxIDAuOTYyNzcxIDEwOC4wMTUgMC40OTcwMiAxMDkuMDg4QzAuMDMxMjY5MSAxMTAuMTYyIC0wLjExMTI4NiAxMTEuMzQ4IDAuMDg2ODcxMiAxMTIuNTAyQzAuMjg1MDI4IDExMy42NTYgMC44MTUyNjUgMTE0LjcyNiAxLjYxMjQzIDExNS41ODJMNTMuMzA5OSAxNzEuMDgzQzU0LjQyOTkgMTcyLjI4NiA1NS43ODQzIDE3My4yNDUgNTcuMjg5MyAxNzMuOTAyQzU4Ljc5NDMgMTc0LjU1OSA2MC40MTc4IDE3NC44OTkgNjIuMDU5NSAxNzQuOTAySDMwNi45MzNDMzA4LjEwMSAxNzQuOTAyIDMwOS4yNDQgMTc0LjU2IDMxMC4yMjEgMTczLjkxOEMzMTEuMTk5IDE3My4yNzYgMzExLjk2NyAxNzIuMzYyIDMxMi40MzMgMTcxLjI4OEMzMTIuODk5IDE3MC4yMTUgMzEzLjA0MSAxNjkuMDI4IDMxMi44NDMgMTY3Ljg3NUMzMTIuNjQ1IDE2Ni43MjEgMzEyLjExNSAxNjUuNjUxIDMxMS4zMTggMTY0Ljc5NUwyNTkuNjYgMTA5LjI5NFpNNS45OTcxOSA2OS40MjY3SDI1MC44ODRDMjUyLjUzIDY5LjQyNzUgMjU0LjE1OSA2OS4wODkgMjU1LjY2OSA2OC40MzJDMjU3LjE3OCA2Ny43NzUxIDI1OC41MzcgNjYuODEzOSAyNTkuNjYgNjUuNjA4MkwzMTEuMzE4IDEwLjEwNjlDMzEyLjExNSA5LjI1MTA3IDMxMi42NDUgOC4xODA1NiAzMTIuODQzIDcuMDI2OTVDMzEzLjA0MSA1Ljg3MzM0IDMxMi44OTkgNC42ODY4NiAzMTIuNDMzIDMuNjEzM0MzMTEuOTY3IDIuNTM5NzQgMzExLjE5OSAxLjYyNTg2IDMxMC4yMjEgMC45ODM5NDFDMzA5LjI0NCAwLjM0MjAyNiAzMDguMTAxIDMuOTUzMTRlLTA1IDMwNi45MzMgMEw2Mi4wNTk1IDBDNjAuNDE3OCAwLjAwMjc5ODY2IDU4Ljc5NDMgMC4zNDMxNCA1Ny4yODkzIDAuOTk5OTUzQzU1Ljc4NDMgMS42NTY3NyA1NC40Mjk5IDIuNjE2MDcgNTMuMzA5OSAzLjgxODQ3TDEuNjI1NzYgNTkuMzE5N0MwLjgyOTM2MSA2MC4xNzQ4IDAuMjk5MzU5IDYxLjI0NCAwLjEwMDc1MiA2Mi4zOTY0Qy0wLjA5Nzg1MzkgNjMuNTQ4OCAwLjA0MzU2OTggNjQuNzM0MiAwLjUwNzY3OSA2NS44MDczQzAuOTcxNzg5IDY2Ljg4MDMgMS43Mzg0MSA2Ny43OTQzIDIuNzEzNTIgNjguNDM3MkMzLjY4ODYzIDY5LjA4MDIgNC44Mjk4NCA2OS40MjQgNS45OTcxOSA2OS40MjY3WiIgZmlsbD0idXJsKCNwYWludDBfbGluZWFyXzQ3Nl8yNDMwKSIvPgo8L2c+CjxkZWZzPgo8bGluZWFyR3JhZGllbnQgaWQ9InBhaW50MF9saW5lYXJfNDc2XzI0MzAiIHgxPSIyNi40MTUiIHkxPSIyODcuMDU5IiB4Mj0iMjgzLjczNSIgeTI9Ii0yLjQ5NTc0IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+CjxzdG9wIG9mZnNldD0iMC4wOCIgc3RvcC1jb2xvcj0iIzk5NDVGRiIvPgo8c3RvcCBvZmZzZXQ9IjAuMyIgc3RvcC1jb2xvcj0iIzg3NTJGMyIvPgo8c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzU0OTdENSIvPgo8c3RvcCBvZmZzZXQ9IjAuNiIgc3RvcC1jb2xvcj0iIzQzQjRDQSIvPgo8c3RvcCBvZmZzZXQ9IjAuNzIiIHN0b3AtY29sb3I9IiMyOEUwQjkiLz4KPHN0b3Agb2Zmc2V0PSIwLjk3IiBzdG9wLWNvbG9yPSIjMTlGQjlCIi8+CjwvbGluZWFyR3JhZGllbnQ+CjxjbGlwUGF0aCBpZD0iY2xpcDBfNDc2XzI0MzAiPgo8cmVjdCB3aWR0aD0iMzEyLjkzIiBoZWlnaHQ9IjI4MC4zNzciIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==&color=9945FF" /></a>
-<a href="https://www.npmjs.com/package/@solana-program/stake"><img src="https://img.shields.io/npm/v/%40solana-program%2Fstake?logo=npm&color=377CC0" /></a>
-<a href="https://crates.io/crates/solana-stake-client"><img src="https://img.shields.io/crates/v/solana-stake-client?logo=rust" /></a>
+Solana Core BPF Stake Program.
 
-This template should help get you started developing Solana programs. Let's walk through this generated program repository and see what's included.
+| Information | Account Address |
+| --- | --- |
+| Stake Program | `Stake11111111111111111111111111111111111111` |
 
-## Project setup
+## Overview
 
-The first thing you'll want to do is install NPM dependencies which will allow you to access all the scripts and tools provided by this template.
+This repository contains the BPF port of the native Agave Stake Program, along with the official Rust interface and Codama-generated Rust and Javascript clients for interacting with it. The Stake Program is what allows stake accounts to be created, delegated, split, merged, and so forth.
 
-```sh
-pnpm install
-```
+Historically, the Stake Program was built into the Agave validator client as a pseudo-program. This would necessitate that any future validator client reimplement it exactly. To ease the development of new validator clients, the Stake Program has been converted to an ordinary BPF program which can be invoked like any normal program. This BPF Stake Program is now live on all clusters.
 
-## Managing programs
+## Security Audits
 
-You'll notice a `program` folder in the root of this repository. This is where your generated Solana program is located.
+The BPF Stake Program has received one external audit:
 
-Whilst only one program gets generated, note that you can have as many programs as you like in this repository.
-Whenever you add a new program folder to this repository, remember to add it to the `members` array of your root `Cargo.toml` file.
-That way, your programs will be recognized by the following scripts that allow you to build, test, format and lint your programs respectively.
+* Zellic (2025-03-12)
+    - Review commit hash [`5ec49ccb`](https://github.com/solana-program/stake/commit/5ec49ccb08c3e588940a2038c99efc7acf563b4a)
+    - Final report (todo)
 
-```sh
-pnpm program:build
-pnpm programs:test
-pnpm programs:format
-pnpm programs:lint
-```
+## Interface
 
-## Generating IDLs
+Instructions, errors, and assorted structs related to the stake program, which used to live in the Solana SDK repo, now live here. For more, see [docs.rs](https://docs.rs/solana-stake-interface/latest/solana_stake_interface/).
 
-You may use the following command to generate the IDLs for your programs.
+## Compute Units
 
-```sh
-pnpm generate:idls
-```
+Previously, the Stake Program was essentially free, costing 1500 Compute Units irrespective of any work the program actually did. As a normal BPF program, the Stake Program now pays Compute Units as any other program.
 
-Depending on your program's framework, this will either use Shank or Anchor to generate the IDLs.
-Note that, to ensure IDLs are generated using the correct framework version, the specific version used by the program will be downloaded and used locally.
+For the initial 1.0.0 release, we followed the existing Agave code as closely as possible, to minimize the possibility of introducing any bugs or changing any behaviors in the port because of the total rewrite of the calling interface the port necessitated. This means the existing program is expected to be non-optimal. With the ability to test more thoroughly against this 1.0.0 version, we expect to be able to optimize these costs in the future.
 
-## Generating clients
+Based on the sample invocations in `program/tests/interface.rs`, approximate costs as of 2025-07-28 are as follows. These should be treated as baselines and are rounded to thousands; instructions may do less or more work depending on arguments and account states.
 
-Once your programs' IDLs have been generated, you can generate clients for them using the following command.
-
-```sh
-pnpm generate:clients
-```
-
-Alternatively, you can use the `generate` script to generate both the IDLs and the clients at once.
-
-```sh
-pnpm generate
-```
-
-## Managing clients
-
-The following clients are available for your programs. You may use the following links to learn more about each client.
-
-- [JS client](./clients/js)
-- [Rust client](./clients/rust)
-
-## Starting and stopping the local validator
-
-The following script is available to start your local validator.
-
-```sh
-pnpm validator:start
-```
-
-By default, if a local validator is already running, the script will be skipped. You may use the `validator:restart` script instead to force the validator to restart.
-
-```sh
-pnpm validator:restart
-```
-
-Finally, you may stop the local validator using the following command.
-
-```sh
-pnpm validator:stop
-```
-
-## Using external programs in your validator
-
-If your program requires any external programs to be running, you'll want to in your local validator.
-
-You can do this by adding their program addresses to the `program-dependencies` array in the `Cargo.toml` of your program.
-
-```toml
-program-dependencies = [
-  "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
-  "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV",
-]
-```
-
-Next time you build your program and run your validator, these external programs will automatically be fetched from mainnet and used in your local validator.
-
-```sh
-pnpm program:build
-pnpm validator:restart
-```
+| Instruction | Estimated Cost |
+| --- | --- |
+| `Initialize` | 9000 |
+| `Authorize` | 12000 |
+| `DelegateStake` | 15000 |
+| `Split` | 20000 |
+| `Withdraw` | 8000 |
+| `Deactivate` | 13000 |
+| `SetLockup` | 11000 |
+| `Merge` | 21000 |
+| `AuthorizeWithSeed` | 14000 |
+| `InitializeChecked` | 6000 |
+| `AuthorizeChecked` | 12000 |
+| `AuthorizeCheckedWithSeed` | 14000 |
+| `SetLockupChecked` | 11000 |
+| `GetMinimumDelegation` | (negligible) |
+| `DeactivateDelinquent` | 18000 |
+| `MoveStake` | 25000 |
+| `MoveLamports` | 15000 |


### PR DESCRIPTION
honestly had writers block on this because i expected to crib from the other core bpf program readmes but they dont exist yet either. i mostly followed the format of the spl single pool docs. far from perfect but we want something up, especially given the compute unit situation

i pinged zellic for the audit pdf and will add it to https://github.com/anza-xyz/security-audits/ and link it here once i have it

i would ignore the (unreadably interleaved) diff and just look at the raw file, i deleted everything and started from scratch

closes #29 