### PR TITLE
deps: Bump sdk v3 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,10 +60,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e4bb8842e634f00f7f56bed7fcf67464bf2689378b3977350a8d0e6918a1ea"
 dependencies = [
  "ahash 0.8.11",
- "solana-epoch-schedule",
- "solana-hash",
- "solana-pubkey",
- "solana-sha256-hasher",
+ "solana-epoch-schedule 2.2.1",
+ "solana-hash 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sha256-hasher 2.2.1",
  "solana-svm-feature-set",
 ]
 
@@ -96,8 +96,8 @@ dependencies = [
  "solana-ed25519-program",
  "solana-message",
  "solana-precompile-error",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-secp256k1-program",
  "solana-secp256r1-program",
 ]
@@ -109,8 +109,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2343e5e83d2a33f965dd2fd18840351d821de9a5a427880a05069cc60ec18a81"
 dependencies = [
  "agave-feature-set",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
 ]
 
 [[package]]
@@ -119,11 +119,11 @@ version = "2.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd48ceb336d71d199015f825802824d28ebcda5c0c9e4c062fb3b93781f0583"
 dependencies = [
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-message",
  "solana-packet",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-short-vec",
  "solana-signature",
  "solana-svm-transaction",
@@ -641,6 +641,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxcar"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c4925bc979b677330a8c7fe7a8c94af2dbb4a2d37b4a20a80d884400f46baa"
+
+[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1094,7 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
  "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -2553,31 +2560,31 @@ dependencies = [
  "mollusk-svm-error",
  "mollusk-svm-keys",
  "mollusk-svm-result",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-bpf-loader-program",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-compute-budget",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-hash",
- "solana-instruction",
+ "solana-epoch-rewards 2.2.1",
+ "solana-epoch-schedule 2.2.1",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-loader-v3-interface 3.0.0",
  "solana-loader-v4-interface",
  "solana-log-collector",
  "solana-logger",
  "solana-precompile-error",
- "solana-program-error",
+ "solana-program-error 2.2.1",
  "solana-program-runtime",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-slot-hashes",
- "solana-stake-interface",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
+ "solana-sdk-ids 2.2.1",
+ "solana-slot-hashes 2.2.1",
+ "solana-stake-interface 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-stake-program 2.3.6",
  "solana-svm-callback",
  "solana-system-program",
- "solana-sysvar",
- "solana-sysvar-id",
+ "solana-sysvar 2.2.2",
+ "solana-sysvar-id 2.2.1",
  "solana-timings",
  "solana-transaction-context",
 ]
@@ -2588,7 +2595,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2443a68c1f91e3ed4ac014b17a438cbcf976e636f0ad1e613c49873ee2e764"
 dependencies = [
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "thiserror 1.0.69",
 ]
 
@@ -2599,9 +2606,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55f53f00fc28aa0561e04088fe90115fc2f348c3380adc9500de2a2b62b4d0ff"
 dependencies = [
  "mollusk-svm-error",
- "solana-account",
- "solana-instruction",
- "solana-pubkey",
+ "solana-account 2.2.1",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
  "solana-transaction-context",
 ]
 
@@ -2611,11 +2618,11 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b25a23a80c4273f698c595fa10f969050effca7bb2ecee2df72c956f582b174a"
 dependencies = [
- "solana-account",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
+ "solana-account 2.2.1",
+ "solana-instruction 2.3.0",
+ "solana-program-error 2.2.1",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
 ]
 
 [[package]]
@@ -3863,6 +3870,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,12 +4047,30 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "solana-account-info",
- "solana-clock",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-sysvar",
+ "solana-account-info 2.2.1",
+ "solana-clock 2.2.2",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
+ "solana-sysvar 2.2.2",
+]
+
+[[package]]
+name = "solana-account"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f885ce7f937871ecb56aadbeaaec963b234a580b7d6ebbdb8fa4249a36f92433"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-account-info 3.0.0",
+ "solana-clock 3.0.0",
+ "solana-instruction-error",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-sysvar 3.0.0",
 ]
 
 [[package]]
@@ -4034,8 +4084,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account",
- "solana-pubkey",
+ "solana-account 2.2.1",
+ "solana-pubkey 2.4.0",
  "zstd",
 ]
 
@@ -4047,9 +4097,20 @@ checksum = "e0c17d606a298a205fae325489fbed88ee6dc4463c111672172327e741c8905d"
 dependencies = [
  "bincode",
  "serde",
- "solana-program-error",
- "solana-program-memory",
- "solana-pubkey",
+ "solana-program-error 2.2.1",
+ "solana-program-memory 2.2.1",
+ "solana-pubkey 2.4.0",
+]
+
+[[package]]
+name = "solana-account-info"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f4691b69b172c687d218dd2f1f23fc7ea5e9aa79df9ac26dab3d8dd829ce48"
+dependencies = [
+ "solana-program-error 3.0.0",
+ "solana-program-memory 3.0.0",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -4084,28 +4145,28 @@ dependencies = [
  "serde_derive",
  "slab",
  "smallvec",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-address-lookup-table-interface",
  "solana-bucket-map",
- "solana-clock",
- "solana-epoch-schedule",
- "solana-fee-calculator",
+ "solana-clock 2.2.2",
+ "solana-epoch-schedule 2.2.1",
+ "solana-fee-calculator 2.2.1",
  "solana-genesis-config",
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-lattice-hash",
  "solana-measure",
  "solana-message",
  "solana-metrics",
  "solana-nohash-hasher",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-rayon-threadlimit",
  "solana-rent-collector",
  "solana-reward-info",
- "solana-sha256-hasher",
- "solana-slot-hashes",
+ "solana-sha256-hasher 2.2.1",
+ "solana-slot-hashes 2.2.1",
  "solana-svm-transaction",
- "solana-system-interface",
- "solana-sysvar",
+ "solana-system-interface 1.0.0",
+ "solana-sysvar 2.2.2",
  "solana-time-utils",
  "solana-transaction",
  "solana-transaction-context",
@@ -4118,6 +4179,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-address"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7a457086457ea9db9a5199d719dc8734dc2d0342fad0d8f77633c31eb62f19"
+dependencies = [
+ "borsh 1.5.7",
+ "five8",
+ "five8_const",
+ "serde",
+ "serde_derive",
+ "solana-atomic-u64 3.0.0",
+ "solana-define-syscall 3.0.0",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-program-error 3.0.0",
+ "solana-sanitize 3.0.0",
+ "solana-sha256-hasher 3.0.0",
+]
+
+[[package]]
 name = "solana-address-lookup-table-interface"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,11 +4208,11 @@ dependencies = [
  "bytemuck",
  "serde",
  "serde_derive",
- "solana-clock",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-slot-hashes",
+ "solana-clock 2.2.2",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
+ "solana-slot-hashes 2.2.1",
 ]
 
 [[package]]
@@ -4144,6 +4225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-atomic-u64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a933ff1e50aff72d02173cfcd7511bd8540b027ee720b75f353f594f834216d0"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "solana-banks-client"
 version = "2.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4151,17 +4241,17 @@ checksum = "9f5171881f7f7efa72b94bbac33f8fc54f913bc8f87b1937f34ef922d2f50dce"
 dependencies = [
  "borsh 1.5.7",
  "futures",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-banks-interface",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-commitment-config",
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-message",
  "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
  "solana-signature",
- "solana-sysvar",
+ "solana-sysvar 2.2.2",
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
@@ -4179,12 +4269,12 @@ checksum = "d565122efb0e1929f6c6d34e92ccca46d5f0045328622d738037da24c91c9d1b"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-account",
- "solana-clock",
+ "solana-account 2.2.1",
+ "solana-clock 2.2.2",
  "solana-commitment-config",
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-message",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-context",
@@ -4202,14 +4292,14 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-banks-interface",
  "solana-client",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-commitment-config",
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-message",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-send-transaction-service",
@@ -4230,7 +4320,7 @@ checksum = "75db7f2bbac3e62cfd139065d15bcda9e2428883ba61fc8d27ccb251081e7567"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
- "solana-define-syscall",
+ "solana-define-syscall 2.3.0",
 ]
 
 [[package]]
@@ -4241,7 +4331,7 @@ checksum = "19a3787b8cf9c9fe3dd360800e8b70982b9e5a8af9e11c354b6665dd4a003adc"
 dependencies = [
  "bincode",
  "serde",
- "solana-instruction",
+ "solana-instruction 2.3.0",
 ]
 
 [[package]]
@@ -4251,9 +4341,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a0801e25a1b31a14494fc80882a036be0ffd290efc4c2d640bfcca120a4672"
 dependencies = [
  "blake3",
- "solana-define-syscall",
- "solana-hash",
- "solana-sanitize",
+ "solana-define-syscall 2.3.0",
+ "solana-hash 2.3.0",
+ "solana-sanitize 2.2.1",
 ]
 
 [[package]]
@@ -4267,7 +4357,7 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "bytemuck",
- "solana-define-syscall",
+ "solana-define-syscall 2.3.0",
  "thiserror 2.0.12",
 ]
 
@@ -4282,6 +4372,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-borsh"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc402b16657abbfa9991cd5cbfac5a11d809f7e7d28d3bb291baeb088b39060e"
+dependencies = [
+ "borsh 1.5.7",
+]
+
+[[package]]
 name = "solana-bpf-loader-program"
 version = "2.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4292,17 +4391,17 @@ dependencies = [
  "num-traits",
  "qualifier_attr",
  "scopeguard",
- "solana-account",
- "solana-account-info",
+ "solana-account 2.2.1",
+ "solana-account-info 2.2.1",
  "solana-big-mod-exp",
  "solana-bincode",
  "solana-blake3-hasher",
  "solana-bn254",
- "solana-clock",
- "solana-cpi",
+ "solana-clock 2.2.2",
+ "solana-cpi 2.2.1",
  "solana-curve25519",
- "solana-hash",
- "solana-instruction",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-keccak-hasher",
  "solana-loader-v3-interface 5.0.0",
  "solana-loader-v4-interface",
@@ -4310,18 +4409,18 @@ dependencies = [
  "solana-measure",
  "solana-packet",
  "solana-poseidon",
- "solana-program-entrypoint",
+ "solana-program-entrypoint 2.2.1",
  "solana-program-runtime",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-sbpf",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
  "solana-secp256k1-recover",
- "solana-sha256-hasher",
- "solana-stable-layout",
+ "solana-sha256-hasher 2.2.1",
+ "solana-stable-layout 2.2.1",
  "solana-svm-feature-set",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
+ "solana-system-interface 1.0.0",
+ "solana-sysvar 2.2.2",
+ "solana-sysvar-id 2.2.1",
  "solana-timings",
  "solana-transaction-context",
  "solana-type-overrides",
@@ -4341,9 +4440,9 @@ dependencies = [
  "modular-bitfield",
  "num_enum",
  "rand 0.8.5",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-measure",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "tempfile",
 ]
 
@@ -4356,11 +4455,11 @@ dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-loader-v4-program",
  "solana-program-runtime",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-stake-program 2.3.6",
  "solana-system-program",
  "solana-vote-program",
@@ -4380,8 +4479,8 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
  "solana-loader-v4-program",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-stake-program 2.3.6",
  "solana-system-program",
  "solana-vote-program",
@@ -4403,17 +4502,17 @@ dependencies = [
  "log",
  "quinn",
  "rayon",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-client-traits",
  "solana-commitment-config",
  "solana-connection-cache",
  "solana-epoch-info",
- "solana-hash",
- "solana-instruction",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-keypair",
  "solana-measure",
  "solana-message",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-pubsub-client",
  "solana-quic-client",
  "solana-quic-definitions",
@@ -4439,17 +4538,17 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83f0071874e629f29e0eb3dab8a863e98502ac7aba55b7e0df1803fc5cac72a7"
 dependencies = [
- "solana-account",
+ "solana-account 2.2.1",
  "solana-commitment-config",
  "solana-epoch-info",
- "solana-hash",
- "solana-instruction",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-keypair",
  "solana-message",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 1.0.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -4462,9 +4561,22 @@ checksum = "1bb482ab70fced82ad3d7d3d87be33d466a3498eb8aa856434ff3c0dfc2e2e31"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
+ "solana-sdk-ids 2.2.1",
+ "solana-sdk-macro 2.2.1",
+ "solana-sysvar-id 2.2.1",
+]
+
+[[package]]
+name = "solana-clock"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb62e9381182459a4520b5fe7fb22d423cae736239a6427fc398a88743d0ed59"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids 3.0.0",
+ "solana-sdk-macro 3.0.0",
+ "solana-sysvar-id 3.0.0",
 ]
 
 [[package]]
@@ -4475,7 +4587,7 @@ checksum = "7ace9fea2daa28354d107ea879cff107181d85cd4e0f78a2bedb10e1a428c97e"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash",
+ "solana-hash 2.3.0",
 ]
 
 [[package]]
@@ -4506,14 +4618,14 @@ checksum = "736870acb9ea636ad321b31074ce6e64e5ce51973c05afd8ed38da7531d572a4"
 dependencies = [
  "agave-feature-set",
  "log",
- "solana-borsh",
+ "solana-borsh 2.2.1",
  "solana-builtins-default-costs",
  "solana-compute-budget",
  "solana-compute-budget-interface",
- "solana-instruction",
+ "solana-instruction 2.3.0",
  "solana-packet",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-svm-transaction",
  "solana-transaction-error",
  "thiserror 2.0.12",
@@ -4528,8 +4640,8 @@ dependencies = [
  "borsh 1.5.7",
  "serde",
  "serde_derive",
- "solana-instruction",
- "solana-sdk-ids",
+ "solana-instruction 2.3.0",
+ "solana-sdk-ids 2.2.1",
 ]
 
 [[package]]
@@ -4549,8 +4661,8 @@ checksum = "3fbdbcfedb467322ac9686ca61da0a1fdede2fd99a01fb2ed52b49452abd22e0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-short-vec",
 ]
 
@@ -4600,20 +4712,20 @@ dependencies = [
  "ahash 0.8.11",
  "log",
  "solana-bincode",
- "solana-borsh",
+ "solana-borsh 2.2.1",
  "solana-builtins-default-costs",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
  "solana-fee-structure",
  "solana-metrics",
  "solana-packet",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-runtime-transaction",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 1.0.0",
  "solana-transaction-error",
  "solana-vote-program",
 ]
@@ -4624,12 +4736,26 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dc71126edddc2ba014622fc32d0f5e2e78ec6c5a1e0eb511b85618c09e9ea11"
 dependencies = [
- "solana-account-info",
- "solana-define-syscall",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-stable-layout",
+ "solana-account-info 2.2.1",
+ "solana-define-syscall 2.3.0",
+ "solana-instruction 2.3.0",
+ "solana-program-error 2.2.1",
+ "solana-pubkey 2.4.0",
+ "solana-stable-layout 2.2.1",
+]
+
+[[package]]
+name = "solana-cpi"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16238feb63d1cbdf915fb287f29ef7a7ebf81469bd6214f8b72a53866b593f8f"
+dependencies = [
+ "solana-account-info 3.0.0",
+ "solana-define-syscall 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-program-error 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-stable-layout 3.0.0",
 ]
 
 [[package]]
@@ -4641,7 +4767,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-define-syscall",
+ "solana-define-syscall 2.3.0",
  "subtle",
  "thiserror 2.0.12",
 ]
