### PR TITLE
CI: Use ANZA_TEAM_PAT to properly push during release

### DIFF
--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -77,6 +77,9 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ANZA_TEAM_PAT }}
+          fetch-depth: 0 # get the whole history for git-cliff
 
       - name: Setup Environment
         uses: ./.github/actions/setup


### PR DESCRIPTION
#### Problem

During release, the CI job failed to push to main because it wasn't using the ANZA_TEAM_PAT when checking out the repo.

#### Summary of changes

Use ANZA_TEAM_PAT to actually push changes to main