@@ -4660,6 +4786,12 @@ name = "solana-define-syscall"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae3e2abcf541c8122eafe9a625d4d194b4023c20adde1e251f94e056bb1aee2"
+
+[[package]]
+name = "solana-define-syscall"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
 
 [[package]]
 name = "solana-derivation-path"
@@ -4682,9 +4814,9 @@ dependencies = [
  "bytemuck_derive",
  "ed25519-dalek",
  "solana-feature-set",
- "solana-instruction",
+ "solana-instruction 2.3.0",
  "solana-precompile-error",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
 ]
 
 [[package]]
@@ -4705,10 +4837,24 @@ checksum = "86b575d3dd323b9ea10bb6fe89bf6bf93e249b215ba8ed7f68f1a3633f384db7"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
+ "solana-hash 2.3.0",
+ "solana-sdk-ids 2.2.1",
+ "solana-sdk-macro 2.2.1",
+ "solana-sysvar-id 2.2.1",
+]
+
+[[package]]
+name = "solana-epoch-rewards"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b319a4ed70390af911090c020571f0ff1f4ec432522d05ab89f5c08080381995"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-hash 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-sdk-macro 3.0.0",
+ "solana-sysvar-id 3.0.0",
 ]
 
 [[package]]
@@ -4718,8 +4864,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c5fd2662ae7574810904585fd443545ed2b568dbd304b25a31e79ccc76e81b"
 dependencies = [
  "siphasher 0.3.11",
- "solana-hash",
- "solana-pubkey",
+ "solana-hash 2.3.0",
+ "solana-pubkey 2.4.0",
 ]
 
 [[package]]
@@ -4730,9 +4876,22 @@ checksum = "3fce071fbddecc55d727b1d7ed16a629afe4f6e4c217bc8d00af3b785f6f67ed"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
+ "solana-sdk-ids 2.2.1",
+ "solana-sdk-macro 2.2.1",
+ "solana-sysvar-id 2.2.1",
+]
+
+[[package]]
+name = "solana-epoch-schedule"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5481e72cc4d52c169db73e4c0cd16de8bc943078aac587ec4817a75cc6388f"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids 3.0.0",
+ "solana-sdk-macro 3.0.0",
+ "solana-sysvar-id 3.0.0",
 ]
 
 [[package]]
@@ -4744,15 +4903,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-hash",
- "solana-instruction",
+ "solana-clock 2.2.2",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-keccak-hasher",
  "solana-message",
  "solana-nonce",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
+ "solana-system-interface 1.0.0",
  "thiserror 2.0.12",
 ]
 
@@ -4765,14 +4924,14 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-account",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-system-interface",
+ "solana-account 2.2.1",
+ "solana-account-info 2.2.1",
+ "solana-instruction 2.3.0",
+ "solana-program-error 2.2.1",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
+ "solana-sdk-ids 2.2.1",
+ "solana-system-interface 1.0.0",
 ]
 
 [[package]]
@@ -4783,10 +4942,10 @@ checksum = "89e1d3b52b4a014efeaaab67f14e40af3972a4be61c523d612860db8e3145529"
 dependencies = [
  "ahash 0.8.11",
  "lazy_static",
- "solana-epoch-schedule",
- "solana-hash",
- "solana-pubkey",
- "solana-sha256-hasher",
+ "solana-epoch-schedule 2.2.1",
+ "solana-hash 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sha256-hasher 2.2.1",
 ]
 
 [[package]]
@@ -4812,6 +4971,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-fee-calculator"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a73cc03ca4bed871ca174558108835f8323e85917bb38b9c81c7af2ab853efe"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "solana-fee-structure"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4825,12 +4995,15 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685197cf2304e5d26973c72286abb8eb503eede4555b05dbe853d236fd74132c"
+checksum = "f19aad3b79cf84cd24de85e711ed1718de1e5bf46a710fa73179efa6a117d707"
 dependencies = [
+ "boxcar",
  "bs58",
  "bv",
+ "bytes",
+ "dashmap",
  "im",
  "log",
  "memmap2 0.5.10",
@@ -4844,9 +5017,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83f88a126213cbcb57672c5e70ddb9791eff9b480e9f39fe9285fd2abca66fa"
+checksum = "d42809b90c84963eb5f2e17afafb1384892341b0d8ec12ae8f4a8c69a96138e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4864,21 +5037,21 @@ dependencies = [
  "memmap2 0.5.10",
  "serde",
  "serde_derive",
- "solana-account",
- "solana-clock",
+ "solana-account 2.2.1",
+ "solana-clock 2.2.2",
  "solana-cluster-type",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-hash",
+ "solana-epoch-schedule 2.2.1",
+ "solana-fee-calculator 2.2.1",
+ "solana-hash 2.3.0",
  "solana-inflation",
  "solana-keypair",
  "solana-logger",
  "solana-native-token",
  "solana-poh-config",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-sha256-hasher",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
+ "solana-sdk-ids 2.2.1",
+ "solana-sha256-hasher 2.2.1",
  "solana-shred-version",
  "solana-signer",
  "solana-time-utils",
@@ -4907,9 +5080,24 @@ dependencies = [
  "js-sys",
  "serde",
  "serde_derive",
- "solana-atomic-u64",
- "solana-sanitize",
+ "solana-atomic-u64 2.2.1",
+ "solana-sanitize 2.2.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-hash"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a063723b9e84c14d8c0d2cdf0268207dc7adecf546e31251f9e07c7b00b566c"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+ "five8",
+ "serde",
+ "serde_derive",
+ "solana-atomic-u64 3.0.0",
+ "solana-sanitize 3.0.0",
 ]
 
 [[package]]
@@ -4935,11 +5123,36 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-define-syscall",
+ "solana-define-syscall 2.3.0",
+ "solana-pubkey 2.4.0",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-instruction"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df4e8fcba01d7efa647ed20a081c234475df5e11a93acb4393cc2c9a7b99bab"
+dependencies = [
+ "bincode",
+ "borsh 1.5.7",
+ "serde",
+ "serde_derive",
+ "solana-define-syscall 3.0.0",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-pubkey",
- "wasm-bindgen",
+ "solana-instruction-error",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "solana-instruction-error"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f0d483b8ae387178d9210e0575b666b05cdd4bd0f2f188128249f6e454d39d"
+dependencies = [
+ "num-traits",
+ "solana-program-error 3.0.0",
 ]
 
 [[package]]
@@ -4949,14 +5162,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0e85a6fad5c2d0c4f5b91d34b8ca47118fc593af706e523cdbedf846a954f57"
 dependencies = [
  "bitflags",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-ids",
+ "solana-account-info 2.2.1",
+ "solana-instruction 2.3.0",
+ "solana-program-error 2.2.1",
+ "solana-pubkey 2.4.0",
+ "solana-sanitize 2.2.1",
+ "solana-sdk-ids 2.2.1",
  "solana-serialize-utils",
- "solana-sysvar-id",
+ "solana-sysvar-id 2.2.1",
 ]
 
 [[package]]
@@ -4966,9 +5179,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7aeb957fbd42a451b99235df4942d96db7ef678e8d5061ef34c9b34cae12f79"
 dependencies = [
  "sha3",
- "solana-define-syscall",
- "solana-hash",
- "solana-sanitize",
+ "solana-define-syscall 2.3.0",
+ "solana-hash 2.3.0",
+ "solana-sanitize 2.2.1",
 ]
 
 [[package]]
@@ -4982,7 +5195,7 @@ dependencies = [
  "ed25519-dalek-bip32",
  "rand 0.7.3",
  "solana-derivation-path",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
@@ -4998,9 +5211,22 @@ checksum = "4a6360ac2fdc72e7463565cd256eedcf10d7ef0c28a1249d261ec168c1b55cdd"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
+ "solana-sdk-ids 2.2.1",
+ "solana-sdk-macro 2.2.1",
+ "solana-sysvar-id 2.2.1",
+]
+
+[[package]]
+name = "solana-last-restart-slot"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcda154ec827f5fc1e4da0af3417951b7e9b8157540f81f936c4a8b1156134d0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids 3.0.0",
+ "solana-sdk-macro 3.0.0",
+ "solana-sysvar-id 3.0.0",
 ]
 
 [[package]]
@@ -5024,9 +5250,9 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
 ]
 
 [[package]]
@@ -5038,10 +5264,10 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
+ "solana-system-interface 1.0.0",
 ]
 
 [[package]]
@@ -5053,10 +5279,10 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
+ "solana-system-interface 1.0.0",
 ]
 
 [[package]]
@@ -5068,10 +5294,10 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
+ "solana-system-interface 1.0.0",
 ]
 
 [[package]]
@@ -5082,19 +5308,19 @@ checksum = "3200cc1e57efa2d18f370dd828d26106fe9e4b01332272ed3fb5d005a0edee52"
 dependencies = [
  "log",
  "qualifier_attr",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-bincode",
  "solana-bpf-loader-program",
- "solana-instruction",
+ "solana-instruction 2.3.0",
  "solana-loader-v3-interface 5.0.0",
  "solana-loader-v4-interface",
  "solana-log-collector",
  "solana-measure",
  "solana-packet",
  "solana-program-runtime",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-sbpf",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
  "solana-transaction-context",
  "solana-type-overrides",
 ]
@@ -5139,13 +5365,13 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-bincode",
- "solana-hash",
- "solana-instruction",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-ids",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sanitize 2.2.1",
+ "solana-sdk-ids 2.2.1",
  "solana-short-vec",
- "solana-system-interface",
+ "solana-system-interface 1.0.0",
  "solana-transaction-error",
  "wasm-bindgen",
 ]
@@ -5161,7 +5387,7 @@ dependencies = [
  "log",
  "reqwest",
  "solana-cluster-type",
- "solana-sha256-hasher",
+ "solana-sha256-hasher 2.2.1",
  "solana-time-utils",
  "thiserror 2.0.12",
 ]
@@ -5172,7 +5398,16 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36a1a14399afaabc2781a1db09cb14ee4cc4ee5c7a5a3cfcc601811379a8092"
 dependencies = [
- "solana-define-syscall",
+ "solana-define-syscall 2.3.0",
+]
+
+[[package]]
+name = "solana-msg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "264275c556ea7e22b9d3f87d56305546a38d4eee8ec884f3b126236cb7dcbbb4"
+dependencies = [
+ "solana-define-syscall 3.0.0",
 ]
 
 [[package]]
@@ -5216,10 +5451,10 @@ checksum = "703e22eb185537e06204a5bd9d509b948f0066f2d1d814a6f475dafb3ddf1325"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-fee-calculator",
- "solana-hash",
- "solana-pubkey",
- "solana-sha256-hasher",
+ "solana-fee-calculator 2.2.1",
+ "solana-hash 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sha256-hasher 2.2.1",
 ]
 
 [[package]]
@@ -5228,10 +5463,10 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde971a20b8dbf60144d6a84439dda86b5466e00e2843091fe731083cda614da"
 dependencies = [
- "solana-account",
- "solana-hash",
+ "solana-account 2.2.1",
+ "solana-hash 2.3.0",
  "solana-nonce",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
 ]
 
 [[package]]
@@ -5241,11 +5476,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b526398ade5dea37f1f147ce55dae49aa017a5d7326606359b0445ca8d946581"
 dependencies = [
  "num_enum",
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-packet",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sha256-hasher",
+ "solana-pubkey 2.4.0",
+ "solana-sanitize 2.2.1",
+ "solana-sha256-hasher 2.2.1",
  "solana-signature",
  "solana-signer",
 ]
@@ -5284,13 +5519,13 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "serde",
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-message",
  "solana-metrics",
  "solana-packet",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-rayon-threadlimit",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
  "solana-short-vec",
  "solana-signature",
  "solana-time-utils",
@@ -5314,7 +5549,7 @@ checksum = "ac40625dac6471cbeaa92cc07edb2ea0e718c6ab63c3c856df142b3a57dd3b8b"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
- "solana-define-syscall",
+ "solana-define-syscall 2.3.0",
  "thiserror 2.0.12",
 ]
 
@@ -5339,8 +5574,8 @@ dependencies = [
  "solana-feature-set",
  "solana-message",
  "solana-precompile-error",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-secp256k1-program",
  "solana-secp256r1-program",
 ]
@@ -5351,7 +5586,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a57a24e6a4125fc69510b6774cd93402b943191b6cddad05de7281491c90fe"
 dependencies = [
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-signature",
  "solana-signer",
 ]
@@ -5381,56 +5616,56 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "solana-account-info",
+ "solana-account-info 2.2.1",
  "solana-address-lookup-table-interface",
- "solana-atomic-u64",
+ "solana-atomic-u64 2.2.1",
  "solana-big-mod-exp",
  "solana-bincode",
  "solana-blake3-hasher",
- "solana-borsh",
- "solana-clock",
- "solana-cpi",
+ "solana-borsh 2.2.1",
+ "solana-clock 2.2.2",
+ "solana-cpi 2.2.1",
  "solana-decode-error",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
+ "solana-define-syscall 2.3.0",
+ "solana-epoch-rewards 2.2.1",
+ "solana-epoch-schedule 2.2.1",
  "solana-example-mocks",
  "solana-feature-gate-interface",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
+ "solana-fee-calculator 2.2.1",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-instructions-sysvar",
  "solana-keccak-hasher",
- "solana-last-restart-slot",
+ "solana-last-restart-slot 2.2.1",
  "solana-loader-v2-interface",
  "solana-loader-v3-interface 3.0.0",
  "solana-loader-v4-interface",
  "solana-message",
- "solana-msg",
+ "solana-msg 2.2.1",
  "solana-native-token",
  "solana-nonce",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
+ "solana-program-entrypoint 2.2.1",
+ "solana-program-error 2.2.1",
+ "solana-program-memory 2.2.1",
  "solana-program-option",
  "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
+ "solana-sanitize 2.2.1",
+ "solana-sdk-ids 2.2.1",
+ "solana-sdk-macro 2.2.1",
  "solana-secp256k1-recover",
  "solana-serde-varint",
  "solana-serialize-utils",
- "solana-sha256-hasher",
+ "solana-sha256-hasher 2.2.1",
  "solana-short-vec",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stable-layout",
- "solana-stake-interface",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
+ "solana-slot-hashes 2.2.1",
+ "solana-slot-history 2.2.1",
+ "solana-stable-layout 2.2.1",
+ "solana-stake-interface 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-system-interface 1.0.0",
+ "solana-sysvar 2.2.2",
+ "solana-sysvar-id 2.2.1",
  "solana-vote-interface",
  "thiserror 2.0.12",
  "wasm-bindgen",
@@ -5442,10 +5677,23 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473ffe73c68d93e9f2aa726ad2985fe52760052709aaab188100a42c618060ec"
 dependencies = [
- "solana-account-info",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
+ "solana-account-info 2.2.1",
+ "solana-msg 2.2.1",
+ "solana-program-error 2.2.1",
+ "solana-pubkey 2.4.0",
+]
+
+[[package]]
+name = "solana-program-entrypoint"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb61aaf3bf54b69721fbaadb0942cfd41f608cf279e514c1362264a24e469a9e"
+dependencies = [
+ "solana-account-info 3.0.0",
+ "solana-define-syscall 3.0.0",
+ "solana-msg 3.0.0",
+ "solana-program-error 3.0.0",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -5459,9 +5707,18 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-pubkey",
+ "solana-instruction 2.3.0",
+ "solana-msg 2.2.1",
+ "solana-pubkey 2.4.0",
+]
+
+[[package]]
+name = "solana-program-error"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1af32c995a7b692a915bb7414d5f8e838450cf7c70414e763d8abcae7b51f28"
+dependencies = [
+ "borsh 1.5.7",
 ]
 
 [[package]]
@@ -5471,7 +5728,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b0268f6c89825fb634a34bd0c3b8fdaeaecfc3728be1d622a8ee6dd577b60d4"
 dependencies = [
  "num-traits",
- "solana-define-syscall",
+ "solana-define-syscall 2.3.0",
+]
+
+[[package]]
+name = "solana-program-memory"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10e5660c60749c7bfb30b447542529758e4dbcecd31b1e8af1fdc92e2bdde90a"
+dependencies = [
+ "solana-define-syscall 3.0.0",
 ]
 
 [[package]]
@@ -5486,7 +5752,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "319f0ef15e6e12dc37c597faccb7d62525a509fec5f6975ecb9419efddeb277b"
 dependencies = [
- "solana-program-error",
+ "solana-program-error 2.2.1",
 ]
 
 [[package]]
@@ -5503,29 +5769,29 @@ dependencies = [
  "percentage",
  "rand 0.8.5",
  "serde",
- "solana-account",
- "solana-clock",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
+ "solana-account 2.2.1",
+ "solana-clock 2.2.2",
+ "solana-epoch-rewards 2.2.1",
+ "solana-epoch-schedule 2.2.1",
  "solana-fee-structure",
- "solana-hash",
- "solana-instruction",
- "solana-last-restart-slot",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
+ "solana-last-restart-slot 2.2.1",
  "solana-log-collector",
  "solana-measure",
  "solana-metrics",
- "solana-program-entrypoint",
- "solana-pubkey",
- "solana-rent",
+ "solana-program-entrypoint 2.2.1",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
  "solana-sbpf",
- "solana-sdk-ids",
- "solana-slot-hashes",
- "solana-stable-layout",
+ "solana-sdk-ids 2.2.1",
+ "solana-slot-hashes 2.2.1",
+ "solana-stable-layout 2.2.1",
  "solana-svm-callback",
  "solana-svm-feature-set",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
+ "solana-system-interface 1.0.0",
+ "solana-sysvar 2.2.2",
+ "solana-sysvar-id 2.2.1",
  "solana-timings",
  "solana-transaction-context",
  "solana-type-overrides",
@@ -5547,44 +5813,44 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "serde",
- "solana-account",
- "solana-account-info",
+ "solana-account 2.2.1",
+ "solana-account-info 2.2.1",
  "solana-accounts-db",
  "solana-banks-client",
  "solana-banks-interface",
  "solana-banks-server",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-commitment-config",
  "solana-compute-budget",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee-calculator",
+ "solana-epoch-rewards 2.2.1",
+ "solana-epoch-schedule 2.2.1",
+ "solana-fee-calculator 2.2.1",
  "solana-genesis-config",
- "solana-hash",
- "solana-instruction",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-keypair",
  "solana-loader-v3-interface 5.0.0",
  "solana-log-collector",
  "solana-logger",
  "solana-message",
- "solana-msg",
+ "solana-msg 2.2.1",
  "solana-native-token",
  "solana-poh-config",
- "solana-program-entrypoint",
- "solana-program-error",
+ "solana-program-entrypoint 2.2.1",
+ "solana-program-error 2.2.1",
  "solana-program-runtime",
- "solana-pubkey",
- "solana-rent",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
  "solana-runtime",
  "solana-sbpf",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
  "solana-signer",
- "solana-stable-layout",
- "solana-stake-interface",
+ "solana-stable-layout 2.2.1",
+ "solana-stake-interface 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-svm",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
+ "solana-system-interface 1.0.0",
+ "solana-sysvar 2.2.2",
+ "solana-sysvar-id 2.2.1",
  "solana-timings",
  "solana-transaction",
  "solana-transaction-context",
@@ -5614,14 +5880,21 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_derive",
- "solana-atomic-u64",
+ "solana-atomic-u64 2.2.1",
  "solana-decode-error",
- "solana-define-syscall",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-sanitize",
- "solana-sha256-hasher",
+ "solana-define-syscall 2.3.0",
+ "solana-sanitize 2.2.1",
+ "solana-sha256-hasher 2.2.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-pubkey"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
+dependencies = [
+ "solana-address",
 ]
 
 [[package]]
@@ -5639,8 +5912,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-clock",
- "solana-pubkey",
+ "solana-clock 2.2.2",
+ "solana-pubkey 2.4.0",
  "solana-rpc-client-types",
  "solana-signature",
  "thiserror 2.0.12",
@@ -5670,7 +5943,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-quic-definitions",
  "solana-rpc-client-api",
  "solana-signer",
@@ -5707,9 +5980,22 @@ checksum = "d1aea8fdea9de98ca6e8c2da5827707fb3842833521b528a713810ca685d2480"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
+ "solana-sdk-ids 2.2.1",
+ "solana-sdk-macro 2.2.1",
+ "solana-sysvar-id 2.2.1",
+]
+
+[[package]]
+name = "solana-rent"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b702d8c43711e3c8a9284a4f1bbc6a3de2553deb25b0c8142f9a44ef0ce5ddc1"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids 3.0.0",
+ "solana-sdk-macro 3.0.0",
+ "solana-sysvar-id 3.0.0",
 ]
 
 [[package]]
@@ -5720,13 +6006,13 @@ checksum = "7c1e19f5d5108b0d824244425e43bc78bbb9476e2199e979b0230c9f632d3bf4"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-account",
- "solana-clock",
- "solana-epoch-schedule",
+ "solana-account 2.2.1",
+ "solana-clock 2.2.2",
+ "solana-epoch-schedule 2.2.1",
  "solana-genesis-config",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
+ "solana-sdk-ids 2.2.1",
 ]
 
 [[package]]
@@ -5735,7 +6021,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f6f9113c6003492e74438d1288e30cffa8ccfdc2ef7b49b9e816d8034da18cd"
 dependencies = [
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-reward-info",
 ]
 
@@ -5747,8 +6033,8 @@ checksum = "2b293f4246626c0e0a991531f08848a713ada965612e99dc510963f04d12cae7"
 dependencies = [
  "lazy_static",
  "solana-feature-set",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
 ]
 
 [[package]]
@@ -5780,17 +6066,17 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-account-decoder-client-types",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-commitment-config",
  "solana-epoch-info",
- "solana-epoch-schedule",
+ "solana-epoch-schedule 2.2.1",
  "solana-feature-gate-interface",
- "solana-hash",
- "solana-instruction",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-message",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-rpc-client-api",
  "solana-signature",
  "solana-transaction",
@@ -5815,7 +6101,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-rpc-client-types",
  "solana-signer",
  "solana-transaction-error",
@@ -5829,14 +6115,14 @@ version = "2.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce22eb0035a10f2fc0c9214bef85bcc20a8b876d4f991bab18568c5154e466b"
 dependencies = [
- "solana-account",
+ "solana-account 2.2.1",
  "solana-commitment-config",
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-message",
  "solana-nonce",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-rpc-client",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
  "thiserror 2.0.12",
 ]
 
@@ -5852,13 +6138,13 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-account-decoder-client-types",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-commitment-config",
- "solana-fee-calculator",
+ "solana-fee-calculator 2.2.1",
  "solana-inflation",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-version",
@@ -5911,34 +6197,34 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with",
- "solana-account",
- "solana-account-info",
+ "solana-account 2.2.1",
+ "solana-account-info 2.2.1",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bpf-loader-program",
  "solana-bucket-map",
  "solana-builtins",
  "solana-client-traits",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-commitment-config",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
  "solana-cost-model",
- "solana-cpi",
+ "solana-cpi 2.2.1",
  "solana-ed25519-program",
  "solana-epoch-info",
  "solana-epoch-rewards-hasher",
- "solana-epoch-schedule",
+ "solana-epoch-schedule 2.2.1",
  "solana-feature-gate-interface",
  "solana-fee",
- "solana-fee-calculator",
+ "solana-fee-calculator 2.2.1",
  "solana-fee-structure",
  "solana-genesis-config",
  "solana-hard-forks",
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-inflation",
- "solana-instruction",
+ "solana-instruction 2.3.0",
  "solana-keypair",
  "solana-lattice-hash",
  "solana-loader-v3-interface 5.0.0",
@@ -5955,32 +6241,32 @@ dependencies = [
  "solana-poh-config",
  "solana-precompile-error",
  "solana-program-runtime",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-rayon-threadlimit",
- "solana-rent",
+ "solana-rent 2.2.1",
  "solana-rent-collector",
  "solana-rent-debits",
  "solana-reward-info",
  "solana-runtime-transaction",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
  "solana-secp256k1-program",
  "solana-seed-derivable",
  "solana-serde",
- "solana-sha256-hasher",
+ "solana-sha256-hasher 2.2.1",
  "solana-signature",
  "solana-signer",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stake-interface",
+ "solana-slot-hashes 2.2.1",
+ "solana-slot-history 2.2.1",
+ "solana-stake-interface 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-stake-program 2.3.6",
  "solana-svm",
  "solana-svm-callback",
  "solana-svm-rent-collector",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 1.0.0",
  "solana-system-transaction",
- "solana-sysvar",
- "solana-sysvar-id",
+ "solana-sysvar 2.2.2",
+ "solana-sysvar-id 2.2.1",
  "solana-time-utils",
  "solana-timings",
  "solana-transaction",
@@ -6013,10 +6299,10 @@ dependencies = [
  "log",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-message",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-signature",
  "solana-svm-transaction",
  "solana-transaction",
@@ -6029,6 +6315,12 @@ name = "solana-sanitize"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
+
+[[package]]
+name = "solana-sanitize"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927e833259588ac8f860861db0f6e2668c3cc46d917798ade116858960acfe8a"
 
 [[package]]
 name = "solana-sbpf"
@@ -6059,7 +6351,7 @@ dependencies = [
  "js-sys",
  "serde",
  "serde_json",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-bn254",
  "solana-client-traits",
  "solana-cluster-type",
@@ -6075,7 +6367,7 @@ dependencies = [
  "solana-genesis-config",
  "solana-hard-forks",
  "solana-inflation",
- "solana-instruction",
+ "solana-instruction 2.3.0",
  "solana-keypair",
  "solana-message",
  "solana-native-token",
@@ -6087,16 +6379,16 @@ dependencies = [
  "solana-precompiles",
  "solana-presigner",
  "solana-program",
- "solana-program-memory",
- "solana-pubkey",
+ "solana-program-memory 2.2.1",
+ "solana-pubkey 2.4.0",
  "solana-quic-definitions",
  "solana-rent-collector",
  "solana-rent-debits",
  "solana-reserved-account-keys",
  "solana-reward-info",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
+ "solana-sanitize 2.2.1",
+ "solana-sdk-ids 2.2.1",
+ "solana-sdk-macro 2.2.1",
  "solana-secp256k1-program",
  "solana-secp256k1-recover",
  "solana-secp256r1-program",
@@ -6124,7 +6416,16 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c5d8b9cc68d5c88b062a33e23a6466722467dde0035152d8fb1afbcdf350a5f"
 dependencies = [
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
+]
+
+[[package]]
+name = "solana-sdk-ids"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b6d6aaf60669c592838d382266b173881c65fb1cdec83b37cb8ce7cb89f9ad"
+dependencies = [
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -6132,6 +6433,18 @@ name = "solana-sdk-macro"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86280da8b99d03560f6ab5aca9de2e38805681df34e0bb8f238e69b29433b9df"
+dependencies = [
+ "bs58",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "solana-sdk-macro"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6430000e97083460b71d9fbadc52a2ab2f88f53b3a4c5e58c5ae3640a0e8c00"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -6152,9 +6465,9 @@ dependencies = [
  "serde_derive",
  "sha3",
  "solana-feature-set",
- "solana-instruction",
+ "solana-instruction 2.3.0",
  "solana-precompile-error",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
 ]
 
 [[package]]
@@ -6165,7 +6478,7 @@ checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
 dependencies = [
  "borsh 1.5.7",
  "libsecp256k1",
- "solana-define-syscall",
+ "solana-define-syscall 2.3.0",
  "thiserror 2.0.12",
 ]
 
@@ -6178,9 +6491,9 @@ dependencies = [
  "bytemuck",
  "openssl",
  "solana-feature-set",
- "solana-instruction",
+ "solana-instruction 2.3.0",
  "solana-precompile-error",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
 ]
 
 [[package]]
@@ -6214,14 +6527,14 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "solana-client",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-connection-cache",
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
  "solana-nonce-account",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-quic-definitions",
  "solana-runtime",
  "solana-signature",
@@ -6255,9 +6568,9 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "817a284b63197d2b27afdba829c5ab34231da4a9b4e763466a003c40ca4f535e"
 dependencies = [
- "solana-instruction",
- "solana-pubkey",
- "solana-sanitize",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sanitize 2.2.1",
 ]
 
 [[package]]
@@ -6267,8 +6580,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0037386961c0d633421f53560ad7c80675c0447cba4d1bb66d60974dd486c7ea"
 dependencies = [
  "sha2 0.10.8",
- "solana-define-syscall",
- "solana-hash",
+ "solana-define-syscall 2.3.0",
+ "solana-hash 2.3.0",
+]
+
+[[package]]
+name = "solana-sha256-hasher"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b912ba6f71cb202c0c3773ec77bf898fa9fe0c78691a2d6859b3b5b8954719"
+dependencies = [
+ "sha2 0.10.8",
+ "solana-define-syscall 3.0.0",
+ "solana-hash 3.0.0",
 ]
 
 [[package]]
@@ -6287,8 +6611,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afd3db0461089d1ad1a78d9ba3f15b563899ca2386351d38428faa5350c60a98"
 dependencies = [
  "solana-hard-forks",
- "solana-hash",
- "solana-sha256-hasher",
+ "solana-hash 2.3.0",
+ "solana-sha256-hasher 2.2.1",
 ]
 
 [[package]]
@@ -6303,7 +6627,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_derive",
- "solana-sanitize",
+ "solana-sanitize 2.2.1",
 ]
 
 [[package]]
@@ -6312,7 +6636,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c41991508a4b02f021c1342ba00bcfa098630b213726ceadc7cb032e051975b"
 dependencies = [
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-signature",
  "solana-transaction-error",
 ]
@@ -6325,9 +6649,22 @@ checksum = "0c8691982114513763e88d04094c9caa0376b867a29577939011331134c301ce"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash",
- "solana-sdk-ids",
- "solana-sysvar-id",
+ "solana-hash 2.3.0",
+ "solana-sdk-ids 2.2.1",
+ "solana-sysvar-id 2.2.1",
+]
+
+[[package]]
+name = "solana-slot-hashes"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a293f952293281443c04f4d96afd9d547721923d596e92b4377ed2360f1746"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-hash 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-sysvar-id 3.0.0",
 ]
 
 [[package]]
@@ -6339,8 +6676,21 @@ dependencies = [
  "bv",
  "serde",
  "serde_derive",
- "solana-sdk-ids",
- "solana-sysvar-id",
+ "solana-sdk-ids 2.2.1",
+ "solana-sysvar-id 2.2.1",
+]
+
+[[package]]
+name = "solana-slot-history"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f914f6b108f5bba14a280b458d023e3621c9973f27f015a4d755b50e88d89e97"
+dependencies = [
+ "bv",
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids 3.0.0",
+ "solana-sysvar-id 3.0.0",
 ]
 
 [[package]]
@@ -6349,8 +6699,18 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f14f7d02af8f2bc1b5efeeae71bc1c2b7f0f65cd75bcc7d8180f2c762a57f54"
 dependencies = [
- "solana-instruction",
- "solana-pubkey",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+]
+
+[[package]]
+name = "solana-stable-layout"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1da74507795b6e8fb60b7c7306c0c36e2c315805d16eaaf479452661234685ac"
+dependencies = [
+ "solana-instruction 3.0.0",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -6374,28 +6734,50 @@ version = "1.2.1"
 dependencies = [
  "assert_matches",
  "bincode",
+ "borsh 1.5.7",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "serial_test",
+ "solana-account 3.0.0",
+ "solana-borsh 3.0.0",
+ "solana-clock 3.0.0",
+ "solana-cpi 3.0.0",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-instruction 3.0.0",
+ "solana-program-error 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-stake-interface 1.2.1",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar 3.0.0",
+ "solana-sysvar-id 3.0.0",
+ "static_assertions",
+ "strum",
+ "strum_macros",
+ "test-case",
+]
+
+[[package]]
+name = "solana-stake-interface"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5269e89fde216b4d7e1d1739cf5303f8398a1ff372a81232abbee80e554a838c"
+dependencies = [
  "borsh 0.10.4",
  "borsh 1.5.7",
  "num-traits",
  "serde",
  "serde_derive",
- "solana-account",
- "solana-borsh",
- "solana-clock",
- "solana-cpi",
+ "solana-clock 2.2.2",
+ "solana-cpi 2.2.1",
  "solana-decode-error",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-instruction",
- "solana-program",
- "solana-program-error",
- "solana-pubkey",
- "solana-system-interface",
- "solana-sysvar-id",
- "static_assertions",
- "strum",
- "strum_macros",
- "test-case",
+ "solana-instruction 2.3.0",
+ "solana-program-error 2.2.1",
+ "solana-pubkey 2.4.0",
+ "solana-system-interface 1.0.0",
+ "solana-sysvar-id 2.2.1",
 ]
 
 [[package]]
@@ -6413,7 +6795,7 @@ dependencies = [
  "num_enum",
  "proptest",
  "rand 0.8.5",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-config-interface",
  "solana-feature-set",
  "solana-logger",
@@ -6421,10 +6803,10 @@ dependencies = [
  "solana-program-runtime",
  "solana-program-test",
  "solana-sdk",
- "solana-sdk-ids",
- "solana-stake-interface",
- "solana-system-interface",
- "solana-sysvar",
+ "solana-sdk-ids 2.2.1",
+ "solana-stake-interface 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-system-interface 1.0.0",
+ "solana-sysvar 2.2.2",
  "solana-vote-program",
  "test-case",
  "thiserror 1.0.69",
@@ -6439,21 +6821,21 @@ dependencies = [
  "agave-feature-set",
  "bincode",
  "log",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-bincode",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-config-program-client",
  "solana-genesis-config",
- "solana-instruction",
+ "solana-instruction 2.3.0",
  "solana-log-collector",
  "solana-native-token",
  "solana-packet",
  "solana-program-runtime",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-stake-interface",
- "solana-sysvar",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
+ "solana-sdk-ids 2.2.1",
+ "solana-stake-interface 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sysvar 2.2.2",
  "solana-transaction-context",
  "solana-type-overrides",
  "solana-vote-interface",
@@ -6492,7 +6874,7 @@ dependencies = [
  "solana-net-utils",
  "solana-packet",
  "solana-perf",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-quic-definitions",
  "solana-signature",
  "solana-signer",
@@ -6518,11 +6900,11 @@ dependencies = [
  "percentage",
  "serde",
  "serde_derive",
- "solana-account",
- "solana-clock",
+ "solana-account 2.2.1",
+ "solana-clock 2.2.2",
  "solana-fee-structure",
- "solana-hash",
- "solana-instruction",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-instructions-sysvar",
  "solana-loader-v3-interface 5.0.0",
  "solana-loader-v4-interface",
@@ -6532,21 +6914,21 @@ dependencies = [
  "solana-message",
  "solana-nonce",
  "solana-nonce-account",
- "solana-program-entrypoint",
+ "solana-program-entrypoint 2.2.1",
  "solana-program-pack",
  "solana-program-runtime",
- "solana-pubkey",
- "solana-rent",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
  "solana-rent-collector",
  "solana-rent-debits",
- "solana-sdk-ids",
- "solana-slot-hashes",
+ "solana-sdk-ids 2.2.1",
+ "solana-slot-hashes 2.2.1",
  "solana-svm-callback",
  "solana-svm-feature-set",
  "solana-svm-rent-collector",
  "solana-svm-transaction",
- "solana-system-interface",
- "solana-sysvar-id",
+ "solana-system-interface 1.0.0",
+ "solana-sysvar-id 2.2.1",
  "solana-timings",
  "solana-transaction-context",
  "solana-transaction-error",
@@ -6561,9 +6943,9 @@ version = "2.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5498ea1832b503ec4a5c48bfe13994a168ee6515420f435a93ccec62b4820a40"
 dependencies = [
- "solana-account",
+ "solana-account 2.2.1",
  "solana-precompile-error",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
 ]
 
 [[package]]
@@ -6578,12 +6960,12 @@ version = "2.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67b3aa1d2749f0a404d20deccb37e5760f8a24c5cc6b35d49856dabe1010421"
 dependencies = [
- "solana-account",
- "solana-clock",
- "solana-pubkey",
- "solana-rent",
+ "solana-account 2.2.1",
+ "solana-clock 2.2.2",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
  "solana-rent-collector",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
  "solana-transaction-context",
  "solana-transaction-error",
 ]
@@ -6594,10 +6976,10 @@ version = "2.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "931effbfd38cfbe87198f29fc4a44fa069016ce1a1a3d10c2084e5cd7ffe8624"
 dependencies = [
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-message",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-signature",
  "solana-transaction",
 ]
@@ -6613,9 +6995,24 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-decode-error",
- "solana-instruction",
- "solana-pubkey",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1790547bfc3061f1ee68ea9d8dc6c973c02a163697b24263a8e9f2e6d4afa2"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-instruction 3.0.0",
+ "solana-msg 3.0.0",
+ "solana-program-error 3.0.0",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -6628,19 +7025,19 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-bincode",
- "solana-fee-calculator",
- "solana-instruction",
+ "solana-fee-calculator 2.2.1",
+ "solana-instruction 2.3.0",
  "solana-log-collector",
  "solana-nonce",
  "solana-nonce-account",
  "solana-packet",
  "solana-program-runtime",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
- "solana-sysvar",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
+ "solana-system-interface 1.0.0",
+ "solana-sysvar 2.2.2",
  "solana-transaction-context",
  "solana-type-overrides",
 ]
@@ -6651,12 +7048,12 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd98a25e5bcba8b6be8bcbb7b84b24c2a6a8178d7fb0e3077a916855ceba91a"
 dependencies = [
- "solana-hash",
+ "solana-hash 2.3.0",
  "solana-keypair",
  "solana-message",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 1.0.0",
  "solana-transaction",
 ]
 
@@ -6673,28 +7070,62 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_derive",
- "solana-account-info",
- "solana-clock",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
+ "solana-account-info 2.2.1",
+ "solana-clock 2.2.2",
+ "solana-define-syscall 2.3.0",
+ "solana-epoch-rewards 2.2.1",
+ "solana-epoch-schedule 2.2.1",
+ "solana-fee-calculator 2.2.1",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-instructions-sysvar",
- "solana-last-restart-slot",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stake-interface",
- "solana-sysvar-id",
+ "solana-last-restart-slot 2.2.1",
+ "solana-program-entrypoint 2.2.1",
+ "solana-program-error 2.2.1",
+ "solana-program-memory 2.2.1",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
+ "solana-sanitize 2.2.1",
+ "solana-sdk-ids 2.2.1",
+ "solana-sdk-macro 2.2.1",
+ "solana-slot-hashes 2.2.1",
+ "solana-slot-history 2.2.1",
+ "solana-stake-interface 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sysvar-id 2.2.1",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63205e68d680bcc315337dec311b616ab32fea0a612db3b883ce4de02e0953f9"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-account-info 3.0.0",
+ "solana-clock 3.0.0",
+ "solana-define-syscall 3.0.0",
+ "solana-epoch-rewards 3.0.0",
+ "solana-epoch-schedule 3.0.0",
+ "solana-fee-calculator 3.0.0",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-last-restart-slot 3.0.0",
+ "solana-program-entrypoint 3.0.0",
+ "solana-program-error 3.0.0",
+ "solana-program-memory 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-sdk-macro 3.0.0",
+ "solana-slot-hashes 3.0.0",
+ "solana-slot-history 3.0.0",
+ "solana-sysvar-id 3.0.0",
 ]
 
 [[package]]
@@ -6703,8 +7134,18 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5762b273d3325b047cfda250787f8d796d781746860d5d0a746ee29f3e8812c1"
 dependencies = [
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
+]
+
+[[package]]
+name = "solana-sysvar-id"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5051bc1a16d5d96a96bc33b5b2ec707495c48fe978097bdaba68d3c47987eb32"
+dependencies = [
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
 ]
 
 [[package]]
@@ -6716,22 +7157,22 @@ dependencies = [
  "bincode",
  "log",
  "rayon",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-client-traits",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-commitment-config",
  "solana-connection-cache",
  "solana-epoch-info",
- "solana-hash",
- "solana-instruction",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-keypair",
  "solana-message",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 1.0.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -6750,7 +7191,7 @@ checksum = "bf5069234bff52d9c541137bc939a0cd5a9707d6536ce34c18580d4b6bf18e91"
 dependencies = [
  "eager",
  "enum-iterator",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
 ]
 
 [[package]]
@@ -6761,7 +7202,7 @@ checksum = "bf10bf4485fbe6d6e9560f59327bf564b0502ae31b7195f4e59598fbe640a4ff"
 dependencies = [
  "rustls 0.23.29",
  "solana-keypair",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-signer",
  "x509-parser",
 ]
@@ -6780,14 +7221,14 @@ dependencies = [
  "log",
  "rayon",
  "solana-client-traits",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-commitment-config",
  "solana-connection-cache",
- "solana-epoch-schedule",
+ "solana-epoch-schedule 2.2.1",
  "solana-measure",
  "solana-message",
  "solana-net-utils",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-pubsub-client",
  "solana-quic-definitions",
  "solana-rpc-client",
@@ -6811,7 +7252,7 @@ dependencies = [
  "lru",
  "quinn",
  "rustls 0.23.29",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
@@ -6838,18 +7279,18 @@ dependencies = [
  "serde_derive",
  "solana-bincode",
  "solana-feature-set",
- "solana-hash",
- "solana-instruction",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-keypair",
  "solana-message",
  "solana-precompiles",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sanitize 2.2.1",
+ "solana-sdk-ids 2.2.1",
  "solana-short-vec",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 1.0.0",
  "solana-transaction-error",
  "wasm-bindgen",
 ]
@@ -6863,12 +7304,12 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-account",
- "solana-instruction",
+ "solana-account 2.2.1",
+ "solana-instruction 2.3.0",
  "solana-instructions-sysvar",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
+ "solana-sdk-ids 2.2.1",
 ]
 
 [[package]]
@@ -6879,8 +7320,8 @@ checksum = "222a9dc8fdb61c6088baab34fc3a8b8473a03a7a5fd404ed8dd502fa79b67cb1"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-instruction",
- "solana-sanitize",
+ "solana-instruction 2.3.0",
+ "solana-sanitize 2.2.1",
 ]
 
 [[package]]
@@ -6954,7 +7395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20de595ba952541a82b59565631064e28b4dd8bdd09460f3ed55c42e7c5a1f0b"
 dependencies = [
  "assert_matches",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
  "solana-runtime-transaction",
  "solana-transaction",
  "static_assertions",
@@ -6978,7 +7419,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
- "solana-sanitize",
+ "solana-sanitize 2.2.1",
  "solana-serde-varint",
 ]
 
@@ -6992,15 +7433,15 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-bincode",
- "solana-clock",
- "solana-hash",
- "solana-instruction",
+ "solana-clock 2.2.2",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-keypair",
  "solana-packet",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-serialize-utils",
  "solana-signature",
  "solana-signer",
@@ -7021,17 +7462,17 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-clock",
+ "solana-clock 2.2.2",
  "solana-decode-error",
- "solana-hash",
- "solana-instruction",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
+ "solana-sdk-ids 2.2.1",
  "solana-serde-varint",
  "solana-serialize-utils",
  "solana-short-vec",
- "solana-system-interface",
+ "solana-system-interface 1.0.0",
 ]
 
 [[package]]
@@ -7047,21 +7488,21 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-account",
+ "solana-account 2.2.1",
  "solana-bincode",
- "solana-clock",
- "solana-epoch-schedule",
- "solana-hash",
- "solana-instruction",
+ "solana-clock 2.2.2",
+ "solana-epoch-schedule 2.2.1",
+ "solana-hash 2.3.0",
+ "solana-instruction 2.3.0",
  "solana-keypair",
  "solana-metrics",
  "solana-packet",
  "solana-program-runtime",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
+ "solana-pubkey 2.4.0",
+ "solana-rent 2.2.1",
+ "solana-sdk-ids 2.2.1",
  "solana-signer",
- "solana-slot-hashes",
+ "solana-slot-hashes 2.2.1",
  "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface",
@@ -7078,10 +7519,10 @@ dependencies = [
  "bytemuck",
  "num-derive 0.4.2",
  "num-traits",
- "solana-instruction",
+ "solana-instruction 2.3.0",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
  "solana-zk-sdk",
 ]
 
@@ -7108,9 +7549,9 @@ dependencies = [
  "serde_json",
  "sha3",
  "solana-derivation-path",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
@@ -7131,10 +7572,10 @@ dependencies = [
  "bytemuck",
  "num-derive 0.4.2",
  "num-traits",
- "solana-instruction",
+ "solana-instruction 2.3.0",
  "solana-log-collector",
  "solana-program-runtime",
- "solana-sdk-ids",
+ "solana-sdk-ids 2.2.1",
  "solana-zk-token-sdk",
 ]
 
@@ -7161,9 +7602,9 @@ dependencies = [
  "sha3",
  "solana-curve25519",
  "solana-derivation-path",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
+ "solana-instruction 2.3.0",
+ "solana-pubkey 2.4.0",
+ "solana-sdk-ids 2.2.1",
  "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
@@ -7189,7 +7630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741a62a566d97c58d33f9ed32337ceedd4e35109a686e31b1866c5dfa56abddc"
 dependencies = [
  "bytemuck",
- "solana-pubkey",
+ "solana-pubkey 2.4.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,3 @@ build = "1.86.0"
 format = "nightly-2025-02-16"
 lint = "nightly-2025-02-16"
 test = "nightly-2025-02-16"
-
-[patch.crates-io]
-solana-stake-interface = { path = "interface" }

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -8,7 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-rust_version = "1.81.0"
+rust-version = "1.81.0"
 
 [lib]
 crate-type = ["rlib"]
@@ -18,29 +18,27 @@ program-id = "Stake11111111111111111111111111111111111111"
 
 [dependencies]
 borsh = { version = "1.5.1", features = ["derive", "unstable__schema"], optional = true }
-borsh0-10 = { package = "borsh", version = "0.10.3", optional = true }
 num-traits = "0.2"
 serde = { version = "1.0.210", optional = true }
 serde_derive = { version = "1.0.210", optional = true }
-solana-decode-error = "2.2.1"
-solana-clock = "2.2.1"
-solana-cpi = { version = "2.2.1", optional = true }
-solana-frozen-abi = { version = "2.2.1", features = ["frozen-abi"], optional = true }
-solana-frozen-abi-macro = { version = "2.2.1", features = ["frozen-abi"], optional = true }
-solana-instruction = "2.2.1"
-solana-program-error = "2.2.1"
-solana-pubkey = { version = "2.2.1", default-features = false }
-solana-system-interface = "1.0.0"
-solana-sysvar = { version = "2.2.1", optional = true }
-solana-sysvar-id = { version = "2.2.1", optional = true }
+solana-clock = "3.0.0"
+solana-cpi = { version = "3.0.0", optional = true }
+solana-frozen-abi = { version = "3.0.0", features = ["frozen-abi"], optional = true }
+solana-frozen-abi-macro = { version = "3.0.0", features = ["frozen-abi"], optional = true }
+solana-instruction = "3.0.0"
+solana-program-error = "3.0.0"
+solana-pubkey = { version = "3.0.0", default-features = false }
+solana-system-interface = "2.0.0"
+solana-sysvar = { version = "3.0.0", optional = true }
+solana-sysvar-id = { version = "3.0.0", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 bincode = "1.3.3"
 serial_test = "2.0.0"
-solana-account = {version = "2.2.1", features = ["bincode"] }
-solana-borsh = "2.2.1"
-solana-program = { version = "2.2.1", default-features = false }
+solana-account = {version = "3.0.0", features = ["bincode"] }
+solana-borsh = "3.0.0"
+solana-sdk-ids = "3.0.0"
 solana-stake-interface = { path = ".", features = ["bincode", "borsh", "sysvar"] }
 static_assertions = "1.1.0"
 strum = "0.24"
@@ -63,7 +61,6 @@ bincode = [
 ]
 borsh = [
     "dep:borsh",
-    "dep:borsh0-10",
     "solana-instruction/borsh",
     "solana-program-error/borsh",
     "solana-pubkey/borsh"

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -30,14 +30,17 @@ solana-instruction = "2.2.1"
 solana-program-error = "2.2.1"
 solana-pubkey = { version = "2.2.1", default-features = false }
 solana-system-interface = "1.0.0"
-solana-sysvar-id = "2.2.1"
+solana-sysvar = { version = "2.2.1", optional = true }
+solana-sysvar-id = { version = "2.2.1", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 bincode = "1.3.3"
+serial_test = "2.0.0"
 solana-account = {version = "2.2.1", features = ["bincode"] }
 solana-borsh = "2.2.1"
 solana-program = { version = "2.2.1", default-features = false }
+solana-stake-interface = { path = ".", features = ["bincode", "borsh", "sysvar"] }
 static_assertions = "1.1.0"
 strum = "0.24"
 strum_macros = "0.24"
@@ -54,6 +57,7 @@ bincode = [
     "solana-instruction/bincode",
     "solana-instruction/serde",
     "solana-system-interface/bincode",
+    "solana-sysvar/bincode",
     "serde"
 ]
 borsh = [
@@ -67,6 +71,8 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-instruction/frozen-abi",
-    "solana-pubkey/frozen-abi"
+    "solana-pubkey/frozen-abi",
+    "solana-sysvar/frozen-abi",
 ]
-serde = ["dep:serde", "dep:serde_derive", "solana-pubkey/serde"]
+serde = ["dep:serde", "dep:serde_derive", "solana-pubkey/serde", "solana-sysvar/serde"]
+sysvar = ["dep:solana-sysvar", "dep:solana-sysvar-id"]

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+rust_version = "1.81.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -205,10 +205,7 @@ impl core::fmt::Display for StakeError {
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::StakeError, num_traits::FromPrimitive,
-        solana_instruction::error::InstructionError, strum::IntoEnumIterator,
-    };
+    use {super::StakeError, num_traits::FromPrimitive, strum::IntoEnumIterator};
 
     #[test]
     fn test_stake_error_from_primitive_exhaustive() {

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -1,6 +1,5 @@
 use {
     num_traits::{FromPrimitive, ToPrimitive},
-    solana_decode_error::DecodeError,
     solana_program_error::ProgramError,
 };
 
@@ -157,7 +156,7 @@ impl ToPrimitive for StakeError {
     }
 }
 
-impl std::error::Error for StakeError {}
+impl core::error::Error for StakeError {}
 
 impl core::fmt::Display for StakeError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -204,16 +203,10 @@ impl core::fmt::Display for StakeError {
     }
 }
 
-impl<E> DecodeError<E> for StakeError {
-    fn type_of() -> &'static str {
-        "StakeError"
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use {
-        super::StakeError, num_traits::FromPrimitive, solana_decode_error::DecodeError,
+        super::StakeError, num_traits::FromPrimitive,
         solana_instruction::error::InstructionError, strum::IntoEnumIterator,
     };
 
@@ -226,31 +219,5 @@ mod tests {
                 StakeError::from_i64(variant_i64)
             );
         }
-    }
-
-    #[test]
-    fn test_custom_error_decode() {
-        use num_traits::FromPrimitive;
-        fn pretty_err<T>(err: InstructionError) -> String
-        where
-            T: 'static + std::error::Error + DecodeError<T> + FromPrimitive,
-        {
-            if let InstructionError::Custom(code) = err {
-                let specific_error: T = T::decode_custom_error_to_enum(code).unwrap();
-                format!(
-                    "{:?}: {}::{:?} - {}",
-                    err,
-                    T::type_of(),
-                    specific_error,
-                    specific_error,
-                )
-            } else {
-                "".to_string()
-            }
-        }
-        assert_eq!(
-            "Custom(0): StakeError::NoCreditsToRedeem - not enough credits to redeem",
-            pretty_err::<StakeError>(StakeError::NoCreditsToRedeem.into())
-        )
     }
 }

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -909,12 +909,12 @@ mod tests {
     #[test]
     fn test_constants() {
         // Ensure that the constants are in sync with the solana program.
-        assert_eq!(CLOCK_ID, solana_program::sysvar::clock::ID);
+        assert_eq!(CLOCK_ID, solana_sdk_ids::sysvar::clock::ID);
 
         // Ensure that the constants are in sync with the solana program.
-        assert_eq!(STAKE_HISTORY_ID, solana_program::sysvar::stake_history::ID);
+        assert_eq!(STAKE_HISTORY_ID, solana_sdk_ids::sysvar::stake_history::ID);
 
         // Ensure that the constants are in sync with the solana rent.
-        assert_eq!(RENT_ID, solana_program::sysvar::rent::ID);
+        assert_eq!(RENT_ID, solana_sdk_ids::sysvar::rent::ID);
     }
 }

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -10,6 +10,8 @@ pub mod instruction;
 pub mod stake_flags;
 pub mod stake_history;
 pub mod state;
+#[cfg(feature = "sysvar")]
+pub mod sysvar;
 pub mod tools;
 
 pub mod program {

--- a/interface/src/stake_flags.rs
+++ b/interface/src/stake_flags.rs
@@ -17,55 +17,6 @@ pub struct StakeFlags {
     bits: u8,
 }
 
-#[cfg(feature = "borsh")]
-impl borsh0_10::de::BorshDeserialize for StakeFlags {
-    fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
-        reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh0_10::maybestd::io::Error> {
-        Ok(Self {
-            bits: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-        })
-    }
-}
-
-#[cfg(feature = "borsh")]
-impl borsh0_10::BorshSchema for StakeFlags {
-    fn declaration() -> borsh0_10::schema::Declaration {
-        "StakeFlags".to_string()
-    }
-    fn add_definitions_recursively(
-        definitions: &mut borsh0_10::maybestd::collections::HashMap<
-            borsh0_10::schema::Declaration,
-            borsh0_10::schema::Definition,
-        >,
-    ) {
-        let fields = borsh0_10::schema::Fields::NamedFields(<[_]>::into_vec(
-            borsh0_10::maybestd::boxed::Box::new([(
-                "bits".to_string(),
-                <u8 as borsh0_10::BorshSchema>::declaration(),
-            )]),
-        ));
-        let definition = borsh0_10::schema::Definition::Struct { fields };
-        Self::add_definition(
-            <Self as borsh0_10::BorshSchema>::declaration(),
-            definition,
-            definitions,
-        );
-        <u8 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-    }
-}
-
-#[cfg(feature = "borsh")]
-impl borsh0_10::ser::BorshSerialize for StakeFlags {
-    fn serialize<W: borsh0_10::maybestd::io::Write>(
-        &self,
-        writer: &mut W,
-    ) -> ::core::result::Result<(), borsh0_10::maybestd::io::Error> {
-        borsh0_10::BorshSerialize::serialize(&self.bits, writer)?;
-        Ok(())
-    }
-}
-
 /// Currently, only bit 1 is used. The other 7 bits are reserved for future usage.
 impl StakeFlags {
     ///  Stake must be fully activated before deactivation is allowed (bit 1).

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -133,7 +133,7 @@ mod tests {
     fn test_id() {
         assert_eq!(
             StakeHistory::id(),
-            solana_program::sysvar::stake_history::id()
+            solana_sdk_ids::sysvar::stake_history::id()
         );
     }
 }

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -3,7 +3,7 @@
 //! [sv]: https://docs.solanalabs.com/runtime/sysvars#stakehistory
 
 pub use solana_clock::Epoch;
-use {solana_sysvar_id::declare_sysvar_id, std::ops::Deref};
+use std::ops::Deref;
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
@@ -64,8 +64,6 @@ impl std::ops::Add for StakeHistoryEntry {
 )]
 #[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);
-
-declare_sysvar_id!("SysvarStakeHistory1111111111111111111111111", StakeHistory);
 
 impl StakeHistory {
     pub fn get(&self, epoch: Epoch) -> Option<&StakeHistoryEntry> {

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -99,8 +99,6 @@ pub enum StakeState {
 }
 #[cfg(feature = "borsh")]
 impl_borsh_stake_state!(borsh);
-#[cfg(feature = "borsh")]
-impl_borsh_stake_state!(borsh0_10);
 impl StakeState {
     /// The fixed number of bytes used to serialize each stake account
     pub const fn size_of() -> usize {
@@ -205,8 +203,6 @@ macro_rules! impl_borsh_stake_state_v2 {
 }
 #[cfg(feature = "borsh")]
 impl_borsh_stake_state_v2!(borsh);
-#[cfg(feature = "borsh")]
-impl_borsh_stake_state_v2!(borsh0_10);
 
 impl StakeStateV2 {
     /// The fixed number of bytes used to serialize each stake account
@@ -304,68 +300,6 @@ impl Lockup {
         self.unix_timestamp > clock.unix_timestamp || self.epoch > clock.epoch
     }
 }
-#[cfg(feature = "borsh")]
-impl borsh0_10::de::BorshDeserialize for Lockup {
-    fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
-        reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh0_10::maybestd::io::Error> {
-        Ok(Self {
-            unix_timestamp: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-            epoch: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-            custodian: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-        })
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::BorshSchema for Lockup {
-    fn declaration() -> borsh0_10::schema::Declaration {
-        "Lockup".to_string()
-    }
-    fn add_definitions_recursively(
-        definitions: &mut borsh0_10::maybestd::collections::HashMap<
-            borsh0_10::schema::Declaration,
-            borsh0_10::schema::Definition,
-        >,
-    ) {
-        let fields = borsh0_10::schema::Fields::NamedFields(<[_]>::into_vec(
-            borsh0_10::maybestd::boxed::Box::new([
-                (
-                    "unix_timestamp".to_string(),
-                    <UnixTimestamp as borsh0_10::BorshSchema>::declaration(),
-                ),
-                (
-                    "epoch".to_string(),
-                    <Epoch as borsh0_10::BorshSchema>::declaration(),
-                ),
-                (
-                    "custodian".to_string(),
-                    <Pubkey as borsh0_10::BorshSchema>::declaration(),
-                ),
-            ]),
-        ));
-        let definition = borsh0_10::schema::Definition::Struct { fields };
-        Self::add_definition(
-            <Self as borsh0_10::BorshSchema>::declaration(),
-            definition,
-            definitions,
-        );
-        <UnixTimestamp as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-        <Epoch as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-        <Pubkey as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::ser::BorshSerialize for Lockup {
-    fn serialize<W: borsh0_10::maybestd::io::Write>(
-        &self,
-        writer: &mut W,
-    ) -> ::core::result::Result<(), borsh0_10::maybestd::io::Error> {
-        borsh0_10::BorshSerialize::serialize(&self.unix_timestamp, writer)?;
-        borsh0_10::BorshSerialize::serialize(&self.epoch, writer)?;
-        borsh0_10::BorshSerialize::serialize(&self.custodian, writer)?;
-        Ok(())
-    }
-}
 
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(
@@ -448,61 +382,6 @@ impl Authorized {
         Ok(())
     }
 }
-#[cfg(feature = "borsh")]
-impl borsh0_10::de::BorshDeserialize for Authorized {
-    fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
-        reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh0_10::maybestd::io::Error> {
-        Ok(Self {
-            staker: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-            withdrawer: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-        })
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::BorshSchema for Authorized {
-    fn declaration() -> borsh0_10::schema::Declaration {
-        "Authorized".to_string()
-    }
-    fn add_definitions_recursively(
-        definitions: &mut borsh0_10::maybestd::collections::HashMap<
-            borsh0_10::schema::Declaration,
-            borsh0_10::schema::Definition,
-        >,
-    ) {
-        let fields = borsh0_10::schema::Fields::NamedFields(<[_]>::into_vec(
-            borsh0_10::maybestd::boxed::Box::new([
-                (
-                    "staker".to_string(),
-                    <Pubkey as borsh0_10::BorshSchema>::declaration(),
-                ),
-                (
-                    "withdrawer".to_string(),
-                    <Pubkey as borsh0_10::BorshSchema>::declaration(),
-                ),
-            ]),
-        ));
-        let definition = borsh0_10::schema::Definition::Struct { fields };
-        Self::add_definition(
-            <Self as borsh0_10::BorshSchema>::declaration(),
-            definition,
-            definitions,
-        );
-        <Pubkey as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-        <Pubkey as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::ser::BorshSerialize for Authorized {
-    fn serialize<W: borsh0_10::maybestd::io::Write>(
-        &self,
-        writer: &mut W,
-    ) -> ::core::result::Result<(), borsh0_10::maybestd::io::Error> {
-        borsh0_10::BorshSerialize::serialize(&self.staker, writer)?;
-        borsh0_10::BorshSerialize::serialize(&self.withdrawer, writer)?;
-        Ok(())
-    }
-}
 
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(
@@ -555,68 +434,6 @@ impl Meta {
             authorized: Authorized::auto(authorized),
             ..Meta::default()
         }
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::de::BorshDeserialize for Meta {
-    fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
-        reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh0_10::maybestd::io::Error> {
-        Ok(Self {
-            rent_exempt_reserve: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-            authorized: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-            lockup: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-        })
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::BorshSchema for Meta {
-    fn declaration() -> borsh0_10::schema::Declaration {
-        "Meta".to_string()
-    }
-    fn add_definitions_recursively(
-        definitions: &mut borsh0_10::maybestd::collections::HashMap<
-            borsh0_10::schema::Declaration,
-            borsh0_10::schema::Definition,
-        >,
-    ) {
-        let fields = borsh0_10::schema::Fields::NamedFields(<[_]>::into_vec(
-            borsh0_10::maybestd::boxed::Box::new([
-                (
-                    "rent_exempt_reserve".to_string(),
-                    <u64 as borsh0_10::BorshSchema>::declaration(),
-                ),
-                (
-                    "authorized".to_string(),
-                    <Authorized as borsh0_10::BorshSchema>::declaration(),
-                ),
-                (
-                    "lockup".to_string(),
-                    <Lockup as borsh0_10::BorshSchema>::declaration(),
-                ),
-            ]),
-        ));
-        let definition = borsh0_10::schema::Definition::Struct { fields };
-        Self::add_definition(
-            <Self as borsh0_10::BorshSchema>::declaration(),
-            definition,
-            definitions,
-        );
-        <u64 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-        <Authorized as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-        <Lockup as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::ser::BorshSerialize for Meta {
-    fn serialize<W: borsh0_10::maybestd::io::Write>(
-        &self,
-        writer: &mut W,
-    ) -> ::core::result::Result<(), borsh0_10::maybestd::io::Error> {
-        borsh0_10::BorshSerialize::serialize(&self.rent_exempt_reserve, writer)?;
-        borsh0_10::BorshSerialize::serialize(&self.authorized, writer)?;
-        borsh0_10::BorshSerialize::serialize(&self.lockup, writer)?;
-        Ok(())
     }
 }
 
@@ -858,82 +675,6 @@ impl Delegation {
         }
     }
 }
-#[cfg(feature = "borsh")]
-impl borsh0_10::de::BorshDeserialize for Delegation {
-    fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
-        reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh0_10::maybestd::io::Error> {
-        Ok(Self {
-            voter_pubkey: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-            stake: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-            activation_epoch: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-            deactivation_epoch: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-            warmup_cooldown_rate: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-        })
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::BorshSchema for Delegation {
-    fn declaration() -> borsh0_10::schema::Declaration {
-        "Delegation".to_string()
-    }
-    fn add_definitions_recursively(
-        definitions: &mut borsh0_10::maybestd::collections::HashMap<
-            borsh0_10::schema::Declaration,
-            borsh0_10::schema::Definition,
-        >,
-    ) {
-        let fields = borsh0_10::schema::Fields::NamedFields(<[_]>::into_vec(
-            borsh0_10::maybestd::boxed::Box::new([
-                (
-                    "voter_pubkey".to_string(),
-                    <Pubkey as borsh0_10::BorshSchema>::declaration(),
-                ),
-                (
-                    "stake".to_string(),
-                    <u64 as borsh0_10::BorshSchema>::declaration(),
-                ),
-                (
-                    "activation_epoch".to_string(),
-                    <Epoch as borsh0_10::BorshSchema>::declaration(),
-                ),
-                (
-                    "deactivation_epoch".to_string(),
-                    <Epoch as borsh0_10::BorshSchema>::declaration(),
-                ),
-                (
-                    "warmup_cooldown_rate".to_string(),
-                    <f64 as borsh0_10::BorshSchema>::declaration(),
-                ),
-            ]),
-        ));
-        let definition = borsh0_10::schema::Definition::Struct { fields };
-        Self::add_definition(
-            <Self as borsh0_10::BorshSchema>::declaration(),
-            definition,
-            definitions,
-        );
-        <Pubkey as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-        <u64 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-        <Epoch as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-        <Epoch as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-        <f64 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::ser::BorshSerialize for Delegation {
-    fn serialize<W: borsh0_10::maybestd::io::Write>(
-        &self,
-        writer: &mut W,
-    ) -> ::core::result::Result<(), borsh0_10::maybestd::io::Error> {
-        borsh0_10::BorshSerialize::serialize(&self.voter_pubkey, writer)?;
-        borsh0_10::BorshSerialize::serialize(&self.stake, writer)?;
-        borsh0_10::BorshSerialize::serialize(&self.activation_epoch, writer)?;
-        borsh0_10::BorshSerialize::serialize(&self.deactivation_epoch, writer)?;
-        borsh0_10::BorshSerialize::serialize(&self.warmup_cooldown_rate, writer)?;
-        Ok(())
-    }
-}
 
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(
@@ -989,61 +730,6 @@ impl Stake {
             self.delegation.deactivation_epoch = epoch;
             Ok(())
         }
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::de::BorshDeserialize for Stake {
-    fn deserialize_reader<R: borsh0_10::maybestd::io::Read>(
-        reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh0_10::maybestd::io::Error> {
-        Ok(Self {
-            delegation: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-            credits_observed: borsh0_10::BorshDeserialize::deserialize_reader(reader)?,
-        })
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::BorshSchema for Stake {
-    fn declaration() -> borsh0_10::schema::Declaration {
-        "Stake".to_string()
-    }
-    fn add_definitions_recursively(
-        definitions: &mut borsh0_10::maybestd::collections::HashMap<
-            borsh0_10::schema::Declaration,
-            borsh0_10::schema::Definition,
-        >,
-    ) {
-        let fields = borsh0_10::schema::Fields::NamedFields(<[_]>::into_vec(
-            borsh0_10::maybestd::boxed::Box::new([
-                (
-                    "delegation".to_string(),
-                    <Delegation as borsh0_10::BorshSchema>::declaration(),
-                ),
-                (
-                    "credits_observed".to_string(),
-                    <u64 as borsh0_10::BorshSchema>::declaration(),
-                ),
-            ]),
-        ));
-        let definition = borsh0_10::schema::Definition::Struct { fields };
-        Self::add_definition(
-            <Self as borsh0_10::BorshSchema>::declaration(),
-            definition,
-            definitions,
-        );
-        <Delegation as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-        <u64 as borsh0_10::BorshSchema>::add_definitions_recursively(definitions);
-    }
-}
-#[cfg(feature = "borsh")]
-impl borsh0_10::ser::BorshSerialize for Stake {
-    fn serialize<W: borsh0_10::maybestd::io::Write>(
-        &self,
-        writer: &mut W,
-    ) -> ::core::result::Result<(), borsh0_10::maybestd::io::Error> {
-        borsh0_10::BorshSerialize::serialize(&self.delegation, writer)?;
-        borsh0_10::BorshSerialize::serialize(&self.credits_observed, writer)?;
-        Ok(())
     }
 }
 

--- a/interface/src/sysvar/mod.rs
+++ b/interface/src/sysvar/mod.rs
@@ -1,0 +1,2 @@
+//! Sysvars in the stake program
+pub mod stake_history;

--- a/interface/src/sysvar/stake_history.rs
+++ b/interface/src/sysvar/stake_history.rs
@@ -1,0 +1,283 @@
+//! History of stake activations and de-activations.
+//!
+//! The _stake history sysvar_ provides access to the [`StakeHistory`] type.
+//!
+//! The [`Sysvar::get`] method always returns
+//! [`ProgramError::UnsupportedSysvar`], and in practice the data size of this
+//! sysvar is too large to process on chain. One can still use the
+//! [`SysvarId::id`], [`SysvarId::check_id`] and [`SysvarSerialize::size_of`] methods in
+//! an on-chain program, and it can be accessed off-chain through RPC.
+//!
+//! [`ProgramError::UnsupportedSysvar`]: https://docs.rs/solana-program-error/latest/solana_program_error/enum.ProgramError.html#variant.UnsupportedSysvar
+//! [`SysvarId::id`]: https://docs.rs/solana-sysvar-id/latest/solana_sysvar_id/trait.SysvarId.html
+//! [`SysvarId::check_id`]: https://docs.rs/solana-sysvar-id/latest/solana_sysvar_id/trait.SysvarId.html#tymethod.check_id
+//!
+//! # Examples
+//!
+//! Calling via the RPC client:
+//!
+//! ```
+//! # use solana_example_mocks::{solana_account, solana_rpc_client};
+//! # use solana_stake_interface::{stake_history::StakeHistory, sysvar::stake_history};
+//! # use solana_account::Account;
+//! # use solana_rpc_client::rpc_client::RpcClient;
+//! # use anyhow::Result;
+//! #
+//! fn print_sysvar_stake_history(client: &RpcClient) -> Result<()> {
+//! #   client.set_get_account_response(stake_history::ID, Account {
+//! #       lamports: 114979200,
+//! #       data: vec![0, 0, 0, 0, 0, 0, 0, 0],
+//! #       owner: solana_sdk_ids::system_program::ID,
+//! #       executable: false,
+//! #   });
+//! #
+//!     let stake_history = client.get_account(&stake_history::ID)?;
+//!     let data: StakeHistory = bincode::deserialize(&stake_history.data)?;
+//!
+//!     Ok(())
+//! }
+//! #
+//! # let client = RpcClient::new(String::new());
+//! # print_sysvar_stake_history(&client)?;
+//! #
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+
+#[cfg(feature = "bincode")]
+use solana_sysvar::SysvarSerialize;
+use {
+    crate::stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry, MAX_ENTRIES},
+    solana_clock::Epoch,
+    solana_sysvar::{get_sysvar, Sysvar},
+    solana_sysvar_id::declare_sysvar_id,
+};
+
+declare_sysvar_id!("SysvarStakeHistory1111111111111111111111111", StakeHistory);
+
+impl Sysvar for StakeHistory {}
+#[cfg(feature = "bincode")]
+impl SysvarSerialize for StakeHistory {
+    // override
+    fn size_of() -> usize {
+        // hard-coded so that we don't have to construct an empty
+        16392 // golden, update if MAX_ENTRIES changes
+    }
+}
+
+// we do not provide Default because this requires the real current epoch
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct StakeHistorySysvar(pub Epoch);
+
+// precompute so we can statically allocate buffer
+const EPOCH_AND_ENTRY_SERIALIZED_SIZE: u64 = 32;
+
+impl StakeHistoryGetEntry for StakeHistorySysvar {
+    fn get_entry(&self, target_epoch: Epoch) -> Option<StakeHistoryEntry> {
+        let current_epoch = self.0;
+
+        // if current epoch is zero this returns None because there is no history yet
+        let newest_historical_epoch = current_epoch.checked_sub(1)?;
+        let oldest_historical_epoch = current_epoch.saturating_sub(MAX_ENTRIES as u64);
+
+        // target epoch is old enough to have fallen off history; presume fully active/deactive
+        if target_epoch < oldest_historical_epoch {
+            return None;
+        }
+
+        // epoch delta is how many epoch-entries we offset in the stake history vector, which may be zero
+        // None means target epoch is current or in the future; this is a user error
+        let epoch_delta = newest_historical_epoch.checked_sub(target_epoch)?;
+
+        // offset is the number of bytes to our desired entry, including eight for vector length
+        let offset = epoch_delta
+            .checked_mul(EPOCH_AND_ENTRY_SERIALIZED_SIZE)?
+            .checked_add(std::mem::size_of::<u64>() as u64)?;
+
+        let mut entry_buf = [0; EPOCH_AND_ENTRY_SERIALIZED_SIZE as usize];
+        let result = get_sysvar(
+            &mut entry_buf,
+            &id(),
+            offset,
+            EPOCH_AND_ENTRY_SERIALIZED_SIZE,
+        );
+
+        match result {
+            Ok(()) => {
+                // All safe because `entry_buf` is a 32-length array
+                let entry_epoch = u64::from_le_bytes(entry_buf[0..8].try_into().unwrap());
+                let effective = u64::from_le_bytes(entry_buf[8..16].try_into().unwrap());
+                let activating = u64::from_le_bytes(entry_buf[16..24].try_into().unwrap());
+                let deactivating = u64::from_le_bytes(entry_buf[24..32].try_into().unwrap());
+
+                // this would only fail if stake history skipped an epoch or the binary format of the sysvar changed
+                assert_eq!(entry_epoch, target_epoch);
+
+                Some(StakeHistoryEntry {
+                    effective,
+                    activating,
+                    deactivating,
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        serial_test::serial,
+        solana_sysvar::program_stubs::{set_syscall_stubs, SyscallStubs},
+    };
+
+    // NOTE tests that use this mock MUST carry the #[serial] attribute
+    struct MockGetSysvarSyscall {
+        data: Vec<u8>,
+    }
+    impl SyscallStubs for MockGetSysvarSyscall {
+        #[allow(clippy::arithmetic_side_effects)]
+        fn sol_get_sysvar(
+            &self,
+            _sysvar_id_addr: *const u8,
+            var_addr: *mut u8,
+            offset: u64,
+            length: u64,
+        ) -> u64 {
+            let slice = unsafe { std::slice::from_raw_parts_mut(var_addr, length as usize) };
+            slice.copy_from_slice(&self.data[offset as usize..(offset + length) as usize]);
+            0 // SUCCESS
+        }
+    }
+    pub fn mock_get_sysvar_syscall(data: &[u8]) {
+        set_syscall_stubs(Box::new(MockGetSysvarSyscall {
+            data: data.to_vec(),
+        }));
+    }
+
+    #[test]
+    fn test_size_of() {
+        let mut stake_history = StakeHistory::default();
+        for i in 0..MAX_ENTRIES as u64 {
+            stake_history.add(
+                i,
+                StakeHistoryEntry {
+                    activating: i,
+                    ..StakeHistoryEntry::default()
+                },
+            );
+        }
+
+        assert_eq!(
+            bincode::serialized_size(&stake_history).unwrap() as usize,
+            StakeHistory::size_of()
+        );
+
+        let stake_history_inner: Vec<(Epoch, StakeHistoryEntry)> =
+            bincode::deserialize(&bincode::serialize(&stake_history).unwrap()).unwrap();
+        let epoch_entry = stake_history_inner.into_iter().next().unwrap();
+
+        assert_eq!(
+            bincode::serialized_size(&epoch_entry).unwrap(),
+            EPOCH_AND_ENTRY_SERIALIZED_SIZE
+        );
+    }
+
+    #[serial]
+    #[test]
+    fn test_stake_history_get_entry() {
+        let unique_entry_for_epoch = |epoch: u64| StakeHistoryEntry {
+            activating: epoch.saturating_mul(2),
+            deactivating: epoch.saturating_mul(3),
+            effective: epoch.saturating_mul(5),
+        };
+
+        let current_epoch = MAX_ENTRIES.saturating_add(2) as u64;
+
+        // make a stake history object with at least one valid entry that has expired
+        let mut stake_history = StakeHistory::default();
+        for i in 0..current_epoch {
+            stake_history.add(i, unique_entry_for_epoch(i));
+        }
+        assert_eq!(stake_history.len(), MAX_ENTRIES);
+        assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 2);
+
+        // set up sol_get_sysvar
+        mock_get_sysvar_syscall(&bincode::serialize(&stake_history).unwrap());
+
+        // make a syscall interface object
+        let stake_history_sysvar = StakeHistorySysvar(current_epoch);
+
+        // now test the stake history interfaces
+
+        assert_eq!(stake_history.get(0), None);
+        assert_eq!(stake_history.get(1), None);
+        assert_eq!(stake_history.get(current_epoch), None);
+
+        assert_eq!(stake_history.get_entry(0), None);
+        assert_eq!(stake_history.get_entry(1), None);
+        assert_eq!(stake_history.get_entry(current_epoch), None);
+
+        assert_eq!(stake_history_sysvar.get_entry(0), None);
+        assert_eq!(stake_history_sysvar.get_entry(1), None);
+        assert_eq!(stake_history_sysvar.get_entry(current_epoch), None);
+
+        for i in 2..current_epoch {
+            let entry = Some(unique_entry_for_epoch(i));
+
+            assert_eq!(stake_history.get(i), entry.as_ref(),);
+
+            assert_eq!(stake_history.get_entry(i), entry,);
+
+            assert_eq!(stake_history_sysvar.get_entry(i), entry,);
+        }
+    }
+
+    #[serial]
+    #[test]
+    fn test_stake_history_get_entry_zero() {
+        let mut current_epoch = 0;
+
+        // first test that an empty history returns None
+        let stake_history = StakeHistory::default();
+        assert_eq!(stake_history.len(), 0);
+
+        mock_get_sysvar_syscall(&bincode::serialize(&stake_history).unwrap());
+        let stake_history_sysvar = StakeHistorySysvar(current_epoch);
+
+        assert_eq!(stake_history.get(0), None);
+        assert_eq!(stake_history.get_entry(0), None);
+        assert_eq!(stake_history_sysvar.get_entry(0), None);
+
+        // next test that we can get a zeroth entry in the first epoch
+        let entry_zero = StakeHistoryEntry {
+            effective: 100,
+            ..StakeHistoryEntry::default()
+        };
+        let entry = Some(entry_zero.clone());
+
+        let mut stake_history = StakeHistory::default();
+        stake_history.add(current_epoch, entry_zero);
+        assert_eq!(stake_history.len(), 1);
+        current_epoch = current_epoch.saturating_add(1);
+
+        mock_get_sysvar_syscall(&bincode::serialize(&stake_history).unwrap());
+        let stake_history_sysvar = StakeHistorySysvar(current_epoch);
+
+        assert_eq!(stake_history.get(0), entry.as_ref());
+        assert_eq!(stake_history.get_entry(0), entry);
+        assert_eq!(stake_history_sysvar.get_entry(0), entry);
+
+        // finally test that we can still get a zeroth entry in later epochs
+        stake_history.add(current_epoch, StakeHistoryEntry::default());
+        assert_eq!(stake_history.len(), 2);
+        current_epoch = current_epoch.saturating_add(1);
+
+        mock_get_sysvar_syscall(&bincode::serialize(&stake_history).unwrap());
+        let stake_history_sysvar = StakeHistorySysvar(current_epoch);
+
+        assert_eq!(stake_history.get(0), entry.as_ref());
+        assert_eq!(stake_history.get_entry(0), entry);
+        assert_eq!(stake_history_sysvar.get_entry(0), entry);
+    }
+}

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -32,7 +32,7 @@ solana-feature-set = "2.2.1"
 solana-logger = "2.2.1"
 solana-program-test = "2.3.4"
 solana-program-runtime = "2.2.0"
-solana-stake-interface = { path = "../interface", features = ["bincode"] }
+solana-stake-interface = { version = "1", features = ["bincode"] }
 solana-system-interface = { version = "1", features = ["bincode"] }
 solana-vote-program = "2.2.0"
 solana-sdk = "2.2.1"


### PR DESCRIPTION
#### Problem

The SDK V3 crates are available, but the stake interface is still using the v2 crates.

#### Summary of changes

Start using the new crates. The commits should mostly tell the story of the other work needed:

* move the stake-history sysvar implementation with the `sysvar` trait
* fixup the error type by implementing `ToStr` and removing solana-decode-error
* remove borsh 0.10 support
* use solana-sdk-ids
* bump everything
* detach the program build