### PR TITLE
program: bump deps to SDK 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,23 +55,23 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e4bb8842e634f00f7f56bed7fcf67464bf2689378b3977350a8d0e6918a1ea"
+checksum = "0fd3c04892222a4599aa8e89a190c07ba8011223e49c20b6169f50866cfceabd"
 dependencies = [
  "ahash 0.8.11",
- "solana-epoch-schedule 2.2.1",
- "solana-hash 2.3.0",
- "solana-pubkey 2.4.0",
- "solana-sha256-hasher 2.2.1",
+ "solana-epoch-schedule 3.0.0",
+ "solana-hash 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-sha256-hasher 3.0.0",
  "solana-svm-feature-set",
 ]
 
 [[package]]
 name = "agave-io-uring"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd8b57436694f492a1954a6796eaec3f2644fc9a152351dae4bf1576f8e557c"
+checksum = "b5071bf296a0bd05f3f9e4d40de5621a20460ae8de6d75285ed787ab532f1baa"
 dependencies = [
  "io-uring",
  "libc",
@@ -82,49 +82,92 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c80965f60e812e96fc0cb1b5ec7ef89a3ebf757517678915142eb181f4e6e4"
+checksum = "448b75b0723b14a474006ef7a11fab7b585e3a8b27ea7ec7d0a0b7e3411bfe55"
 dependencies = [
  "agave-feature-set",
  "bincode",
  "digest 0.10.7",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "libsecp256k1",
  "openssl",
  "sha3",
  "solana-ed25519-program",
- "solana-message 2.4.0",
+ "solana-message 3.0.0",
  "solana-precompile-error",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
  "solana-secp256k1-program",
  "solana-secp256r1-program",
 ]
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2343e5e83d2a33f965dd2fd18840351d821de9a5a427880a05069cc60ec18a81"
+checksum = "93f5a6c1912c22b18816c9aafd359643f7a6ea21fa02ca5cf15b1ae95d7be3e8"
 dependencies = [
  "agave-feature-set",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
+]
+
+[[package]]
+name = "agave-syscalls"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63b754b0ed36753c706ec4d4b12073aebb095b15b50943cbc809b6e21830bf7"
+dependencies = [
+ "bincode",
+ "libsecp256k1",
+ "num-traits",
+ "solana-account 3.0.0",
+ "solana-account-info 3.0.0",
+ "solana-big-mod-exp 3.0.0",
+ "solana-blake3-hasher 3.0.0",
+ "solana-bn254",
+ "solana-clock 3.0.0",
+ "solana-cpi 3.0.0",
+ "solana-curve25519",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-keccak-hasher 3.0.0",
+ "solana-loader-v3-interface 6.1.0",
+ "solana-poseidon",
+ "solana-program-entrypoint 3.1.0",
+ "solana-program-runtime",
+ "solana-pubkey 3.0.0",
+ "solana-sbpf",
+ "solana-sdk-ids 3.0.0",
+ "solana-secp256k1-recover 3.0.0",
+ "solana-sha256-hasher 3.0.0",
+ "solana-stable-layout 3.0.0",
+ "solana-stake-interface 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-svm-callback",
+ "solana-svm-feature-set",
+ "solana-svm-log-collector",
+ "solana-svm-measure",
+ "solana-svm-timings",
+ "solana-svm-type-overrides",
+ "solana-sysvar 3.0.0",
+ "solana-sysvar-id 3.0.0",
+ "solana-transaction-context",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd48ceb336d71d199015f825802824d28ebcda5c0c9e4c062fb3b93781f0583"
+checksum = "c5eb699f076d0a508c16c96ff751a5bb3b66206cfb99eec8940a1de909039dfd"
 dependencies = [
- "solana-hash 2.3.0",
- "solana-message 2.4.0",
+ "solana-hash 3.0.0",
+ "solana-message 3.0.0",
  "solana-packet",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
- "solana-short-vec 2.2.1",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-short-vec 3.0.0",
  "solana-signature",
  "solana-svm-transaction",
 ]
@@ -193,10 +236,60 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
+name = "anstream"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "aquamarine"
@@ -220,6 +313,12 @@ checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "ark-bn254"
@@ -428,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
  "event-listener 5.4.0",
  "event-listener-strategy",
@@ -439,24 +538,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -481,6 +569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +591,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bincode"
@@ -694,18 +794,18 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441473f2b4b0459a68628c744bc61d23e730fb00128b841d30fa4bb3972257e4"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -831,6 +931,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,15 +970,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -894,6 +1000,12 @@ dependencies = [
  "log",
  "web-sys",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -976,6 +1088,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1059,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1073,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
@@ -1102,6 +1226,16 @@ name = "data-encoding"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "der-parser"
@@ -1177,6 +1311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1231,10 +1366,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "eager"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abe71d579d1812060163dff96056261deb5bf6729b100fa2e36a68b9649ba3d3"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 2.2.0",
+ "spki",
+]
 
 [[package]]
 name = "ed25519"
@@ -1242,7 +1397,17 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1252,7 +1417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.2.0",
- "ed25519",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
@@ -1260,13 +1425,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-dalek-bip32"
-version = "0.2.0"
+name = "ed25519-dalek"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2be62a4061b872c8c0873ee4fc6f101ce7b889d039f019c5fa2af471a59908"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek-bip32"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b49a684b133c4980d7ee783936af771516011c8cd15f429dbda77245e282f03"
 dependencies = [
  "derivation-path",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hmac 0.12.1",
  "sha2 0.10.8",
 ]
@@ -1288,6 +1468,25 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1329,16 +1528,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.3"
+name = "env_filter"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
- "atty",
- "humantime",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1407,6 +1616,16 @@ name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1608,6 +1827,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1627,10 +1847,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1687,6 +1905,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,15 +1959,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1873,7 +2093,7 @@ dependencies = [
  "http 1.3.1",
  "hyper",
  "hyper-util",
- "rustls 0.23.29",
+ "rustls 0.23.32",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -2132,14 +2352,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -2180,6 +2400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,6 +2428,30 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "jni"
@@ -2260,13 +2510,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "kaigan"
-version = "0.2.6"
+name = "k256"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba15de5aeb137f0f65aa3bf82187647f1285abfe5b20c80c2c37f7007ad519a"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
- "borsh 0.10.4",
- "serde",
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.8",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -2286,9 +2540,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libredox"
@@ -2550,79 +2804,81 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5e2f229c38a778c6e629f32ad2de2adb69df8dba07cbbf99b944aa330b1c4f"
+checksum = "5f7da80022acbada517ec6becc3e7e2012b9012e1cf00cf0e0a336156f32fddd"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
+ "agave-syscalls",
  "bincode",
  "mollusk-svm-error",
  "mollusk-svm-keys",
  "mollusk-svm-result",
- "solana-account 2.2.1",
+ "solana-account 3.0.0",
  "solana-bpf-loader-program",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
  "solana-compute-budget",
- "solana-epoch-rewards 2.2.1",
- "solana-epoch-schedule 2.2.1",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
- "solana-loader-v3-interface 3.0.0",
- "solana-loader-v4-interface",
- "solana-log-collector",
+ "solana-epoch-rewards 3.0.0",
+ "solana-epoch-schedule 3.0.0",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-instruction-error",
+ "solana-loader-v3-interface 6.1.0",
+ "solana-loader-v4-interface 3.1.0",
  "solana-logger",
  "solana-precompile-error",
- "solana-program-error 2.2.1",
+ "solana-program-error 3.0.0",
  "solana-program-runtime",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
- "solana-sdk-ids 2.2.1",
- "solana-slot-hashes 2.2.1",
- "solana-stake-interface 1.2.1",
- "solana-stake-program 2.3.6",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-slot-hashes 3.0.0",
+ "solana-stake-interface 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-stake-program 3.0.5",
  "solana-svm-callback",
+ "solana-svm-log-collector",
+ "solana-svm-timings",
  "solana-system-program",
- "solana-sysvar 2.2.2",
- "solana-sysvar-id 2.2.1",
- "solana-timings",
+ "solana-sysvar 3.0.0",
+ "solana-sysvar-id 3.0.0",
  "solana-transaction-context",
 ]
 
 [[package]]
 name = "mollusk-svm-error"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2443a68c1f91e3ed4ac014b17a438cbcf976e636f0ad1e613c49873ee2e764"
+checksum = "97230bc9e87c95fcd9cc0b42a9da212e9a62b0807b70cadfcf9272baef8900bd"
 dependencies = [
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "mollusk-svm-keys"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f53f00fc28aa0561e04088fe90115fc2f348c3380adc9500de2a2b62b4d0ff"
+checksum = "11a5b42ac2953ef03b105388cbef6e35a1b2ef05277f9bc7c4c8c5dfe2dbae85"
 dependencies = [
  "mollusk-svm-error",
- "solana-account 2.2.1",
- "solana-instruction 2.3.0",
- "solana-pubkey 2.4.0",
+ "solana-account 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-pubkey 3.0.0",
  "solana-transaction-context",
 ]
 
 [[package]]
 name = "mollusk-svm-result"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25a23a80c4273f698c595fa10f969050effca7bb2ecee2df72c956f582b174a"
+checksum = "7645fffe38e8de4831bebbe94db7d96d05c056b400aa7a1d9c3c1224ae0e592c"
 dependencies = [
- "solana-account 2.2.1",
- "solana-instruction 2.3.0",
- "solana-program-error 2.2.1",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
+ "solana-account 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-program-error 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
 ]
 
 [[package]]
@@ -2786,36 +3042,31 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -2840,6 +3091,12 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "opaque-debug"
@@ -3021,6 +3278,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,6 +3310,15 @@ name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -3210,9 +3486,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.29",
+ "rustls 0.23.32",
  "socket2 0.5.10",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -3231,11 +3507,11 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.29",
+ "rustls 0.23.32",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3421,6 +3697,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3451,9 +3747,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -3472,7 +3768,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.29",
+ "rustls 0.23.32",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3480,7 +3776,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.2",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
  "tower",
  "tower-http",
  "tower-service",
@@ -3504,6 +3800,16 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tower-service",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -3573,7 +3879,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3590,14 +3896,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.4",
+ "rustls-webpki 0.103.7",
  "subtle",
  "zeroize",
 ]
@@ -3635,10 +3941,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.29",
+ "rustls 0.23.32",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.4",
+ "rustls-webpki 0.103.7",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3663,9 +3969,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3724,6 +4030,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3737,6 +4067,20 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3779,10 +4123,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3805,10 +4150,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3817,14 +4171,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3841,15 +4196,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3859,9 +4216,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3980,6 +4337,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4003,12 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -4042,17 +4406,11 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f949fe4edaeaea78c844023bfc1c898e0b1f5a100f8a8d2d0f85d0a7b090258"
 dependencies = [
- "bincode",
- "qualifier_attr",
- "serde",
- "serde_bytes",
- "serde_derive",
  "solana-account-info 2.2.1",
  "solana-clock 2.2.2",
  "solana-instruction 2.3.0",
  "solana-pubkey 2.4.0",
  "solana-sdk-ids 2.2.1",
- "solana-sysvar 2.2.2",
 ]
 
 [[package]]
@@ -4062,6 +4420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f885ce7f937871ecb56aadbeaaec963b234a580b7d6ebbdb8fa4249a36f92433"
 dependencies = [
  "bincode",
+ "qualifier_attr",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -4075,17 +4434,17 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fe163318f8531029ec3e1796f55f16b61dcf194d9502076cbe3505a815d9d5"
+checksum = "bf0013eae1253f557b543c060343cccb0d4f4e59c3f5809f85f3d517a3f198a4"
 dependencies = [
  "base64 0.22.1",
  "bs58",
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account 2.2.1",
- "solana-pubkey 2.4.0",
+ "solana-account 3.0.0",
+ "solana-pubkey 3.0.0",
  "zstd",
 ]
 
@@ -4108,6 +4467,8 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f4691b69b172c687d218dd2f1f23fc7ea5e9aa79df9ac26dab3d8dd829ce48"
 dependencies = [
+ "bincode",
+ "serde",
  "solana-program-error 3.0.0",
  "solana-program-memory 3.0.0",
  "solana-pubkey 3.0.0",
@@ -4115,9 +4476,9 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031320f58958a43a1075c9da18891ed3246e8c62bd491851cbe2403e32fb45e8"
+checksum = "bd275e231d8cb76c1b2b64145cfb92d61e89daf4d24235ee5381fe25f0ef6555"
 dependencies = [
  "agave-io-uring",
  "ahash 0.8.11",
@@ -4132,6 +4493,7 @@ dependencies = [
  "indexmap 2.10.0",
  "io-uring",
  "itertools 0.12.1",
+ "libc",
  "log",
  "lz4",
  "memmap2 0.9.7",
@@ -4145,37 +4507,36 @@ dependencies = [
  "serde_derive",
  "slab",
  "smallvec",
- "solana-account 2.2.1",
- "solana-address-lookup-table-interface 2.2.2",
+ "solana-account 3.0.0",
+ "solana-address-lookup-table-interface 3.0.0",
  "solana-bucket-map",
- "solana-clock 2.2.2",
- "solana-epoch-schedule 2.2.1",
- "solana-fee-calculator 2.2.1",
+ "solana-clock 3.0.0",
+ "solana-epoch-schedule 3.0.0",
+ "solana-fee-calculator 3.0.0",
  "solana-genesis-config",
- "solana-hash 2.3.0",
+ "solana-hash 3.0.0",
  "solana-lattice-hash",
  "solana-measure",
- "solana-message 2.4.0",
+ "solana-message 3.0.0",
  "solana-metrics",
  "solana-nohash-hasher",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-rayon-threadlimit",
- "solana-rent-collector",
  "solana-reward-info",
- "solana-sha256-hasher 2.2.1",
- "solana-slot-hashes 2.2.1",
+ "solana-sha256-hasher 3.0.0",
+ "solana-slot-hashes 3.0.0",
  "solana-svm-transaction",
- "solana-system-interface 1.0.0",
- "solana-sysvar 2.2.2",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar 3.0.0",
  "solana-time-utils",
  "solana-transaction",
  "solana-transaction-context",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
  "spl-generic-token",
  "static_assertions",
  "tar",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4185,9 +4546,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a7a457086457ea9db9a5199d719dc8734dc2d0342fad0d8f77633c31eb62f19"
 dependencies = [
  "borsh 1.5.7",
+ "bytemuck",
+ "bytemuck_derive",
  "curve25519-dalek 4.1.3",
  "five8",
  "five8_const",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "solana-atomic-u64 3.0.0",
@@ -4222,7 +4586,13 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2f56cac5e70517a2f27d05e5100b20de7182473ffd0035b23ea273307905987"
 dependencies = [
+ "bincode",
+ "bytemuck",
+ "serde",
+ "serde_derive",
  "solana-clock 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-instruction-error",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids 3.0.0",
  "solana-slot-hashes 3.0.0",
@@ -4248,78 +4618,78 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5171881f7f7efa72b94bbac33f8fc54f913bc8f87b1937f34ef922d2f50dce"
+checksum = "f4caca031fbcab3f4dffe2036423b51d5109bd3f2ceafccd59b99ed33545470f"
 dependencies = [
  "borsh 1.5.7",
  "futures",
- "solana-account 2.2.1",
+ "solana-account 3.0.0",
  "solana-banks-interface",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
  "solana-commitment-config",
- "solana-hash 2.3.0",
- "solana-message 2.4.0",
- "solana-program-pack",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
+ "solana-hash 3.0.0",
+ "solana-message 3.0.0",
+ "solana-program-pack 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
  "solana-signature",
- "solana-sysvar 2.2.2",
+ "solana-sysvar 3.0.0",
  "solana-transaction",
  "solana-transaction-context",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
  "tarpc",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-serde",
 ]
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d565122efb0e1929f6c6d34e92ccca46d5f0045328622d738037da24c91c9d1b"
+checksum = "940656621f9d4389cfff2b32afcc5fd3800f7f95dff0e4d8131d55c4fe43d100"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-account 2.2.1",
- "solana-clock 2.2.2",
+ "solana-account 3.0.0",
+ "solana-clock 3.0.0",
  "solana-commitment-config",
- "solana-hash 2.3.0",
- "solana-message 2.4.0",
- "solana-pubkey 2.4.0",
+ "solana-hash 3.0.0",
+ "solana-message 3.0.0",
+ "solana-pubkey 3.0.0",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-context",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7c60901285f352c5b03d903958a33b8a9e3b75bf372bd35a6e87ca0eae0381"
+checksum = "fc3e31804e7306066cd3bad28c7555971eb567a1b95e9b8bb31dc31a48dc79fd"
 dependencies = [
  "agave-feature-set",
  "bincode",
  "crossbeam-channel",
  "futures",
- "solana-account 2.2.1",
+ "solana-account 3.0.0",
  "solana-banks-interface",
  "solana-client",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
  "solana-commitment-config",
- "solana-hash 2.3.0",
- "solana-message 2.4.0",
- "solana-pubkey 2.4.0",
+ "solana-hash 3.0.0",
+ "solana-message 3.0.0",
+ "solana-pubkey 3.0.0",
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-send-transaction-service",
  "solana-signature",
  "solana-svm",
  "solana-transaction",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
  "tarpc",
  "tokio",
  "tokio-serde",
@@ -4337,6 +4707,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-big-mod-exp"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "solana-define-syscall 3.0.0",
+]
+
+[[package]]
 name = "solana-bincode"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,6 +4726,17 @@ dependencies = [
  "bincode",
  "serde",
  "solana-instruction 2.3.0",
+]
+
+[[package]]
+name = "solana-bincode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534a37aecd21986089224d0c01006a75b96ac6fb2f418c24edc15baf0d2a4c99"
+dependencies = [
+ "bincode",
+ "serde",
+ "solana-instruction-error",
 ]
 
 [[package]]
@@ -4360,18 +4752,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-bn254"
-version = "2.2.2"
+name = "solana-blake3-hasher"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4420f125118732833f36facf96a27e7b78314b2d642ba07fa9ffdacd8d79e243"
+checksum = "ffa2e3bdac3339c6d0423275e45dafc5ac25f4d43bf344d026a3cc9a85e244a6"
+dependencies = [
+ "blake3",
+ "solana-define-syscall 3.0.0",
+ "solana-hash 3.0.0",
+]
+
+[[package]]
+name = "solana-bn254"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a5f01e99addb316d95d4ed31aa6eacfda557fffc00ae316b919e8ba0fc5b91"
 dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
  "bytemuck",
- "solana-define-syscall 2.3.0",
- "thiserror 2.0.12",
+ "solana-define-syscall 3.0.0",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4395,56 +4798,38 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435d7938247d4bbffdc04297539fb8f9bcc5f54a0ad8fcf2bc4eb22e0b11427"
+checksum = "1c0d0b4b15df3569a4d240c57b177b8e93f44efacd147b5b2303956da21dafe1"
 dependencies = [
+ "agave-syscalls",
  "bincode",
- "libsecp256k1",
- "num-traits",
  "qualifier_attr",
- "scopeguard",
- "solana-account 2.2.1",
- "solana-account-info 2.2.1",
- "solana-big-mod-exp",
- "solana-bincode",
- "solana-blake3-hasher",
- "solana-bn254",
- "solana-clock 2.2.2",
- "solana-cpi 2.2.1",
- "solana-curve25519",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
- "solana-keccak-hasher 2.2.1",
- "solana-loader-v3-interface 5.0.0",
- "solana-loader-v4-interface",
- "solana-log-collector",
- "solana-measure",
+ "solana-account 3.0.0",
+ "solana-bincode 3.0.0",
+ "solana-clock 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-loader-v3-interface 6.1.0",
+ "solana-loader-v4-interface 3.1.0",
  "solana-packet",
- "solana-poseidon",
- "solana-program-entrypoint 2.2.1",
+ "solana-program-entrypoint 3.1.0",
  "solana-program-runtime",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-sbpf",
- "solana-sdk-ids 2.2.1",
- "solana-secp256k1-recover",
- "solana-sha256-hasher 2.2.1",
- "solana-stable-layout 2.2.1",
+ "solana-sdk-ids 3.0.0",
  "solana-svm-feature-set",
- "solana-system-interface 1.0.0",
- "solana-sysvar 2.2.2",
- "solana-sysvar-id 2.2.1",
- "solana-timings",
+ "solana-svm-log-collector",
+ "solana-svm-measure",
+ "solana-svm-type-overrides",
+ "solana-system-interface 2.0.0",
  "solana-transaction-context",
- "solana-type-overrides",
- "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0baed2d92efa99923518ef026071810232740e4c82a6c4e084302a3c8963c10d"
+checksum = "6975244288387316f7dea1d532b14d51345c36e1f83b98e6cbdc8312727709dd"
 dependencies = [
  "bv",
  "bytemuck",
@@ -4453,27 +4838,27 @@ dependencies = [
  "modular-bitfield",
  "num_enum",
  "rand 0.8.5",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
  "solana-measure",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "tempfile",
 ]
 
 [[package]]
 name = "solana-builtins"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423c0ed5c9c79059d6f853b851d3e9a7e95b3f390e8c15efcfa3c66d4184f980"
+checksum = "dfdf0ceefc187f6028b29eb2d6dcac2e355b3c67aa045ebabbfca786e8d70d5d"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
- "solana-hash 2.3.0",
+ "solana-hash 3.0.0",
  "solana-loader-v4-program",
  "solana-program-runtime",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
- "solana-stake-program 2.3.6",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-stake-program 3.0.5",
  "solana-system-program",
  "solana-vote-program",
  "solana-zk-elgamal-proof-program",
@@ -4482,9 +4867,9 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aeec27cd875bcb5b17e0e74fbbe970c334f2c8a5d13720b6604372f4eb39bac"
+checksum = "3498f0bcd31dbe5ae530c54faa2f33819ec113d403c5faca5da5d7a703f947e4"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -4492,18 +4877,18 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
  "solana-loader-v4-program",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
- "solana-stake-program 2.3.6",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-stake-program 3.0.5",
  "solana-system-program",
  "solana-vote-program",
 ]
 
 [[package]]
 name = "solana-client"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1793999292740ee9e40245c987887b0648d3cf2b50e2d38679e9b04c22507e11"
+checksum = "58c96b68e457bab1ea06c513095a17cd1bddae5fe788d22f7e187d1eae72226b"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4515,17 +4900,17 @@ dependencies = [
  "log",
  "quinn",
  "rayon",
- "solana-account 2.2.1",
+ "solana-account 3.0.0",
  "solana-client-traits",
  "solana-commitment-config",
  "solana-connection-cache",
  "solana-epoch-info",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
  "solana-keypair",
  "solana-measure",
- "solana-message 2.4.0",
- "solana-pubkey 2.4.0",
+ "solana-message 3.0.0",
+ "solana-pubkey 3.0.0",
  "solana-pubsub-client",
  "solana-quic-client",
  "solana-quic-definitions",
@@ -4535,35 +4920,35 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-streamer",
- "solana-thin-client",
  "solana-time-utils",
  "solana-tpu-client",
  "solana-transaction",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
+ "solana-transaction-status-client-types",
  "solana-udp-client",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
 [[package]]
 name = "solana-client-traits"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0071874e629f29e0eb3dab8a863e98502ac7aba55b7e0df1803fc5cac72a7"
+checksum = "08618ed587e128105510c54ae3e456b9a06d674d8640db75afe66dad65cb4e02"
 dependencies = [
- "solana-account 2.2.1",
+ "solana-account 3.0.0",
  "solana-commitment-config",
  "solana-epoch-info",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
  "solana-keypair",
- "solana-message 2.4.0",
- "solana-pubkey 2.4.0",
+ "solana-message 3.0.0",
+ "solana-pubkey 3.0.0",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 1.0.0",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
 ]
 
 [[package]]
@@ -4594,20 +4979,20 @@ dependencies = [
 
 [[package]]
 name = "solana-cluster-type"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ace9fea2daa28354d107ea879cff107181d85cd4e0f78a2bedb10e1a428c97e"
+checksum = "eb7692fa6bf10a1a86b450c4775526f56d7e0e2116a53313f2533b5694abea64"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 2.3.0",
+ "solana-hash 3.0.0",
 ]
 
 [[package]]
 name = "solana-commitment-config"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac49c4dde3edfa832de1697e9bcdb7c3b3f7cb7a1981b7c62526c8bb6700fb73"
+checksum = "5fa5933a62dadb7d3ed35e6329de5cebb0678acc8f9cfdf413269084eeccc63f"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4615,9 +5000,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f45da2b9fdc06feb90f020bebda1dc3e2d4076e2044b1a330ddec67d4492a3a"
+checksum = "ad7f4ea0b6f186c25ffd2c3564deda1ec5610418b3396a7162f8956086b53a4a"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -4625,43 +5010,41 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736870acb9ea636ad321b31074ce6e64e5ce51973c05afd8ed38da7531d572a4"
+checksum = "210cb81e37c04c8808ecac169bfd0d1fbe0137175a6b932cb771a1c80abbe185"
 dependencies = [
  "agave-feature-set",
  "log",
- "solana-borsh 2.2.1",
+ "solana-borsh 3.0.0",
  "solana-builtins-default-costs",
  "solana-compute-budget",
  "solana-compute-budget-interface",
- "solana-instruction 2.3.0",
+ "solana-instruction 3.0.0",
  "solana-packet",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
  "solana-svm-transaction",
- "solana-transaction-error 2.2.1",
- "thiserror 2.0.12",
+ "solana-transaction-error 3.0.0",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-compute-budget-interface"
-version = "2.2.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8432d2c4c22d0499aa06d62e4f7e333f81777b3d7c96050ae9e5cb71a8c3aee4"
+checksum = "8292c436b269ad23cecc8b24f7da3ab07ca111661e25e00ce0e1d22771951ab9"
 dependencies = [
  "borsh 1.5.7",
- "serde",
- "serde_derive",
- "solana-instruction 2.3.0",
- "solana-sdk-ids 2.2.1",
+ "solana-instruction 3.0.0",
+ "solana-sdk-ids 3.0.0",
 ]
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90113e99d618a141e1ebf016fcd2a5722bf7547260ccfc3202ab757034b94898"
+checksum = "561a932e17967ba85c54d7987f1823f455cfdcbdcbd106a3938946bd002843ea"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -4680,23 +5063,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-config-program-client"
-version = "0.0.2"
+name = "solana-config-interface"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53aceac36f105fd4922e29b4f0c1f785b69d7b3e7e387e384b8985c8e0c3595e"
+checksum = "63e401ae56aed512821cc7a0adaa412ff97fecd2dff4602be7b1330d2daec0c4"
 dependencies = [
  "bincode",
- "borsh 0.10.4",
- "kaigan",
  "serde",
- "solana-program",
+ "serde_derive",
+ "solana-account 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-short-vec 3.0.0",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdb20d50937e157f139154369207c87377cd7bfc3b1ca1b22d8bd1115c47f8e"
+checksum = "705bd6853d523dcab773eb32c1e3b47f367276e368148afb532293604a027dd2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4710,36 +5097,36 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-time-utils",
- "solana-transaction-error 2.2.1",
- "thiserror 2.0.12",
+ "solana-transaction-error 3.0.0",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
 [[package]]
 name = "solana-cost-model"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2aecc9df0a6d87c13785a64e08a420fcf3fd7fa55551620408a822d4e288b41"
+checksum = "a0b00204940763b36862107e2c728462b7faf5b9ea9b86be36d96672c73c056a"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
  "log",
- "solana-bincode",
- "solana-borsh 2.2.1",
+ "solana-bincode 3.0.0",
+ "solana-borsh 3.0.0",
  "solana-builtins-default-costs",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
  "solana-fee-structure",
  "solana-metrics",
  "solana-packet",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-runtime-transaction",
- "solana-sdk-ids 2.2.1",
+ "solana-sdk-ids 3.0.0",
  "solana-svm-transaction",
- "solana-system-interface 1.0.0",
- "solana-transaction-error 2.2.1",
+ "solana-system-interface 2.0.0",
+ "solana-transaction-error 3.0.0",
  "solana-vote-program",
 ]
 
@@ -4773,16 +5160,16 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6269c8dded5d571c75a4a32997514f57f23757f2e18549ca3040586465e336"
+checksum = "35cead1611796d2dbb09ed42c15f775fefdf5d9f02e522bcb651914e87b393c2"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-define-syscall 2.3.0",
+ "solana-define-syscall 3.0.0",
  "subtle",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4808,9 +5195,9 @@ checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
 
 [[package]]
 name = "solana-derivation-path"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "939756d798b25c5ec3cca10e06212bdca3b1443cb9bb740a38124f58b258737b"
+checksum = "ff71743072690fdbdfcdc37700ae1cb77485aaad49019473a81aee099b1e0b8c"
 dependencies = [
  "derivation-path",
  "qstring",
@@ -4819,24 +5206,21 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feafa1691ea3ae588f99056f4bdd1293212c7ece28243d7da257c443e84753"
+checksum = "e1419197f1c06abf760043f6d64ba9d79a03ad5a43f18c7586471937122094da"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
- "ed25519-dalek",
- "solana-feature-set",
- "solana-instruction 2.3.0",
- "solana-precompile-error",
- "solana-sdk-ids 2.2.1",
+ "solana-instruction 3.0.0",
+ "solana-sdk-ids 3.0.0",
 ]
 
 [[package]]
 name = "solana-epoch-info"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ef6f0b449290b0b9f32973eefd95af35b01c5c0c34c569f936c34c5b20d77b"
+checksum = "f8a6b69bd71386f61344f2bcf0f527f5fd6dd3b22add5880e2e1bf1dd1fa8059"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4872,13 +5256,13 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-rewards-hasher"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c5fd2662ae7574810904585fd443545ed2b568dbd304b25a31e79ccc76e81b"
+checksum = "e507099d0c2c5d7870c9b1848281ea67bbeee80d171ca85003ee5767994c9c38"
 dependencies = [
  "siphasher 0.3.11",
- "solana-hash 2.3.0",
- "solana-pubkey 2.4.0",
+ "solana-hash 3.0.0",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -4925,7 +5309,7 @@ dependencies = [
  "solana-pubkey 2.4.0",
  "solana-sdk-ids 2.2.1",
  "solana-system-interface 1.0.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4946,7 +5330,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-sdk-ids 3.0.0",
  "solana-system-interface 2.0.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4969,24 +5353,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-feature-set"
-version = "2.2.1"
+name = "solana-feature-gate-interface"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e1d3b52b4a014efeaaab67f14e40af3972a4be61c523d612860db8e3145529"
+checksum = "7347ab62e6d47a82e340c865133795b394feea7c2b2771d293f57691c6544c3f"
 dependencies = [
- "ahash 0.8.11",
- "lazy_static",
- "solana-epoch-schedule 2.2.1",
- "solana-hash 2.3.0",
- "solana-pubkey 2.4.0",
- "solana-sha256-hasher 2.2.1",
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-account 3.0.0",
+ "solana-account-info 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-program-error 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
 name = "solana-fee"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14d795ca750c94c004de736fbb6c157f8eecba99d047b9dedae5737c0bd0be9"
+checksum = "5e6667d85441707518bcd9cfd544f6688f2242649d9d5eddcaa12f42b2107500"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -5017,14 +5406,12 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-structure"
-version = "2.3.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33adf673581c38e810bf618f745bf31b683a0a4a4377682e6aaac5d9a058dd4e"
+checksum = "5e2abdb1223eea8ec64136f39cb1ffcf257e00f915c957c35c0dd9e3f4e700b0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-message 2.4.0",
- "solana-native-token",
 ]
 
 [[package]]
@@ -5046,7 +5433,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.8",
  "solana-frozen-abi-macro",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5062,30 +5449,28 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-config"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968dabd2b92d57131473eddbd475339da530e14f54397386abf303de3a2595a2"
+checksum = "749eccc960e85c9b33608450093d256006253e1cb436b8380e71777840a3f675"
 dependencies = [
  "bincode",
  "chrono",
  "memmap2 0.5.10",
  "serde",
  "serde_derive",
- "solana-account 2.2.1",
- "solana-clock 2.2.2",
+ "solana-account 3.0.0",
+ "solana-clock 3.0.0",
  "solana-cluster-type",
- "solana-epoch-schedule 2.2.1",
- "solana-fee-calculator 2.2.1",
- "solana-hash 2.3.0",
+ "solana-epoch-schedule 3.0.0",
+ "solana-fee-calculator 3.0.0",
+ "solana-hash 3.0.0",
  "solana-inflation",
  "solana-keypair",
- "solana-logger",
- "solana-native-token",
  "solana-poh-config",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
- "solana-sdk-ids 2.2.1",
- "solana-sha256-hasher 2.2.1",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-sha256-hasher 3.0.0",
  "solana-shred-version",
  "solana-signer",
  "solana-time-utils",
@@ -5093,9 +5478,9 @@ dependencies = [
 
 [[package]]
 name = "solana-hard-forks"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c28371f878e2ead55611d8ba1b5fb879847156d04edea13693700ad1a28baf"
+checksum = "0abacc4b66ce471f135f48f22facf75cbbb0f8a252fbe2c1e0aa59d5b203f519"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5136,9 +5521,9 @@ dependencies = [
 
 [[package]]
 name = "solana-inflation"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23eef6a09eb8e568ce6839573e4966850e85e9ce71e6ae1a6c930c1c43947de3"
+checksum = "e92f37a14e7c660628752833250dd3dcd8e95309876aee751d7f8769a27947c6"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5186,6 +5571,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f0d483b8ae387178d9210e0575b666b05cdd4bd0f2f188128249f6e454d39d"
 dependencies = [
  "num-traits",
+ "serde",
+ "serde_derive",
  "solana-program-error 3.0.0",
 ]
 
@@ -5202,8 +5589,26 @@ dependencies = [
  "solana-pubkey 2.4.0",
  "solana-sanitize 2.2.1",
  "solana-sdk-ids 2.2.1",
- "solana-serialize-utils",
+ "solana-serialize-utils 2.2.1",
  "solana-sysvar-id 2.2.1",
+]
+
+[[package]]
+name = "solana-instructions-sysvar"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddf67876c541aa1e21ee1acae35c95c6fbc61119814bfef70579317a5e26955"
+dependencies = [
+ "bitflags",
+ "solana-account-info 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-instruction-error",
+ "solana-program-error 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-sanitize 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-serialize-utils 3.1.0",
+ "solana-sysvar-id 3.0.0",
 ]
 
 [[package]]
@@ -5224,27 +5629,27 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57eebd3012946913c8c1b8b43cdf8a6249edb09c0b6be3604ae910332a3acd97"
 dependencies = [
+ "sha3",
  "solana-define-syscall 3.0.0",
  "solana-hash 3.0.0",
 ]
 
 [[package]]
 name = "solana-keypair"
-version = "2.2.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dbb7042c2e0c561afa07242b2099d55c57bd1b1da3b6476932197d84e15e3e4"
+checksum = "952ed9074c12edd2060cb09c2a8c664303f4ab7f7056a407ac37dd1da7bdaa3e"
 dependencies = [
- "bs58",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "ed25519-dalek-bip32",
- "rand 0.7.3",
+ "five8",
+ "rand 0.8.5",
  "solana-derivation-path",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -5275,9 +5680,9 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f33a536b2bc459e1443b1bbf807957919fd85b380b7615bcf27df4244cd908d"
+checksum = "99f3718b8d06bbd186b4db175112c3a1743f5b9dc0d8878a37f5350edb77b9bc"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -5316,17 +5721,17 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "5.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7162a05b8b0773156b443bccd674ea78bb9aa406325b467ea78c06c99a63a2"
+checksum = "dee44c9b1328c5c712c68966fb8de07b47f3e7bac006e74ddd1bb053d3e46e5d"
 dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "solana-instruction 2.3.0",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
- "solana-system-interface 1.0.0",
+ "solana-instruction 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -5345,44 +5750,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-loader-v4-program"
-version = "2.3.6"
+name = "solana-loader-v4-interface"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3200cc1e57efa2d18f370dd828d26106fe9e4b01332272ed3fb5d005a0edee52"
+checksum = "e4c948b33ff81fa89699911b207059e493defdba9647eaf18f23abdf3674e0fb"
 dependencies = [
- "log",
- "qualifier_attr",
- "solana-account 2.2.1",
- "solana-bincode",
- "solana-bpf-loader-program",
- "solana-instruction 2.3.0",
- "solana-loader-v3-interface 5.0.0",
- "solana-loader-v4-interface",
- "solana-log-collector",
- "solana-measure",
- "solana-packet",
- "solana-program-runtime",
- "solana-pubkey 2.4.0",
- "solana-sbpf",
- "solana-sdk-ids 2.2.1",
- "solana-transaction-context",
- "solana-type-overrides",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
-name = "solana-log-collector"
-version = "2.3.6"
+name = "solana-loader-v4-program"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc85854914788b7cd377183a991ea94ed0779f0dee086f86af512f928ee07c5"
+checksum = "c2dd1c20797b62e8c12fc524c81b76f50f10ab1d186c611b5bf3c8b63644d1fe"
 dependencies = [
  "log",
+ "qualifier_attr",
+ "solana-account 3.0.0",
+ "solana-bincode 3.0.0",
+ "solana-bpf-loader-program",
+ "solana-instruction 3.0.0",
+ "solana-loader-v3-interface 6.1.0",
+ "solana-loader-v4-interface 3.1.0",
+ "solana-packet",
+ "solana-program-runtime",
+ "solana-pubkey 3.0.0",
+ "solana-sbpf",
+ "solana-sdk-ids 3.0.0",
+ "solana-svm-log-collector",
+ "solana-svm-measure",
+ "solana-svm-type-overrides",
+ "solana-transaction-context",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8e777ec1afd733939b532a42492d888ec7c88d8b4127a5d867eb45c6eb5cd5"
+checksum = "ef7421d1092680d72065edbf5c7605856719b021bf5f173656c71febcdd5d003"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5393,9 +5804,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6371c5d9be72d0c88b017955123908fc720d7b16cb69919f6cd240571f4e395"
+checksum = "65394907101cb3c894c29b10b582cec717691a4af560fc29bc34cf0258c66e22"
 
 [[package]]
 name = "solana-message"
@@ -5408,7 +5819,7 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_derive",
- "solana-bincode",
+ "solana-bincode 2.2.1",
  "solana-hash 2.3.0",
  "solana-instruction 2.3.0",
  "solana-pubkey 2.4.0",
@@ -5426,6 +5837,8 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c33e9fa7871147ac3235a7320386afa2dc64bbb21ca3cf9d79a6f6827313176"
 dependencies = [
+ "bincode",
+ "blake3",
  "lazy_static",
  "serde",
  "serde_derive",
@@ -5440,18 +5853,18 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce9cae65b6ecfa734aebcdd08dd0d6f37ab074f1a1a05395660f6fbfcca6fde"
+checksum = "a317e32ee712e176f7ca3639e12041068ece903a7841b422644651360710e0c6"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
  "log",
  "reqwest",
  "solana-cluster-type",
- "solana-sha256-hasher 2.2.1",
+ "solana-sha256-hasher 3.0.0",
  "solana-time-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5479,10 +5892,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61515b880c36974053dd499c0510066783f0cc6ac17def0c7ef2a244874cf4a9"
 
 [[package]]
-name = "solana-net-utils"
-version = "2.3.6"
+name = "solana-native-token"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4eb0a0779fe252b7fcdcd367a7dc25fe4cac4db9390312f906896caf3e4364"
+checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
+
+[[package]]
+name = "solana-net-utils"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e373baffe78f30acfa8a8f787987389b264d86c4243d5e7006f4b643d2da6e9a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5493,7 +5912,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_derive",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "solana-serde",
  "tokio",
  "url",
@@ -5525,6 +5944,8 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abbdc6c8caf1c08db9f36a50967539d0f72b9f1d4aea04fec5430f532e5afadc"
 dependencies = [
+ "serde",
+ "serde_derive",
  "solana-fee-calculator 3.0.0",
  "solana-hash 3.0.0",
  "solana-pubkey 3.0.0",
@@ -5533,37 +5954,21 @@ dependencies = [
 
 [[package]]
 name = "solana-nonce-account"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde971a20b8dbf60144d6a84439dda86b5466e00e2843091fe731083cda614da"
+checksum = "805fd25b29e5a1a0e6c3dd6320c9da80f275fbe4ff6e392617c303a2085c435e"
 dependencies = [
- "solana-account 2.2.1",
- "solana-hash 2.3.0",
- "solana-nonce 2.2.1",
- "solana-sdk-ids 2.2.1",
-]
-
-[[package]]
-name = "solana-offchain-message"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b526398ade5dea37f1f147ce55dae49aa017a5d7326606359b0445ca8d946581"
-dependencies = [
- "num_enum",
- "solana-hash 2.3.0",
- "solana-packet",
- "solana-pubkey 2.4.0",
- "solana-sanitize 2.2.1",
- "solana-sha256-hasher 2.2.1",
- "solana-signature",
- "solana-signer",
+ "solana-account 3.0.0",
+ "solana-hash 3.0.0",
+ "solana-nonce 3.0.0",
+ "solana-sdk-ids 3.0.0",
 ]
 
 [[package]]
 name = "solana-packet"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004f2d2daf407b3ec1a1ca5ec34b3ccdfd6866dd2d3c7d0715004a96e4b6d127"
+checksum = "6edf2f25743c95229ac0fdc32f8f5893ef738dbf332c669e9861d33ddb0f469d"
 dependencies = [
  "bincode",
  "bitflags",
@@ -5575,9 +5980,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305dc857cdc4b9d9d4c23e5c3f80a32e86362a7031f5d8c7885916ba8142f7cc"
+checksum = "2931167c53ccd05494581e7468fbf8546f2f2fcf9291c8565d756b1e6fc207c9"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -5593,23 +5998,23 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "serde",
- "solana-hash 2.3.0",
- "solana-message 2.4.0",
+ "solana-hash 3.0.0",
+ "solana-message 3.0.0",
  "solana-metrics",
  "solana-packet",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-rayon-threadlimit",
- "solana-sdk-ids 2.2.1",
- "solana-short-vec 2.2.1",
+ "solana-sdk-ids 3.0.0",
+ "solana-short-vec 3.0.0",
  "solana-signature",
  "solana-time-utils",
 ]
 
 [[package]]
 name = "solana-poh-config"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d650c3b4b9060082ac6b0efbbb66865089c58405bfb45de449f3f2b91eccee75"
+checksum = "2f1fef1f2ff2480fdbcc64bef5e3c47bec6e1647270db88b43f23e3a55f8d9cf"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5617,52 +6022,23 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac40625dac6471cbeaa92cc07edb2ea0e718c6ab63c3c856df142b3a57dd3b8b"
+checksum = "f8a22d843a72121bbb45b5dd25ca657d7003b336835c9c648dce85707e7908fb"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
- "solana-define-syscall 2.3.0",
- "thiserror 2.0.12",
+ "solana-define-syscall 3.0.0",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-precompile-error"
-version = "2.2.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d87b2c1f5de77dfe2b175ee8dd318d196aaca4d0f66f02842f80c852811f9f8"
+checksum = "cafcd950de74c6c39d55dc8ca108bbb007799842ab370ef26cf45a34453c31e1"
 dependencies = [
  "num-traits",
- "solana-decode-error",
-]
-
-[[package]]
-name = "solana-precompiles"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a460ab805ec063802105b463ecb5eb02c3ffe469e67a967eea8a6e778e0bc06"
-dependencies = [
- "lazy_static",
- "solana-ed25519-program",
- "solana-feature-set",
- "solana-message 2.4.0",
- "solana-precompile-error",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
- "solana-secp256k1-program",
- "solana-secp256r1-program",
-]
-
-[[package]]
-name = "solana-presigner"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a57a24e6a4125fc69510b6774cd93402b943191b6cddad05de7281491c90fe"
-dependencies = [
- "solana-pubkey 2.4.0",
- "solana-signature",
- "solana-signer",
 ]
 
 [[package]]
@@ -5693,9 +6069,9 @@ dependencies = [
  "solana-account-info 2.2.1",
  "solana-address-lookup-table-interface 2.2.2",
  "solana-atomic-u64 2.2.1",
- "solana-big-mod-exp",
- "solana-bincode",
- "solana-blake3-hasher",
+ "solana-big-mod-exp 2.2.1",
+ "solana-bincode 2.2.1",
+ "solana-blake3-hasher 2.2.1",
  "solana-borsh 2.2.1",
  "solana-clock 2.2.2",
  "solana-cpi 2.2.1",
@@ -5704,33 +6080,33 @@ dependencies = [
  "solana-epoch-rewards 2.2.1",
  "solana-epoch-schedule 2.2.1",
  "solana-example-mocks 2.2.1",
- "solana-feature-gate-interface",
+ "solana-feature-gate-interface 2.2.2",
  "solana-fee-calculator 2.2.1",
  "solana-hash 2.3.0",
  "solana-instruction 2.3.0",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 2.2.2",
  "solana-keccak-hasher 2.2.1",
  "solana-last-restart-slot 2.2.1",
  "solana-loader-v2-interface",
  "solana-loader-v3-interface 3.0.0",
- "solana-loader-v4-interface",
+ "solana-loader-v4-interface 2.2.1",
  "solana-message 2.4.0",
  "solana-msg 2.2.1",
- "solana-native-token",
+ "solana-native-token 2.3.0",
  "solana-nonce 2.2.1",
  "solana-program-entrypoint 2.2.1",
  "solana-program-error 2.2.1",
  "solana-program-memory 2.2.1",
  "solana-program-option",
- "solana-program-pack",
+ "solana-program-pack 2.2.1",
  "solana-pubkey 2.4.0",
  "solana-rent 2.2.1",
  "solana-sanitize 2.2.1",
  "solana-sdk-ids 2.2.1",
  "solana-sdk-macro 2.2.1",
- "solana-secp256k1-recover",
- "solana-serde-varint",
- "solana-serialize-utils",
+ "solana-secp256k1-recover 2.2.1",
+ "solana-serde-varint 2.2.2",
+ "solana-serialize-utils 2.2.1",
  "solana-sha256-hasher 2.2.1",
  "solana-short-vec 2.2.1",
  "solana-slot-hashes 2.2.1",
@@ -5740,8 +6116,8 @@ dependencies = [
  "solana-system-interface 1.0.0",
  "solana-sysvar 2.2.2",
  "solana-sysvar-id 2.2.1",
- "solana-vote-interface",
- "thiserror 2.0.12",
+ "solana-vote-interface 2.2.6",
+ "thiserror 2.0.17",
  "wasm-bindgen",
 ]
 
@@ -5759,9 +6135,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-entrypoint"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb61aaf3bf54b69721fbaadb0942cfd41f608cf279e514c1362264a24e469a9e"
+checksum = "6557cf5b5e91745d1667447438a1baa7823c6086e4ece67f8e6ebfa7a8f72660"
 dependencies = [
  "solana-account-info 3.0.0",
  "solana-define-syscall 3.0.0",
@@ -5830,53 +6206,60 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-program-runtime"
-version = "2.3.6"
+name = "solana-program-pack"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0858a5173268db5c3f81ca3e7f8be60c2b74aeb54527af753ca4459d7b816902"
+checksum = "c169359de21f6034a63ebf96d6b380980307df17a8d371344ff04a883ec4e9d0"
+dependencies = [
+ "solana-program-error 3.0.0",
+]
+
+[[package]]
+name = "solana-program-runtime"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4ac46f029a1250623fc8817e5f781b9a23c1e09d493de1787e7cfdc4a518bf"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "enum-iterator",
  "itertools 0.12.1",
  "log",
  "percentage",
  "rand 0.8.5",
  "serde",
- "solana-account 2.2.1",
- "solana-clock 2.2.2",
- "solana-epoch-rewards 2.2.1",
- "solana-epoch-schedule 2.2.1",
+ "solana-account 3.0.0",
+ "solana-clock 3.0.0",
+ "solana-epoch-rewards 3.0.0",
+ "solana-epoch-schedule 3.0.0",
  "solana-fee-structure",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
- "solana-last-restart-slot 2.2.1",
- "solana-log-collector",
- "solana-measure",
- "solana-metrics",
- "solana-program-entrypoint 2.2.1",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-last-restart-slot 3.0.0",
+ "solana-program-entrypoint 3.1.0",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
  "solana-sbpf",
- "solana-sdk-ids 2.2.1",
- "solana-slot-hashes 2.2.1",
- "solana-stable-layout 2.2.1",
+ "solana-sdk-ids 3.0.0",
+ "solana-slot-hashes 3.0.0",
+ "solana-stake-interface 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-svm-callback",
  "solana-svm-feature-set",
- "solana-system-interface 1.0.0",
- "solana-sysvar 2.2.2",
- "solana-sysvar-id 2.2.1",
- "solana-timings",
+ "solana-svm-log-collector",
+ "solana-svm-measure",
+ "solana-svm-timings",
+ "solana-svm-transaction",
+ "solana-svm-type-overrides",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar 3.0.0",
+ "solana-sysvar-id 3.0.0",
  "solana-transaction-context",
- "solana-type-overrides",
- "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941e90d0ff6f155b71a57013fe59f3cb8c1a12e7d71009ba89af87266dc7897e"
+checksum = "857778d5ac1e1550b8f4fb05093e51f716cf3bc7e32afac8773492284448f53b"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -5887,51 +6270,52 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "serde",
- "solana-account 2.2.1",
- "solana-account-info 2.2.1",
+ "solana-account 3.0.0",
+ "solana-account-info 3.0.0",
  "solana-accounts-db",
  "solana-banks-client",
  "solana-banks-interface",
  "solana-banks-server",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
+ "solana-cluster-type",
  "solana-commitment-config",
  "solana-compute-budget",
- "solana-epoch-rewards 2.2.1",
- "solana-epoch-schedule 2.2.1",
- "solana-fee-calculator 2.2.1",
+ "solana-epoch-rewards 3.0.0",
+ "solana-epoch-schedule 3.0.0",
+ "solana-fee-calculator 3.0.0",
  "solana-genesis-config",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
  "solana-keypair",
- "solana-loader-v3-interface 5.0.0",
- "solana-log-collector",
+ "solana-loader-v3-interface 6.1.0",
  "solana-logger",
- "solana-message 2.4.0",
- "solana-msg 2.2.1",
- "solana-native-token",
+ "solana-message 3.0.0",
+ "solana-msg 3.0.0",
+ "solana-native-token 3.0.0",
  "solana-poh-config",
- "solana-program-entrypoint 2.2.1",
- "solana-program-error 2.2.1",
+ "solana-program-entrypoint 3.1.0",
+ "solana-program-error 3.0.0",
  "solana-program-runtime",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
  "solana-runtime",
  "solana-sbpf",
- "solana-sdk-ids 2.2.1",
+ "solana-sdk-ids 3.0.0",
  "solana-signer",
- "solana-stable-layout 2.2.1",
- "solana-stake-interface 1.2.1",
+ "solana-stable-layout 3.0.0",
+ "solana-stake-interface 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-svm",
- "solana-system-interface 1.0.0",
- "solana-sysvar 2.2.2",
- "solana-sysvar-id 2.2.1",
- "solana-timings",
+ "solana-svm-log-collector",
+ "solana-svm-timings",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar 3.0.0",
+ "solana-sysvar-id 3.0.0",
  "solana-transaction",
  "solana-transaction-context",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
  "solana-vote-program",
  "spl-generic-token",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
@@ -5951,7 +6335,6 @@ dependencies = [
  "getrandom 0.2.15",
  "js-sys",
  "num-traits",
- "rand 0.8.5",
  "serde",
  "serde_derive",
  "solana-atomic-u64 2.2.1",
@@ -5968,14 +6351,15 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
 dependencies = [
+ "rand 0.8.5",
  "solana-address",
 ]
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa010fc15a9d786b74de00e39da48df03b8f47fd7b5198cb01a2ce9f7511cb9"
+checksum = "8d858f0ac64c2d685d79dcd7d5f38b573a59b7e5afd110cca0d0b3cd836a0ee9"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5986,11 +6370,11 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-clock 2.2.2",
- "solana-pubkey 2.4.0",
+ "solana-clock 3.0.0",
+ "solana-pubkey 3.0.0",
  "solana-rpc-client-types",
  "solana-signature",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -6000,9 +6384,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5485bb04c96f8b40ef47ed98204f86217a241234fe745dbdfa6cac469a6efb"
+checksum = "f39f3a8b8367966dacb2d77cc203970fe4b5c9e93760428cda6c6874b8a8fb5e"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6011,38 +6395,39 @@ dependencies = [
  "log",
  "quinn",
  "quinn-proto",
- "rustls 0.23.29",
+ "rustls 0.23.32",
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-quic-definitions",
  "solana-rpc-client-api",
  "solana-signer",
  "solana-streamer",
  "solana-tls-utils",
- "solana-transaction-error 2.2.1",
- "thiserror 2.0.12",
+ "solana-transaction-error 3.0.0",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
 [[package]]
 name = "solana-quic-definitions"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e606feac5110eb5d8afaa43ccaeea3ec49ccec36773387930b5ba545e745aea2"
+checksum = "15319accf7d3afd845817aeffa6edd8cc185f135cefbc6b985df29cfd8c09609"
 dependencies = [
  "solana-keypair",
 ]
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d219c657ea454d0a0f90ecb6c7ca2f62151f5b52082bb717d3c5aa5e4ea64bd0"
+checksum = "978db5d316ec95038593ea62845cd8125b89cbe698f217bdf63d2cf416a5d515"
 dependencies = [
+ "log",
  "num_cpus",
 ]
 
@@ -6073,49 +6458,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-rent-collector"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1e19f5d5108b0d824244425e43bc78bbb9476e2199e979b0230c9f632d3bf4"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-account 2.2.1",
- "solana-clock 2.2.2",
- "solana-epoch-schedule 2.2.1",
- "solana-genesis-config",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
- "solana-sdk-ids 2.2.1",
-]
-
-[[package]]
-name = "solana-rent-debits"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6f9113c6003492e74438d1288e30cffa8ccfdc2ef7b49b9e816d8034da18cd"
-dependencies = [
- "solana-pubkey 2.4.0",
- "solana-reward-info",
-]
-
-[[package]]
-name = "solana-reserved-account-keys"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b293f4246626c0e0a991531f08848a713ada965612e99dc510963f04d12cae7"
-dependencies = [
- "lazy_static",
- "solana-feature-set",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
-]
-
-[[package]]
 name = "solana-reward-info"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18205b69139b1ae0ab8f6e11cdcb627328c0814422ad2482000fa2ca54ae4a2f"
+checksum = "82be7946105c2ee6be9f9ee7bd18a068b558389221d29efa92b906476102bfcc"
 dependencies = [
  "serde",
  "serde_derive",
@@ -6123,9 +6469,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609c855934b9b5ccdb0b1ab89313b4302eac4cf2bdb7298716104185614cd1ba"
+checksum = "6d60f25b9ef788dc5db6fd853bf05f6d939b41bbd494898cb58d87a78bb5d3fe"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6140,32 +6486,32 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account 2.2.1",
+ "solana-account 3.0.0",
  "solana-account-decoder-client-types",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
  "solana-commitment-config",
  "solana-epoch-info",
- "solana-epoch-schedule 2.2.1",
- "solana-feature-gate-interface",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
- "solana-message 2.4.0",
- "solana-pubkey 2.4.0",
+ "solana-epoch-schedule 3.0.0",
+ "solana-feature-gate-interface 3.0.0",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-message 3.0.0",
+ "solana-pubkey 3.0.0",
  "solana-rpc-client-api",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
  "solana-transaction-status-client-types",
  "solana-version",
- "solana-vote-interface",
+ "solana-vote-interface 3.0.0",
  "tokio",
 ]
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f932401ae69ff436e18dc27de5279ec1056aebd471a9e4e48d4d4d40431d784"
+checksum = "e23c95842f140a82089e1c4bb2ac8215ebec7f766e26e9cd7f49961cce165a1e"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -6175,36 +6521,36 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
  "solana-rpc-client-types",
  "solana-signer",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
  "solana-transaction-status-client-types",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce22eb0035a10f2fc0c9214bef85bcc20a8b876d4f991bab18568c5154e466b"
+checksum = "aa1c728d119b7578f52a563768d0b008b8157735633a1be32d534af8e91c7853"
 dependencies = [
- "solana-account 2.2.1",
+ "solana-account 3.0.0",
  "solana-commitment-config",
- "solana-hash 2.3.0",
- "solana-message 2.4.0",
- "solana-nonce 2.2.1",
- "solana-pubkey 2.4.0",
+ "solana-hash 3.0.0",
+ "solana-message 3.0.0",
+ "solana-nonce 3.0.0",
+ "solana-pubkey 3.0.0",
  "solana-rpc-client",
- "solana-sdk-ids 2.2.1",
- "thiserror 2.0.12",
+ "solana-sdk-ids 3.0.0",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ecc13a2e2daa6823289e8f840098bc85388a114c9bf939b357443c3a7849612"
+checksum = "5fe4d441883a072b91b673dd31240006d15a05805759f26a75f7c9aa6f03c4c7"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6212,31 +6558,33 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account 2.2.1",
+ "solana-account 3.0.0",
  "solana-account-decoder-client-types",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
  "solana-commitment-config",
- "solana-fee-calculator 2.2.1",
+ "solana-fee-calculator 3.0.0",
  "solana-inflation",
- "solana-pubkey 2.4.0",
- "solana-transaction-error 2.2.1",
+ "solana-pubkey 3.0.0",
+ "solana-transaction-error 3.0.0",
  "solana-transaction-status-client-types",
  "solana-version",
  "spl-generic-token",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-runtime"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ae52e5588113ee2bf8c826d65721cc448e6a0a1f404c76418d1a8c451a71c8"
+checksum = "308c2726b25e10a31ac410550fa7eaeb487446f403747e168194e71d9b502c0c"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
  "agave-reserved-account-keys",
+ "agave-syscalls",
  "ahash 0.8.11",
  "aquamarine",
+ "arc-swap",
  "arrayref",
  "assert_matches",
  "base64 0.22.1",
@@ -6244,11 +6592,9 @@ dependencies = [
  "blake3",
  "bv",
  "bytemuck",
- "bzip2",
  "crossbeam-channel",
  "dashmap",
  "dir-diff",
- "flate2",
  "fnv",
  "im",
  "itertools 0.12.1",
@@ -6271,86 +6617,84 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with",
- "solana-account 2.2.1",
- "solana-account-info 2.2.1",
+ "solana-account 3.0.0",
+ "solana-account-info 3.0.0",
  "solana-accounts-db",
- "solana-address-lookup-table-interface 2.2.2",
+ "solana-address-lookup-table-interface 3.0.0",
  "solana-bpf-loader-program",
  "solana-bucket-map",
  "solana-builtins",
  "solana-client-traits",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
+ "solana-cluster-type",
  "solana-commitment-config",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
  "solana-cost-model",
- "solana-cpi 2.2.1",
+ "solana-cpi 3.0.0",
  "solana-ed25519-program",
  "solana-epoch-info",
  "solana-epoch-rewards-hasher",
- "solana-epoch-schedule 2.2.1",
- "solana-feature-gate-interface",
+ "solana-epoch-schedule 3.0.0",
+ "solana-feature-gate-interface 3.0.0",
  "solana-fee",
- "solana-fee-calculator 2.2.1",
+ "solana-fee-calculator 3.0.0",
  "solana-fee-structure",
  "solana-genesis-config",
  "solana-hard-forks",
- "solana-hash 2.3.0",
+ "solana-hash 3.0.0",
  "solana-inflation",
- "solana-instruction 2.3.0",
+ "solana-instruction 3.0.0",
  "solana-keypair",
  "solana-lattice-hash",
- "solana-loader-v3-interface 5.0.0",
- "solana-loader-v4-interface",
+ "solana-loader-v3-interface 6.1.0",
+ "solana-loader-v4-interface 3.1.0",
  "solana-measure",
- "solana-message 2.4.0",
+ "solana-message 3.0.0",
  "solana-metrics",
- "solana-native-token",
+ "solana-native-token 3.0.0",
  "solana-nohash-hasher",
- "solana-nonce 2.2.1",
+ "solana-nonce 3.0.0",
  "solana-nonce-account",
  "solana-packet",
  "solana-perf",
  "solana-poh-config",
  "solana-precompile-error",
  "solana-program-runtime",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-rayon-threadlimit",
- "solana-rent 2.2.1",
- "solana-rent-collector",
- "solana-rent-debits",
+ "solana-rent 3.0.0",
  "solana-reward-info",
  "solana-runtime-transaction",
- "solana-sdk-ids 2.2.1",
+ "solana-sdk-ids 3.0.0",
  "solana-secp256k1-program",
  "solana-seed-derivable",
  "solana-serde",
- "solana-sha256-hasher 2.2.1",
+ "solana-sha256-hasher 3.0.0",
  "solana-signature",
  "solana-signer",
- "solana-slot-hashes 2.2.1",
- "solana-slot-history 2.2.1",
- "solana-stake-interface 1.2.1",
- "solana-stake-program 2.3.6",
+ "solana-slot-hashes 3.0.0",
+ "solana-slot-history 3.0.0",
+ "solana-stake-interface 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-stake-program 3.0.5",
  "solana-svm",
  "solana-svm-callback",
- "solana-svm-rent-collector",
+ "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface 1.0.0",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
- "solana-sysvar 2.2.2",
- "solana-sysvar-id 2.2.1",
+ "solana-sysvar 3.0.0",
+ "solana-sysvar-id 3.0.0",
  "solana-time-utils",
- "solana-timings",
  "solana-transaction",
  "solana-transaction-context",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
  "solana-vote",
- "solana-vote-interface",
+ "solana-vote-interface 3.0.0",
  "solana-vote-program",
  "spl-generic-token",
  "static_assertions",
@@ -6359,29 +6703,29 @@ dependencies = [
  "symlink",
  "tar",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "zstd",
 ]
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca3660e9d04cc83f5e15dd7ef34958aa0154e46069141bd0620d91d75b15536"
+checksum = "399ccc88947b000c6b84d1b95599a3cd65fa342bbde541cbe44664d3a207b1e0"
 dependencies = [
  "agave-transaction-view",
  "log",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
- "solana-hash 2.3.0",
- "solana-message 2.4.0",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
+ "solana-hash 3.0.0",
+ "solana-message 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
  "solana-signature",
  "solana-svm-transaction",
  "solana-transaction",
- "solana-transaction-error 2.2.1",
- "thiserror 2.0.12",
+ "solana-transaction-error 3.0.0",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -6398,9 +6742,9 @@ checksum = "927e833259588ac8f860861db0f6e2668c3cc46d917798ade116858960acfe8a"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.11.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474a2d95dc819898ded08d24f29642d02189d3e1497bbb442a92a3997b7eb55f"
+checksum = "0f224d906c14efc7ed7f42bc5fe9588f3f09db8cabe7f6023adda62a69678e1a"
 dependencies = [
  "byteorder",
  "combine 3.8.1",
@@ -6409,79 +6753,8 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustc-demangle",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "winapi",
-]
-
-[[package]]
-name = "solana-sdk"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc0e4a7635b902791c44b6581bfb82f3ada32c5bc0929a64f39fe4bb384c86a"
-dependencies = [
- "bincode",
- "bs58",
- "getrandom 0.1.16",
- "js-sys",
- "serde",
- "serde_json",
- "solana-account 2.2.1",
- "solana-bn254",
- "solana-client-traits",
- "solana-cluster-type",
- "solana-commitment-config",
- "solana-compute-budget-interface",
- "solana-decode-error",
- "solana-derivation-path",
- "solana-ed25519-program",
- "solana-epoch-info",
- "solana-epoch-rewards-hasher",
- "solana-feature-set",
- "solana-fee-structure",
- "solana-genesis-config",
- "solana-hard-forks",
- "solana-inflation",
- "solana-instruction 2.3.0",
- "solana-keypair",
- "solana-message 2.4.0",
- "solana-native-token",
- "solana-nonce-account",
- "solana-offchain-message",
- "solana-packet",
- "solana-poh-config",
- "solana-precompile-error",
- "solana-precompiles",
- "solana-presigner",
- "solana-program",
- "solana-program-memory 2.2.1",
- "solana-pubkey 2.4.0",
- "solana-quic-definitions",
- "solana-rent-collector",
- "solana-rent-debits",
- "solana-reserved-account-keys",
- "solana-reward-info",
- "solana-sanitize 2.2.1",
- "solana-sdk-ids 2.2.1",
- "solana-sdk-macro 2.2.1",
- "solana-secp256k1-program",
- "solana-secp256k1-recover",
- "solana-secp256r1-program",
- "solana-seed-derivable",
- "solana-seed-phrase",
- "solana-serde",
- "solana-serde-varint",
- "solana-short-vec 2.2.1",
- "solana-shred-version",
- "solana-signature",
- "solana-signer",
- "solana-system-transaction",
- "solana-time-utils",
- "solana-transaction",
- "solana-transaction-context",
- "solana-transaction-error 2.2.1",
- "solana-validator-exit",
- "thiserror 2.0.12",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -6528,20 +6801,16 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-program"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a1caa972414cc78122c32bdae65ac5fe89df7db598585a5cde19d16a20280a"
+checksum = "8efa767b0188f577edae7080e8bf080e5db9458e2b6ee5beaa73e2e6bb54e99d"
 dependencies = [
- "bincode",
  "digest 0.10.7",
- "libsecp256k1",
+ "k256",
  "serde",
  "serde_derive",
  "sha3",
- "solana-feature-set",
- "solana-instruction 2.3.0",
- "solana-precompile-error",
- "solana-sdk-ids 2.2.1",
+ "solana-signature",
 ]
 
 [[package]]
@@ -6550,40 +6819,48 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
 dependencies = [
- "borsh 1.5.7",
  "libsecp256k1",
  "solana-define-syscall 2.3.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "solana-secp256k1-recover"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394a4470477d66296af5217970a905b1c5569032a7732c367fb69e5666c8607e"
+dependencies = [
+ "k256",
+ "solana-define-syscall 3.0.0",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-secp256r1-program"
-version = "2.2.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0ae46da3071a900f02d367d99b2f3058fe2e90c5062ac50c4f20cfedad8f0f"
+checksum = "445d8e12592631d76fc4dc57858bae66c9fd7cc838c306c62a472547fc9d0ce6"
 dependencies = [
  "bytemuck",
  "openssl",
- "solana-feature-set",
- "solana-instruction 2.3.0",
- "solana-precompile-error",
- "solana-sdk-ids 2.2.1",
+ "solana-instruction 3.0.0",
+ "solana-sdk-ids 3.0.0",
 ]
 
 [[package]]
 name = "solana-seed-derivable"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beb82b5adb266c6ea90e5cf3967235644848eac476c5a1f2f9283a143b7c97f"
+checksum = "ff7bdb72758e3bec33ed0e2658a920f1f35dfb9ed576b951d20d63cb61ecd95c"
 dependencies = [
  "solana-derivation-path",
 ]
 
 [[package]]
 name = "solana-seed-phrase"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36187af2324f079f65a675ec22b31c24919cb4ac22c79472e85d819db9bbbc15"
+checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -6592,37 +6869,37 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e697230642265a783dda0acf0f2f68687598d63c608c017f549e27e1f3d0091"
+checksum = "4f5c292fe2efa5f25d3adfb67dcc502f0b34b1b5cbd28b37b009b1ba3e978ff1"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
  "itertools 0.12.1",
  "log",
  "solana-client",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
  "solana-connection-cache",
- "solana-hash 2.3.0",
+ "solana-hash 3.0.0",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
  "solana-nonce-account",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-quic-definitions",
  "solana-runtime",
  "solana-signature",
  "solana-time-utils",
  "solana-tpu-client-next",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
 name = "solana-serde"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1931484a408af466e14171556a47adaa215953c7f48b24e5f6b0282763818b04"
+checksum = "709a93cab694c70f40b279d497639788fc2ccbcf9b4aa32273d4b361322c02dd"
 dependencies = [
  "serde",
 ]
@@ -6637,6 +6914,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-serde-varint"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5174c57d5ff3c1995f274d17156964664566e2cde18a07bba1586d35a70d3b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "solana-serialize-utils"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6645,6 +6931,17 @@ dependencies = [
  "solana-instruction 2.3.0",
  "solana-pubkey 2.4.0",
  "solana-sanitize 2.2.1",
+]
+
+[[package]]
+name = "solana-serialize-utils"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e41dd8feea239516c623a02f0a81c2367f4b604d7965237fed0751aeec33ed"
+dependencies = [
+ "solana-instruction-error",
+ "solana-pubkey 3.0.0",
+ "solana-sanitize 3.0.0",
 ]
 
 [[package]]
@@ -6689,39 +6986,38 @@ dependencies = [
 
 [[package]]
 name = "solana-shred-version"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd3db0461089d1ad1a78d9ba3f15b563899ca2386351d38428faa5350c60a98"
+checksum = "94953e22ca28fe4541a3447d6baeaf519cc4ddc063253bfa673b721f34c136bb"
 dependencies = [
  "solana-hard-forks",
- "solana-hash 2.3.0",
- "solana-sha256-hasher 2.2.1",
+ "solana-hash 3.0.0",
+ "solana-sha256-hasher 3.0.0",
 ]
 
 [[package]]
 name = "solana-signature"
-version = "2.3.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c8ec8e657aecfc187522fc67495142c12f35e55ddeca8698edbb738b8dbd8c"
+checksum = "4bb8057cc0e9f7b5e89883d49de6f407df655bb6f3a71d0b7baf9986a2218fd9"
 dependencies = [
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "five8",
- "rand 0.8.5",
  "serde",
  "serde-big-array",
  "serde_derive",
- "solana-sanitize 2.2.1",
+ "solana-sanitize 3.0.0",
 ]
 
 [[package]]
 name = "solana-signer"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c41991508a4b02f021c1342ba00bcfa098630b213726ceadc7cb032e051975b"
+checksum = "5bfea97951fee8bae0d6038f39a5efcb6230ecdfe33425ac75196d1a1e3e3235"
 dependencies = [
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-signature",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
 ]
 
 [[package]]
@@ -6807,7 +7103,6 @@ dependencies = [
  "serde",
  "serde_with",
  "solana-program",
- "solana-sdk",
  "thiserror 1.0.69",
 ]
 
@@ -6866,72 +7161,103 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-stake-program"
-version = "1.0.0"
+name = "solana-stake-interface"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f912ae679b683365348dea482dbd9468d22ff258b554fd36e3d3683c2122e3"
 dependencies = [
- "arbitrary",
- "arrayref",
- "assert_matches",
- "bincode",
  "borsh 1.5.7",
- "mollusk-svm",
- "num-derive 0.4.2",
  "num-traits",
- "num_enum",
- "proptest",
- "rand 0.8.5",
- "solana-account 2.2.1",
- "solana-config-interface",
- "solana-feature-set",
- "solana-logger",
- "solana-program",
- "solana-program-runtime",
- "solana-program-test",
- "solana-sdk",
- "solana-sdk-ids 2.2.1",
- "solana-stake-interface 1.2.1",
- "solana-system-interface 1.0.0",
- "solana-sysvar 2.2.2",
- "solana-vote-program",
- "test-case",
- "thiserror 1.0.69",
+ "serde",
+ "serde_derive",
+ "solana-clock 3.0.0",
+ "solana-cpi 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-program-error 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar 3.0.0",
+ "solana-sysvar-id 3.0.0",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "2.3.6"
+version = "1.0.0"
+dependencies = [
+ "agave-feature-set",
+ "arbitrary",
+ "assert_matches",
+ "bincode",
+ "mollusk-svm",
+ "proptest",
+ "rand 0.8.5",
+ "solana-account 3.0.0",
+ "solana-account-info 3.0.0",
+ "solana-clock 3.0.0",
+ "solana-config-interface 1.0.0",
+ "solana-cpi 3.0.0",
+ "solana-epoch-rewards 3.0.0",
+ "solana-epoch-schedule 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-instruction-error",
+ "solana-keypair",
+ "solana-logger",
+ "solana-msg 3.0.0",
+ "solana-native-token 3.0.0",
+ "solana-program-entrypoint 3.1.0",
+ "solana-program-error 3.0.0",
+ "solana-program-test",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-signature",
+ "solana-signer",
+ "solana-stake-interface 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar 3.0.0",
+ "solana-sysvar-id 3.0.0",
+ "solana-transaction",
+ "solana-vote-interface 4.0.2",
+ "solana-vote-program",
+ "test-case",
+]
+
+[[package]]
+name = "solana-stake-program"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07857ce48e1d4de2015b32a9bcf2818f44e81a04101ac5c8b1058277f84907af"
+checksum = "b3e512b57a53a112f113a08b3c782920354f254ebb194619c96338dd2a236016"
 dependencies = [
  "agave-feature-set",
  "bincode",
  "log",
- "solana-account 2.2.1",
- "solana-bincode",
- "solana-clock 2.2.2",
- "solana-config-program-client",
+ "solana-account 3.0.0",
+ "solana-bincode 3.0.0",
+ "solana-clock 3.0.0",
+ "solana-config-interface 2.0.0",
  "solana-genesis-config",
- "solana-instruction 2.3.0",
- "solana-log-collector",
- "solana-native-token",
+ "solana-instruction 3.0.0",
+ "solana-native-token 3.0.0",
  "solana-packet",
  "solana-program-runtime",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
- "solana-sdk-ids 2.2.1",
- "solana-stake-interface 1.2.1",
- "solana-sysvar 2.2.2",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-stake-interface 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-svm-log-collector",
+ "solana-svm-type-overrides",
+ "solana-sysvar 3.0.0",
  "solana-transaction-context",
- "solana-type-overrides",
- "solana-vote-interface",
+ "solana-vote-interface 3.0.0",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7cf2d0e4f5fabb789a45d1201791d3704bc5317b05dc98e0913d66927a3241"
+checksum = "bdf4026f4b013ace3909d509255b635606268e460d8d1ec9649b3c2383768501"
 dependencies = [
+ "arc-swap",
  "async-channel",
  "bytes",
  "crossbeam-channel",
@@ -6945,128 +7271,144 @@ dependencies = [
  "libc",
  "log",
  "nix",
+ "num_cpus",
  "pem",
  "percentage",
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
- "rustls 0.23.29",
+ "rustls 0.23.32",
  "smallvec",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-packet",
  "solana-perf",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-quic-definitions",
  "solana-signature",
  "solana-signer",
  "solana-time-utils",
  "solana-tls-utils",
- "solana-transaction-error 2.2.1",
+ "solana-transaction-error 3.0.0",
  "solana-transaction-metrics-tracker",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
  "x509-parser",
 ]
 
 [[package]]
 name = "solana-svm"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72aa4a1c89ac10f3eef621992b93015e0c76f90a46d055da8444bb895564f11b"
+checksum = "db6f1df155407105304f384f6ca7328a7cd7c629d42f8fb2c3aca7cf72ec48b5"
 dependencies = [
  "ahash 0.8.11",
- "itertools 0.12.1",
  "log",
  "percentage",
  "serde",
  "serde_derive",
- "solana-account 2.2.1",
- "solana-clock 2.2.2",
+ "solana-account 3.0.0",
+ "solana-clock 3.0.0",
  "solana-fee-structure",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
- "solana-instructions-sysvar",
- "solana-loader-v3-interface 5.0.0",
- "solana-loader-v4-interface",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-instructions-sysvar 3.0.0",
+ "solana-loader-v3-interface 6.1.0",
+ "solana-loader-v4-interface 3.1.0",
  "solana-loader-v4-program",
- "solana-log-collector",
- "solana-measure",
- "solana-message 2.4.0",
- "solana-nonce 2.2.1",
+ "solana-message 3.0.0",
+ "solana-nonce 3.0.0",
  "solana-nonce-account",
- "solana-program-entrypoint 2.2.1",
- "solana-program-pack",
+ "solana-program-entrypoint 3.1.0",
+ "solana-program-pack 3.0.0",
  "solana-program-runtime",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
- "solana-rent-collector",
- "solana-rent-debits",
- "solana-sdk-ids 2.2.1",
- "solana-slot-hashes 2.2.1",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
+ "solana-sdk-ids 3.0.0",
  "solana-svm-callback",
  "solana-svm-feature-set",
- "solana-svm-rent-collector",
+ "solana-svm-log-collector",
+ "solana-svm-measure",
+ "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface 1.0.0",
- "solana-sysvar-id 2.2.1",
- "solana-timings",
+ "solana-svm-type-overrides",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar-id 3.0.0",
  "solana-transaction-context",
- "solana-transaction-error 2.2.1",
- "solana-type-overrides",
+ "solana-transaction-error 3.0.0",
  "spl-generic-token",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-svm-callback"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5498ea1832b503ec4a5c48bfe13994a168ee6515420f435a93ccec62b4820a40"
+checksum = "fd39d07ce725734c384206bac5f2713e625d9ee7d7cacf0e363b8845ecde390a"
 dependencies = [
- "solana-account 2.2.1",
+ "solana-account 3.0.0",
+ "solana-clock 3.0.0",
  "solana-precompile-error",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d525b3bb05c5a56c17ec7f4d5b9f838f0bcf006cf423a7c0e1b05ef4e10a2a"
+checksum = "fabe23745e54e21b2df3cc8763a060e6229f751ab452817d434680ea116a6f0c"
 
 [[package]]
-name = "solana-svm-rent-collector"
-version = "2.3.6"
+name = "solana-svm-log-collector"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67b3aa1d2749f0a404d20deccb37e5760f8a24c5cc6b35d49856dabe1010421"
+checksum = "65cb2aeb187b7e0c19a61166bec7f4a61d6785b1ed394bc9bc66fcc9f4ea59bd"
 dependencies = [
- "solana-account 2.2.1",
- "solana-clock 2.2.2",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
- "solana-rent-collector",
- "solana-sdk-ids 2.2.1",
- "solana-transaction-context",
- "solana-transaction-error 2.2.1",
+ "log",
+]
+
+[[package]]
+name = "solana-svm-measure"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e97aa78d50e968502b5eb20582cca5b773d4864a98ecf54db9900b0602c303"
+
+[[package]]
+name = "solana-svm-timings"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03df9786e6a616b412eb7d333cb8d23f88e5b432bd5115e8db494497237fc022"
+dependencies = [
+ "eager",
+ "enum-iterator",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931effbfd38cfbe87198f29fc4a44fa069016ce1a1a3d10c2084e5cd7ffe8624"
+checksum = "72b4d8a9ffbb2391df19833fd90005712b324709faa1d3c66c301d5281a1a7d2"
 dependencies = [
- "solana-hash 2.3.0",
- "solana-message 2.4.0",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
+ "solana-hash 3.0.0",
+ "solana-message 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
  "solana-signature",
  "solana-transaction",
+]
+
+[[package]]
+name = "solana-svm-type-overrides"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a1145bc1e15b3e454b64643031a1deea12dec168ce0887879a2c529ee38b5f"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -7102,43 +7444,43 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db78dd6bcad8e80a9b170c0881e353cd50ee47e11c72bf3a8cf4619d0546dc16"
+checksum = "e981aefa2b11c54f82bb5312c686f33536c6a67989326ea7a480201ee9644889"
 dependencies = [
  "bincode",
  "log",
  "serde",
  "serde_derive",
- "solana-account 2.2.1",
- "solana-bincode",
- "solana-fee-calculator 2.2.1",
- "solana-instruction 2.3.0",
- "solana-log-collector",
- "solana-nonce 2.2.1",
+ "solana-account 3.0.0",
+ "solana-bincode 3.0.0",
+ "solana-fee-calculator 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-nonce 3.0.0",
  "solana-nonce-account",
  "solana-packet",
  "solana-program-runtime",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
- "solana-system-interface 1.0.0",
- "solana-sysvar 2.2.2",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-svm-log-collector",
+ "solana-svm-type-overrides",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar 3.0.0",
  "solana-transaction-context",
- "solana-type-overrides",
 ]
 
 [[package]]
 name = "solana-system-transaction"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd98a25e5bcba8b6be8bcbb7b84b24c2a6a8178d7fb0e3077a916855ceba91a"
+checksum = "a31b5699ec533621515e714f1533ee6b3b0e71c463301d919eb59b8c1e249d30"
 dependencies = [
- "solana-hash 2.3.0",
+ "solana-hash 3.0.0",
  "solana-keypair",
- "solana-message 2.4.0",
- "solana-pubkey 2.4.0",
+ "solana-message 3.0.0",
+ "solana-pubkey 3.0.0",
  "solana-signer",
- "solana-system-interface 1.0.0",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
 ]
 
@@ -7163,7 +7505,7 @@ dependencies = [
  "solana-fee-calculator 2.2.1",
  "solana-hash 2.3.0",
  "solana-instruction 2.3.0",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 2.2.2",
  "solana-last-restart-slot 2.2.1",
  "solana-program-entrypoint 2.2.1",
  "solana-program-error 2.2.1",
@@ -7201,7 +7543,7 @@ dependencies = [
  "solana-hash 3.0.0",
  "solana-instruction 3.0.0",
  "solana-last-restart-slot 3.0.0",
- "solana-program-entrypoint 3.0.0",
+ "solana-program-entrypoint 3.1.0",
  "solana-program-error 3.0.0",
  "solana-program-memory 3.0.0",
  "solana-pubkey 3.0.0",
@@ -7234,69 +7576,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-thin-client"
-version = "2.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d155a1cac6952122ce45c66da11c69e227b0678487f10e73287bc1ffa5a0556b"
-dependencies = [
- "bincode",
- "log",
- "rayon",
- "solana-account 2.2.1",
- "solana-client-traits",
- "solana-clock 2.2.2",
- "solana-commitment-config",
- "solana-connection-cache",
- "solana-epoch-info",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
- "solana-keypair",
- "solana-message 2.4.0",
- "solana-pubkey 2.4.0",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-signature",
- "solana-signer",
- "solana-system-interface 1.0.0",
- "solana-transaction",
- "solana-transaction-error 2.2.1",
-]
-
-[[package]]
 name = "solana-time-utils"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
-
-[[package]]
-name = "solana-timings"
-version = "2.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5069234bff52d9c541137bc939a0cd5a9707d6536ce34c18580d4b6bf18e91"
-dependencies = [
- "eager",
- "enum-iterator",
- "solana-pubkey 2.4.0",
-]
+checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf10bf4485fbe6d6e9560f59327bf564b0502ae31b7195f4e59598fbe640a4ff"
+checksum = "004de86ad8c122cf78ad4a50d479a3d82d79ead5a7ae5d73eed3b031de68e3de"
 dependencies = [
- "rustls 0.23.29",
+ "rustls 0.23.32",
  "solana-keypair",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-signer",
  "x509-parser",
 ]
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5cbeccc7b67e728480162432174a6a85a0bf99ee395dd5959e9faa34ab7b64"
+checksum = "33af3111104cbe886b588db3a191c1fb90b8dcf7a6fc9b0994ba05daa11dd19a"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7306,14 +7608,14 @@ dependencies = [
  "log",
  "rayon",
  "solana-client-traits",
- "solana-clock 2.2.2",
+ "solana-clock 3.0.0",
  "solana-commitment-config",
  "solana-connection-cache",
- "solana-epoch-schedule 2.2.1",
+ "solana-epoch-schedule 3.0.0",
  "solana-measure",
- "solana-message 2.4.0",
+ "solana-message 3.0.0",
  "solana-net-utils",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-pubsub-client",
  "solana-quic-definitions",
  "solana-rpc-client",
@@ -7321,23 +7623,23 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-transaction",
- "solana-transaction-error 2.2.1",
- "thiserror 2.0.12",
+ "solana-transaction-error 3.0.0",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c96a15d9f7095632582673cd57d0a90dab8bf1c54c641c31d33e306c2e4d8d8"
+checksum = "b361228c5fd33ac4a06bf1e9cd179f0e107ed0b78cf76bdc535bd8351308357f"
 dependencies = [
  "async-trait",
  "log",
  "lru",
  "quinn",
- "rustls 0.23.29",
- "solana-clock 2.2.2",
+ "rustls 0.23.32",
+ "solana-clock 3.0.0",
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
@@ -7348,53 +7650,50 @@ dependencies = [
  "solana-time-utils",
  "solana-tls-utils",
  "solana-tpu-client",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
 name = "solana-transaction"
-version = "2.2.3"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80657d6088f721148f5d889c828ca60c7daeedac9a8679f9ec215e0c42bcbf41"
+checksum = "64928e6af3058dcddd6da6680cbe08324b4e071ad73115738235bbaa9e9f72a5"
 dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-bincode",
- "solana-feature-set",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
- "solana-keypair",
- "solana-message 2.4.0",
- "solana-precompiles",
- "solana-pubkey 2.4.0",
- "solana-sanitize 2.2.1",
- "solana-sdk-ids 2.2.1",
- "solana-short-vec 2.2.1",
+ "solana-address",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-instruction-error",
+ "solana-message 3.0.0",
+ "solana-sanitize 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-short-vec 3.0.0",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 1.0.0",
- "solana-transaction-error 2.2.1",
- "wasm-bindgen",
+ "solana-transaction-error 3.0.0",
 ]
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62899fc8ec399458db3332ec51dfc8379ca8bb5615133510c8b4dca4c5d48111"
+checksum = "d54eb5ab26730d0c8c736076043f0aea61d14bcc98a5feaea5cf78ed5f180c30"
 dependencies = [
  "bincode",
+ "qualifier_attr",
  "serde",
  "serde_derive",
- "solana-account 2.2.1",
- "solana-instruction 2.3.0",
- "solana-instructions-sysvar",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
- "solana-sdk-ids 2.2.1",
+ "solana-account 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-instructions-sysvar 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
+ "solana-sbpf",
+ "solana-sdk-ids 3.0.0",
 ]
 
 [[package]]
@@ -7403,8 +7702,6 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a9dc8fdb61c6088baab34fc3a8b8473a03a7a5fd404ed8dd502fa79b67cb1"
 dependencies = [
- "serde",
- "serde_derive",
  "solana-instruction 2.3.0",
  "solana-sanitize 2.2.1",
 ]
@@ -7415,15 +7712,17 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4222065402340d7e6aec9dc3e54d22992ddcf923d91edcd815443c2bfca3144a"
 dependencies = [
+ "serde",
+ "serde_derive",
  "solana-instruction-error",
  "solana-sanitize 3.0.0",
 ]
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32ca41884c3ebd31717bb9a81e51e005fac4ba3ba6ececce8673ef4abfde380"
+checksum = "c625f3b9abd42342dad5dac95a3c3bd13d028cb749fd772f2e14da03fcbf5056"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7431,15 +7730,15 @@ dependencies = [
  "rand 0.8.5",
  "solana-packet",
  "solana-perf",
- "solana-short-vec 2.2.1",
+ "solana-short-vec 3.0.0",
  "solana-signature",
 ]
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d10a5585f489ca00b0d9fdfd4ffb159450facca7ce52ca025268975f74013c8"
+checksum = "dc18000f80657eae4f34cf2a3f9c0cc4d3b94647e48c5bb0d89a8f123ebe0be6"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7449,48 +7748,41 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-commitment-config",
- "solana-message 2.4.0",
+ "solana-instruction 3.0.0",
+ "solana-message 3.0.0",
+ "solana-pubkey 3.0.0",
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-context",
- "solana-transaction-error 2.2.1",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-type-overrides"
-version = "2.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6a3cca74cf57a3914fb20063ca9422fa4b18f493ed7f34383f1a4b17fc1b55"
-dependencies = [
- "rand 0.8.5",
+ "solana-transaction-error 3.0.0",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-udp-client"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63202b4f3357a6015fcac9e0094a37ca250302dc1cdfaa2ef19cf5ba2072e6d5"
+checksum = "565ba5101ab55862b7722565e92c70bab3f62481a0791a13ff703e53bfb9d9e1"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
  "solana-keypair",
  "solana-net-utils",
  "solana-streamer",
- "solana-transaction-error 2.2.1",
- "thiserror 2.0.12",
+ "solana-transaction-error 3.0.0",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20de595ba952541a82b59565631064e28b4dd8bdd09460f3ed55c42e7c5a1f0b"
+checksum = "0c6c1aa5ef8de81ab33002d01e04146fdf541f4bc2c669d5e662f7b84e8a3774"
 dependencies = [
  "assert_matches",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
  "solana-runtime-transaction",
  "solana-transaction",
  "static_assertions",
@@ -7498,52 +7790,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-validator-exit"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
-
-[[package]]
 name = "solana-version"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c01beecdd0f0e720f69dae5d99a8cf3cf9beafeba776d9e4febcab24653e078"
+checksum = "380c1f2574f06a031ed67e30525d27bc06da05e939a911159ed06e6ff0acc260"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
  "semver",
  "serde",
  "serde_derive",
- "solana-sanitize 2.2.1",
- "solana-serde-varint",
+ "solana-sanitize 3.0.0",
+ "solana-serde-varint 3.0.0",
 ]
 
 [[package]]
 name = "solana-vote"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21702e8b9fc8ae979a1c4693d09b6f91252ebad4398f6938a21cc686a637ce9f"
+checksum = "186189fafe8a19fad620118a9b15e574a18907acb7c92149112d23c71428b864"
 dependencies = [
  "itertools 0.12.1",
  "log",
  "serde",
  "serde_derive",
- "solana-account 2.2.1",
- "solana-bincode",
- "solana-clock 2.2.2",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
+ "solana-account 3.0.0",
+ "solana-bincode 3.0.0",
+ "solana-clock 3.0.0",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
  "solana-keypair",
  "solana-packet",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
- "solana-serialize-utils",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-serialize-utils 3.1.0",
  "solana-signature",
  "solana-signer",
  "solana-svm-transaction",
  "solana-transaction",
- "solana-vote-interface",
- "thiserror 2.0.12",
+ "solana-vote-interface 3.0.0",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7564,17 +7850,69 @@ dependencies = [
  "solana-pubkey 2.4.0",
  "solana-rent 2.2.1",
  "solana-sdk-ids 2.2.1",
- "solana-serde-varint",
- "solana-serialize-utils",
+ "solana-serde-varint 2.2.2",
+ "solana-serialize-utils 2.2.1",
  "solana-short-vec 2.2.1",
  "solana-system-interface 1.0.0",
 ]
 
 [[package]]
-name = "solana-vote-program"
-version = "2.3.6"
+name = "solana-vote-interface"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf232c3b82aa682bd14b7e501d9434c89ea11d8264f38c91cc528cdeb959f3"
+checksum = "66631ddbe889dab5ec663294648cd1df395ec9df7a4476e7b3e095604cfdb539"
+dependencies = [
+ "bincode",
+ "cfg_eval",
+ "num-derive 0.4.2",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "serde_with",
+ "solana-clock 3.0.0",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-instruction-error",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-serde-varint 3.0.0",
+ "solana-serialize-utils 3.1.0",
+ "solana-short-vec 3.0.0",
+ "solana-system-interface 2.0.0",
+]
+
+[[package]]
+name = "solana-vote-interface"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33f1a30b1e61944e52afef0992a2be93720c5770eaf1f6d8e6e34f87d90e754"
+dependencies = [
+ "bincode",
+ "cfg_eval",
+ "num-derive 0.4.2",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "serde_with",
+ "solana-clock 3.0.0",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
+ "solana-instruction-error",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
+ "solana-sdk-ids 3.0.0",
+ "solana-serde-varint 3.0.0",
+ "solana-serialize-utils 3.1.0",
+ "solana-short-vec 3.0.0",
+ "solana-system-interface 2.0.0",
+]
+
+[[package]]
+name = "solana-vote-program"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a30f108ee514aef2fc6dde87b2471f2f56a2b422f1d13de60c708fa4ce4ff3"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7583,49 +7921,49 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-account 2.2.1",
- "solana-bincode",
- "solana-clock 2.2.2",
- "solana-epoch-schedule 2.2.1",
- "solana-hash 2.3.0",
- "solana-instruction 2.3.0",
+ "solana-account 3.0.0",
+ "solana-bincode 3.0.0",
+ "solana-clock 3.0.0",
+ "solana-epoch-schedule 3.0.0",
+ "solana-hash 3.0.0",
+ "solana-instruction 3.0.0",
  "solana-keypair",
  "solana-metrics",
  "solana-packet",
  "solana-program-runtime",
- "solana-pubkey 2.4.0",
- "solana-rent 2.2.1",
- "solana-sdk-ids 2.2.1",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.0.0",
+ "solana-sdk-ids 3.0.0",
  "solana-signer",
- "solana-slot-hashes 2.2.1",
+ "solana-slot-hashes 3.0.0",
  "solana-transaction",
  "solana-transaction-context",
- "solana-vote-interface",
- "thiserror 2.0.12",
+ "solana-vote-interface 3.0.0",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3679c86abc83c6c2422227e6cba59eefdc25a5a2104991021c9973fcbbbb692"
+checksum = "1584d1d31949e9d2eebbb2a146bba7570fed91d26a48360f5b4167cfad8515c9"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
  "num-derive 0.4.2",
  "num-traits",
- "solana-instruction 2.3.0",
- "solana-log-collector",
+ "solana-instruction 3.0.0",
  "solana-program-runtime",
- "solana-sdk-ids 2.2.1",
+ "solana-sdk-ids 3.0.0",
+ "solana-svm-log-collector",
  "solana-zk-sdk",
 ]
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.3.6"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05857892ac50fe03c125d8445fd790c6768015b76f4ad1e4b4b1499938b357f0"
+checksum = "9602bcb1f7af15caef92b91132ec2347e1c51a72ecdbefdaefa3eac4b8711475"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -7633,6 +7971,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
+ "getrandom 0.2.15",
  "itertools 0.12.1",
  "js-sys",
  "merlin",
@@ -7644,41 +7983,41 @@ dependencies = [
  "serde_json",
  "sha3",
  "solana-derivation-path",
- "solana-instruction 2.3.0",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
+ "solana-instruction 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
  "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
  "subtle",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "wasm-bindgen",
  "zeroize",
 ]
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f93fe02c865f62a76bf2d7ae0adfee7d506c7a0337d17fb2e113181fb44d8f"
+checksum = "11e61c809080842a61951812cf1af8a0f7ef771d60085eaad0c130b6d846657d"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
  "num-derive 0.4.2",
  "num-traits",
- "solana-instruction 2.3.0",
- "solana-log-collector",
+ "solana-instruction 3.0.0",
  "solana-program-runtime",
- "solana-sdk-ids 2.2.1",
+ "solana-sdk-ids 3.0.0",
+ "solana-svm-log-collector",
  "solana-zk-token-sdk",
 ]
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.3.6"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71ba14b30e86b3b58074b2830369e6dd6dc87b208dc29c09dad0b32a8288e92"
+checksum = "0ed63854c5d0d506da7bd9a202626de0dfa6f07cd10f2985746ad0b7eba722a8"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -7697,15 +8036,15 @@ dependencies = [
  "sha3",
  "solana-curve25519",
  "solana-derivation-path",
- "solana-instruction 2.3.0",
- "solana-pubkey 2.4.0",
- "solana-sdk-ids 2.2.1",
+ "solana-instruction 3.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.0.0",
  "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
  "subtle",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "zeroize",
 ]
 
@@ -7719,13 +8058,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-generic-token"
-version = "1.0.1"
+name = "spki"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741a62a566d97c58d33f9ed32337ceedd4e35109a686e31b1866c5dfa56abddc"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "spl-generic-token"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233df81b75ab99b42f002b5cdd6e65a7505ffa930624f7096a7580a56765e9cf"
 dependencies = [
  "bytemuck",
- "solana-pubkey 2.4.0",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -7894,15 +8243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7952,11 +8292,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -7972,9 +8312,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8049,9 +8389,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8094,7 +8434,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.29",
+ "rustls 0.23.32",
  "tokio",
 ]
 
@@ -8157,9 +8497,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8354,6 +8694,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8422,6 +8768,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -8671,6 +9023,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8698,6 +9056,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8721,11 +9097,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -8741,6 +9134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8751,6 +9150,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8765,10 +9170,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8783,6 +9200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8793,6 +9216,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8807,6 +9236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8817,6 +9252,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [workspace.metadata.cli]
-solana = "2.3.4"
+solana = "3.0.0"
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -22,4 +22,3 @@ thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-solana-sdk = "2.2.1"

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(non_local_definitions)] // <-- Rustc warning on `FromPrimitive`
+
 mod generated;
 mod hooked;
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,33 +12,43 @@ bpf-entrypoint = []
 test-sbf = []
 
 [dependencies]
-arrayref = "0.3.8"
 bincode = "1.3.3"
-borsh = { version = "1.5.1", features = ["derive", "unstable__schema"] }
-num-derive = "0.4"
-num-traits = "0.2"
-num_enum = "0.7.3"
-solana-program = "2.2.1"
-thiserror = "1.0.63"
+solana-account-info = { version = "3.0.0", features = ["bincode"] }
+solana-clock = "3.0.0"
+solana-cpi = "3.0.0"
+solana-instruction-error = "2.0.0"
+solana-msg = "3.0.0"
+solana-native-token = "3.0.0"
+solana-program-entrypoint = "3.0.0"
+solana-program-error = "3.0.0"
+solana-pubkey = "3.0.0"
+solana-rent = "3.0.0"
+solana-stake-interface = { version = "2", features = ["bincode", "borsh", "sysvar"] }
+solana-sysvar = "3.0.0"
+solana-vote-interface = { version = "4.0.1", features = ["bincode"] }
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+agave-feature-set = "3.0.0"
 arbitrary = { version = "1.4.1", features = ["derive"] }
-mollusk-svm = { version = "0.4.0", features = ["all-builtins"] }
+assert_matches = "1.5.0"
+mollusk-svm = { version = "0.6.1", features = ["all-builtins"] }
 proptest = "1.6.0"
-solana-account = { version = "2.2.1", features = ["bincode"] }
-solana-config-interface = { version = "1", features = ["serde"] }
-solana-feature-set = "2.2.1"
-solana-logger = "2.2.1"
-solana-program-test = "2.3.4"
-solana-program-runtime = "2.2.0"
-solana-stake-interface = { version = "1", features = ["bincode"] }
-solana-system-interface = { version = "1", features = ["bincode"] }
-solana-vote-program = "2.2.0"
-solana-sdk = "2.2.1"
-solana-sdk-ids = "2.2.1"
-solana-sysvar = { version = "2.2.1", features = ["bincode"] }
 rand = "0.8.5"
+solana-account = { version = "3.0.0", features = ["bincode"] }
+solana-config-interface = { version = "1", features = ["serde"] }
+solana-epoch-rewards = "3.0.0"
+solana-epoch-schedule = "3.0.0"
+solana-instruction = "3.0.0"
+solana-keypair = "3.0.0"
+solana-logger = "3.0.0"
+solana-program-test = "3.0.0"
+solana-sdk-ids = "3.0.0"
+solana-signature = "3.0.0"
+solana-signer = "3.0.0"
+solana-system-interface = { version = "2.0.0", features = ["bincode"] }
+solana-sysvar-id = "3.0.0"
+solana-transaction = "3.0.0"
+solana-vote-program = "3.0.0"
 test-case = "3.3.1"
 
 [lib]

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -2,10 +2,13 @@
 
 use {
     crate::processor::Processor,
-    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey},
+    solana_account_info::AccountInfo,
+    solana_msg::msg,
+    solana_program_entrypoint::{entrypoint, ProgramResult},
+    solana_pubkey::Pubkey,
 };
 
-solana_program::entrypoint!(process_instruction);
+entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/src/helpers/delegate.rs
+++ b/program/src/helpers/delegate.rs
@@ -1,17 +1,15 @@
 use {
     crate::PERPETUAL_NEW_WARMUP_COOLDOWN_RATE_EPOCH,
-    solana_program::{
-        account_info::AccountInfo,
-        clock::Epoch,
-        program_error::ProgramError,
-        pubkey::Pubkey,
-        stake::{
-            instruction::StakeError,
-            state::{Delegation, Meta, Stake},
-        },
+    solana_account_info::AccountInfo,
+    solana_clock::Epoch,
+    solana_program_error::ProgramError,
+    solana_pubkey::Pubkey,
+    solana_stake_interface::{
+        error::StakeError,
+        state::{Delegation, Meta, Stake},
         sysvar::stake_history::StakeHistorySysvar,
-        vote::state::VoteState,
     },
+    solana_vote_interface::state::VoteStateV3 as VoteState,
 };
 
 /// After calling `validate_delegated_amount()`, this struct contains calculated

--- a/program/src/helpers/merge.rs
+++ b/program/src/helpers/merge.rs
@@ -1,12 +1,10 @@
 use {
     crate::{helpers::checked_add, PERPETUAL_NEW_WARMUP_COOLDOWN_RATE_EPOCH},
-    solana_program::{
-        clock::{Clock, Epoch},
-        entrypoint::ProgramResult,
-        msg,
-        program_error::ProgramError,
-        stake::{instruction::StakeError, stake_flags::StakeFlags, state::*},
-        stake_history::StakeHistoryGetEntry,
+    solana_clock::{Clock, Epoch},
+    solana_msg::msg,
+    solana_program_error::{ProgramError, ProgramResult},
+    solana_stake_interface::{
+        error::StakeError, stake_flags::StakeFlags, stake_history::StakeHistoryGetEntry, state::*,
     },
     std::convert::TryFrom,
 };
@@ -233,13 +231,10 @@ mod tests {
         super::*,
         crate::id,
         proptest::prelude::*,
-        solana_sdk::{
-            account::{AccountSharedData, ReadableAccount},
-            account_utils::StateMut,
-            pubkey::Pubkey,
-            stake_history::{StakeHistory, StakeHistoryEntry},
-            sysvar::rent::Rent,
-        },
+        solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount},
+        solana_pubkey::Pubkey,
+        solana_rent::Rent,
+        solana_stake_interface::stake_history::{StakeHistory, StakeHistoryEntry},
     };
 
     #[test]

--- a/program/src/helpers/mod.rs
+++ b/program/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-use solana_program::{instruction::InstructionError, program_error::ProgramError};
+use {solana_instruction_error::InstructionError, solana_program_error::ProgramError};
 
 pub(crate) mod delegate;
 pub(crate) use delegate::*;

--- a/program/src/helpers/split.rs
+++ b/program/src/helpers/split.rs
@@ -1,4 +1,7 @@
-use solana_program::{program_error::ProgramError, rent::Rent, stake::state::Meta, sysvar::Sysvar};
+use {
+    solana_program_error::ProgramError, solana_rent::Rent, solana_stake_interface::state::Meta,
+    solana_sysvar::Sysvar,
+};
 
 /// After calling `validate_split_amount()`, this struct contains calculated
 /// values that are used by the caller.

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,4 +1,4 @@
-use solana_program::native_token::LAMPORTS_PER_SOL;
+use solana_native_token::LAMPORTS_PER_SOL;
 
 pub mod helpers;
 pub mod processor;
@@ -6,9 +6,7 @@ pub mod processor;
 #[cfg(feature = "bpf-entrypoint")]
 pub mod entrypoint;
 
-pub use solana_program;
-
-solana_program::declare_id!("Stake11111111111111111111111111111111111111");
+solana_pubkey::declare_id!("Stake11111111111111111111111111111111111111");
 
 // placeholders for features
 // we have ONE feature in the current stake program we care about:

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1,26 +1,25 @@
 use {
     crate::{helpers::*, id, PERPETUAL_NEW_WARMUP_COOLDOWN_RATE_EPOCH},
-    solana_program::{
-        account_info::{next_account_info, AccountInfo},
-        clock::Clock,
-        entrypoint::ProgramResult,
-        msg,
-        program::set_return_data,
-        program_error::ProgramError,
-        pubkey::Pubkey,
-        rent::Rent,
-        stake::{
-            instruction::{
-                AuthorizeCheckedWithSeedArgs, AuthorizeWithSeedArgs, LockupArgs, LockupCheckedArgs,
-                StakeError, StakeInstruction,
-            },
-            stake_flags::StakeFlags,
-            state::{Authorized, Lockup, Meta, StakeAuthorize, StakeStateV2},
-            tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
+    solana_account_info::{next_account_info, AccountInfo},
+    solana_clock::Clock,
+    solana_cpi::set_return_data,
+    solana_msg::msg,
+    solana_program_error::{ProgramError, ProgramResult},
+    solana_pubkey::Pubkey,
+    solana_rent::Rent,
+    solana_stake_interface::{
+        error::StakeError,
+        instruction::{
+            AuthorizeCheckedWithSeedArgs, AuthorizeWithSeedArgs, LockupArgs, LockupCheckedArgs,
+            StakeInstruction,
         },
-        sysvar::{epoch_rewards::EpochRewards, stake_history::StakeHistorySysvar, Sysvar},
-        vote::{program as solana_vote_program, state::VoteState},
+        stake_flags::StakeFlags,
+        state::{Authorized, Lockup, Meta, StakeAuthorize, StakeStateV2},
+        sysvar::stake_history::StakeHistorySysvar,
+        tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
     },
+    solana_sysvar::{epoch_rewards::EpochRewards, Sysvar, SysvarSerialize},
+    solana_vote_interface::{program as solana_vote_program, state::VoteStateV3 as VoteState},
     std::{collections::HashSet, mem::MaybeUninit},
 };
 

--- a/program/tests/interface.rs
+++ b/program/tests/interface.rs
@@ -4,30 +4,29 @@ use {
     arbitrary::{Arbitrary, Unstructured},
     mollusk_svm::{result::Check, Mollusk},
     solana_account::{Account, ReadableAccount, WritableAccount},
-    solana_sdk::{
-        instruction::{AccountMeta, Instruction},
-        native_token::LAMPORTS_PER_SOL,
-        pubkey::Pubkey,
-        stake::{
-            instruction::{self, LockupArgs},
-            stake_flags::StakeFlags,
-            state::{
-                warmup_cooldown_rate, Authorized, Delegation, Lockup, Meta, Stake, StakeAuthorize,
-                StakeStateV2, NEW_WARMUP_COOLDOWN_RATE,
-            },
-        },
-        stake_history::StakeHistoryEntry,
-        sysvar::{
-            clock::Clock, epoch_rewards::EpochRewards, epoch_schedule::EpochSchedule, rent::Rent,
-            stake_history::StakeHistory, SysvarId,
-        },
-        vote::{
-            program as vote_program,
-            state::{VoteState, VoteStateVersions},
+    solana_clock::Clock,
+    solana_epoch_rewards::EpochRewards,
+    solana_epoch_schedule::EpochSchedule,
+    solana_instruction::{AccountMeta, Instruction},
+    solana_native_token::LAMPORTS_PER_SOL,
+    solana_pubkey::Pubkey,
+    solana_rent::Rent,
+    solana_sdk_ids::system_program,
+    solana_stake_interface::{
+        instruction::{self, LockupArgs},
+        stake_flags::StakeFlags,
+        stake_history::{StakeHistory, StakeHistoryEntry},
+        state::{
+            warmup_cooldown_rate, Authorized, Delegation, Lockup, Meta, Stake, StakeAuthorize,
+            StakeStateV2, NEW_WARMUP_COOLDOWN_RATE,
         },
     },
-    solana_sdk_ids::system_program,
     solana_stake_program::{get_minimum_delegation, id},
+    solana_sysvar_id::SysvarId,
+    solana_vote_interface::{
+        program as vote_program,
+        state::{VoteStateV3 as VoteState, VoteStateVersions},
+    },
     std::{
         collections::{HashMap, HashSet},
         sync::LazyLock,
@@ -165,7 +164,7 @@ impl Env {
 
         // create two vote accounts
         let vote_rent_exemption = Rent::default().minimum_balance(VoteState::size_of());
-        let vote_state_versions = VoteStateVersions::new_current(VoteState::default());
+        let vote_state_versions = VoteStateVersions::new_v3(VoteState::default());
         let vote_data = bincode::serialize(&vote_state_versions).unwrap();
         let vote_account = Account::create(
             vote_rent_exemption,

--- a/program/tests/program_test.rs
+++ b/program/tests/program_test.rs
@@ -1,22 +1,16 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
+    solana_account::Account as SolanaAccount,
+    solana_clock::Clock,
+    solana_instruction::Instruction,
+    solana_keypair::Keypair,
+    solana_program_entrypoint::ProgramResult,
+    solana_program_error::ProgramError,
     solana_program_test::*,
-    solana_sdk::{
-        account::Account as SolanaAccount,
-        entrypoint::ProgramResult,
-        instruction::Instruction,
-        program_error::ProgramError,
-        pubkey::Pubkey,
-        signature::{Keypair, Signer},
-        signers::Signers,
-        transaction::{Transaction, TransactionError},
-        vote::{
-            instruction as vote_instruction,
-            state::{VoteInit, VoteState, VoteStateVersions},
-        },
-    },
+    solana_pubkey::Pubkey,
     solana_sdk_ids::system_program,
+    solana_signer::Signer,
     solana_stake_interface::{
         error::StakeError,
         instruction::{self as ixn, LockupArgs},
@@ -25,7 +19,11 @@ use {
         state::{Authorized, Delegation, Lockup, Meta, Stake, StakeAuthorize, StakeStateV2},
     },
     solana_system_interface::instruction as system_instruction,
-    solana_sysvar::clock::Clock,
+    solana_transaction::{Signers, Transaction, TransactionError},
+    solana_vote_interface::{
+        instruction as vote_instruction,
+        state::{VoteInit, VoteStateV3 as VoteState},
+    },
     test_case::{test_case, test_matrix},
 };
 
@@ -114,7 +112,7 @@ pub async fn create_vote(
         },
         rent_voter,
         vote_instruction::CreateVoteAccountConfig {
-            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            space: VoteState::size_of() as u64,
             ..Default::default()
         },
     ));

--- a/program/tests/stake_instruction.rs
+++ b/program/tests/stake_instruction.rs
@@ -1,46 +1,44 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
+    agave_feature_set::stake_raise_minimum_delegation_to_1_sol,
     assert_matches::assert_matches,
     bincode::serialize,
     mollusk_svm::{result::Check, Mollusk},
-    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
-    solana_sdk::{
-        account::create_account_shared_data_for_test,
-        account_utils::StateMut,
-        feature_set::stake_raise_minimum_delegation_to_1_sol,
-        instruction::{AccountMeta, Instruction},
-        program_error::ProgramError,
-        pubkey::Pubkey,
-        stake::{
-            config as stake_config,
-            instruction::{
-                self, authorize_checked, authorize_checked_with_seed, initialize_checked,
-                set_lockup_checked, AuthorizeCheckedWithSeedArgs, AuthorizeWithSeedArgs,
-                LockupArgs, StakeError, StakeInstruction,
-            },
-            stake_flags::StakeFlags,
-            state::{
-                warmup_cooldown_rate, Authorized, Delegation, Lockup, Meta, Stake, StakeAuthorize,
-                StakeStateV2,
-            },
-            MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION,
-        },
-        stake_history::{Epoch, StakeHistoryEntry},
-        sysvar::{
-            clock::{self, Clock},
-            epoch_rewards::{self, EpochRewards},
-            epoch_schedule::{self, EpochSchedule},
-            rent::{self, Rent},
-            rewards,
-            stake_history::{self, StakeHistory},
-        },
+    solana_account::{
+        create_account_shared_data_for_test, state_traits::StateMut, AccountSharedData,
+        ReadableAccount, WritableAccount,
     },
+    solana_clock::{Clock, Epoch},
+    solana_epoch_rewards::EpochRewards,
+    solana_epoch_schedule::EpochSchedule,
+    solana_instruction::{AccountMeta, Instruction},
+    solana_program_error::ProgramError,
+    solana_pubkey::Pubkey,
+    solana_rent::Rent,
     solana_sdk_ids::system_program,
+    solana_stake_interface::{
+        config as stake_config,
+        error::StakeError,
+        instruction::{
+            self, authorize_checked, authorize_checked_with_seed, initialize_checked,
+            set_lockup_checked, AuthorizeCheckedWithSeedArgs, AuthorizeWithSeedArgs, LockupArgs,
+            StakeInstruction,
+        },
+        stake_flags::StakeFlags,
+        stake_history::{StakeHistory, StakeHistoryEntry},
+        state::{
+            warmup_cooldown_rate, Authorized, Delegation, Lockup, Meta, Stake, StakeAuthorize,
+            StakeStateV2,
+        },
+        MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION,
+    },
     solana_stake_program::{get_minimum_delegation, id},
+    solana_sysvar::{clock, epoch_rewards, epoch_schedule, rent, rewards},
+    solana_sysvar_id::SysvarId,
     solana_vote_program::{
         self,
-        vote_state::{self, VoteState, VoteStateVersions},
+        vote_state::{self, VoteStateV3 as VoteState, VoteStateVersions},
     },
     std::{collections::HashSet, str::FromStr},
 };
@@ -128,7 +126,7 @@ fn get_default_transaction_accounts(instruction: &Instruction) -> Vec<(Pubkey, A
         .collect();
     pubkeys.insert(clock::id());
     pubkeys.insert(epoch_schedule::id());
-    pubkeys.insert(stake_history::id());
+    pubkeys.insert(StakeHistory::id());
     #[allow(deprecated)]
     pubkeys
         .iter()
@@ -139,7 +137,7 @@ fn get_default_transaction_accounts(instruction: &Instruction) -> Vec<(Pubkey, A
                     create_account_shared_data_for_test(&clock::Clock::default())
                 } else if rewards::check_id(pubkey) {
                     create_account_shared_data_for_test(&rewards::Rewards::new(0.0))
-                } else if stake_history::check_id(pubkey) {
+                } else if StakeHistory::check_id(pubkey) {
                     create_account_shared_data_for_test(&StakeHistory::default())
                 } else if stake_config::check_id(pubkey) {
                     config::create_account(0, &stake_config::Config::default())
@@ -234,7 +232,7 @@ fn get_active_stake_for_tests(
 }
 
 fn create_empty_stake_history_for_test() -> AccountSharedData {
-    AccountSharedData::create(1, vec![0; 8], solana_program::sysvar::id(), false, u64::MAX)
+    AccountSharedData::create(1, vec![0; 8], solana_sdk_ids::sysvar::id(), false, u64::MAX)
 }
 
 fn new_stake_history_entry<'a, I>(
@@ -287,7 +285,7 @@ mod config {
     use {
         solana_account::{Account, AccountSharedData},
         solana_config_interface::state::ConfigKeys,
-        solana_sdk::stake::config::Config,
+        solana_stake_interface::config::Config,
     };
 
     #[allow(deprecated)]
@@ -297,7 +295,7 @@ mod config {
         AccountSharedData::from(Account {
             lamports,
             data,
-            owner: solana_config_interface::id(),
+            owner: solana_sdk_ids::config::id(),
             ..Account::default()
         })
     }
@@ -453,7 +451,7 @@ fn test_stake_process_instruction_decode_bail() {
     let rent_account = create_account_shared_data_for_test(&rent);
     let rewards_address = rewards::id();
     let rewards_account = create_account_shared_data_for_test(&rewards::Rewards::new(0.0));
-    let stake_history_address = stake_history::id();
+    let stake_history_address = StakeHistory::id();
     let stake_history_account = create_account_shared_data_for_test(&StakeHistory::default());
     let vote_address = Pubkey::new_unique();
     let vote_account = AccountSharedData::new(0, 0, &solana_vote_program::id());
@@ -1084,9 +1082,9 @@ fn test_stake_initialize() {
     let rent = Rent::default();
     let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
     let stake_lamports = rent_exempt_reserve;
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let stake_account = AccountSharedData::new(stake_lamports, StakeStateV2::size_of(), &id());
-    let custodian_address = solana_sdk::pubkey::new_rand();
+    let custodian_address = solana_pubkey::new_rand();
     let lockup = Lockup {
         epoch: 1,
         unix_timestamp: 0,
@@ -1185,9 +1183,9 @@ fn test_stake_initialize() {
 fn test_authorize() {
     let mollusk = mollusk_bpf();
 
-    let authority_address = solana_sdk::pubkey::new_rand();
-    let authority_address_2 = solana_sdk::pubkey::new_rand();
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let authority_address = solana_pubkey::new_rand();
+    let authority_address_2 = solana_pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let stake_lamports = 42;
     let stake_account = AccountSharedData::new_data_with_space(
         stake_lamports,
@@ -1196,7 +1194,7 @@ fn test_authorize() {
         &id(),
     )
     .unwrap();
-    let to_address = solana_sdk::pubkey::new_rand();
+    let to_address = solana_pubkey::new_rand();
     let to_account = AccountSharedData::new(1, 0, &system_program::id());
     let mut transaction_accounts = vec![
         (stake_address, stake_account),
@@ -1207,7 +1205,7 @@ fn test_authorize() {
             create_account_shared_data_for_test(&Clock::default()),
         ),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&StakeHistory::default()),
         ),
         (
@@ -1337,7 +1335,7 @@ fn test_authorize() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -1371,9 +1369,9 @@ fn test_authorize() {
 fn test_authorize_override() {
     let mollusk = mollusk_bpf();
 
-    let authority_address = solana_sdk::pubkey::new_rand();
-    let mallory_address = solana_sdk::pubkey::new_rand();
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let authority_address = solana_pubkey::new_rand();
+    let mallory_address = solana_pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let stake_lamports = 42;
     let stake_account = AccountSharedData::new_data_with_space(
         stake_lamports,
@@ -1491,8 +1489,8 @@ fn test_authorize_override() {
 fn test_authorize_with_seed() {
     let mollusk = mollusk_bpf();
 
-    let authority_base_address = solana_sdk::pubkey::new_rand();
-    let authority_address = solana_sdk::pubkey::new_rand();
+    let authority_base_address = solana_pubkey::new_rand();
+    let authority_address = solana_pubkey::new_rand();
     let seed = "42";
     let stake_address = Pubkey::create_with_seed(&authority_base_address, seed, &id()).unwrap();
     let stake_lamports = 42;
@@ -1609,8 +1607,8 @@ fn test_authorize_with_seed() {
 fn test_authorize_delegated_stake() {
     let mollusk = mollusk_bpf();
 
-    let authority_address = solana_sdk::pubkey::new_rand();
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let authority_address = solana_pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = minimum_delegation;
     let stake_account = AccountSharedData::new_data_with_space(
@@ -1620,14 +1618,14 @@ fn test_authorize_delegated_stake() {
         &id(),
     )
     .unwrap();
-    let vote_address = solana_sdk::pubkey::new_rand();
+    let vote_address = solana_pubkey::new_rand();
     let vote_account =
-        vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
-    let vote_address_2 = solana_sdk::pubkey::new_rand();
+        vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
+    let vote_address_2 = solana_pubkey::new_rand();
     let mut vote_account_2 =
-        vote_state::create_account(&vote_address_2, &solana_sdk::pubkey::new_rand(), 0, 100);
+        vote_state::create_account(&vote_address_2, &solana_pubkey::new_rand(), 0, 100);
     vote_account_2
-        .set_state(&VoteStateVersions::new_current(VoteState::default()))
+        .set_state(&VoteStateVersions::new_v3(VoteState::default()))
         .unwrap();
     #[allow(deprecated)]
     let mut transaction_accounts = vec![
@@ -1643,7 +1641,7 @@ fn test_authorize_delegated_stake() {
             create_account_shared_data_for_test(&Clock::default()),
         ),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&StakeHistory::default()),
         ),
         (
@@ -1673,7 +1671,7 @@ fn test_authorize_delegated_stake() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -1814,21 +1812,21 @@ fn test_stake_delegate() {
         vote_state::process_slot_vote_unchecked(&mut vote_state, i);
     }
     let vote_state_credits = vote_state.credits();
-    let vote_address = solana_sdk::pubkey::new_rand();
-    let vote_address_2 = solana_sdk::pubkey::new_rand();
+    let vote_address = solana_pubkey::new_rand();
+    let vote_address_2 = solana_pubkey::new_rand();
     let mut vote_account =
-        vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+        vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
     let mut vote_account_2 =
-        vote_state::create_account(&vote_address_2, &solana_sdk::pubkey::new_rand(), 0, 100);
+        vote_state::create_account(&vote_address_2, &solana_pubkey::new_rand(), 0, 100);
     vote_account
-        .set_state(&VoteStateVersions::new_current(vote_state.clone()))
+        .set_state(&VoteStateVersions::new_v3(vote_state.clone()))
         .unwrap();
     vote_account_2
-        .set_state(&VoteStateVersions::new_current(vote_state))
+        .set_state(&VoteStateVersions::new_v3(vote_state))
         .unwrap();
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = minimum_delegation;
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let mut stake_account = AccountSharedData::new_data_with_space(
         stake_lamports,
         &StakeStateV2::Initialized(Meta {
@@ -1852,7 +1850,7 @@ fn test_stake_delegate() {
         (vote_address, vote_account),
         (vote_address_2, vote_account_2.clone()),
         (clock::id(), create_account_shared_data_for_test(&clock)),
-        (stake_history::id(), create_empty_stake_history_for_test()),
+        (StakeHistory::id(), create_empty_stake_history_for_test()),
         (
             stake_config::id(),
             config::create_account(0, &stake_config::Config::default()),
@@ -1880,7 +1878,7 @@ fn test_stake_delegate() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -2028,7 +2026,7 @@ fn test_stake_delegate() {
     transaction_accounts[1] = (vote_address_2, vote_account_2);
     transaction_accounts[1]
         .1
-        .set_owner(solana_sdk::pubkey::new_rand());
+        .set_owner(solana_pubkey::new_rand());
     process_instruction(
         &mollusk,
         &serialize(&StakeInstruction::DelegateStake).unwrap(),
@@ -2059,12 +2057,12 @@ fn test_redelegate_consider_balance_changes() {
     let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
     let initial_lamports = 4242424242;
     let stake_lamports = rent_exempt_reserve + initial_lamports;
-    let recipient_address = solana_sdk::pubkey::new_rand();
-    let authority_address = solana_sdk::pubkey::new_rand();
-    let vote_address = solana_sdk::pubkey::new_rand();
+    let recipient_address = solana_pubkey::new_rand();
+    let authority_address = solana_pubkey::new_rand();
+    let vote_address = solana_pubkey::new_rand();
     let vote_account =
-        vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
-    let stake_address = solana_sdk::pubkey::new_rand();
+        vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
+    let stake_address = solana_pubkey::new_rand();
     let stake_account = AccountSharedData::new_data_with_space(
         stake_lamports,
         &StakeStateV2::Initialized(Meta {
@@ -2085,7 +2083,7 @@ fn test_redelegate_consider_balance_changes() {
         ),
         (authority_address, AccountSharedData::default()),
         (clock::id(), create_account_shared_data_for_test(&clock)),
-        (stake_history::id(), create_empty_stake_history_for_test()),
+        (StakeHistory::id(), create_empty_stake_history_for_test()),
         (
             stake_config::id(),
             config::create_account(0, &stake_config::Config::default()),
@@ -2113,7 +2111,7 @@ fn test_redelegate_consider_balance_changes() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -2191,7 +2189,7 @@ fn test_redelegate_consider_balance_changes() {
                 is_writable: false,
             },
             AccountMeta {
-                pubkey: stake_history::id(),
+                pubkey: StakeHistory::id(),
                 is_signer: false,
                 is_writable: false,
             },
@@ -2264,10 +2262,10 @@ fn test_split() {
         epoch: current_epoch,
         ..Clock::default()
     };
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = minimum_delegation * 2;
-    let split_to_address = solana_sdk::pubkey::new_rand();
+    let split_to_address = solana_pubkey::new_rand();
     let split_to_account = AccountSharedData::new_data_with_space(
         0,
         &StakeStateV2::Uninitialized,
@@ -2286,7 +2284,7 @@ fn test_split() {
             }),
         ),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&stake_history),
         ),
         (clock::id(), create_account_shared_data_for_test(&clock)),
@@ -2373,7 +2371,7 @@ fn test_split() {
         0,
         &StakeStateV2::Uninitialized,
         StakeStateV2::size_of(),
-        &solana_sdk::pubkey::new_rand(),
+        &solana_pubkey::new_rand(),
     )
     .unwrap();
     transaction_accounts[1] = (split_to_address, split_to_account);
@@ -2390,10 +2388,10 @@ fn test_split() {
 fn test_withdraw_stake() {
     let mollusk = mollusk_bpf();
 
-    let recipient_address = solana_sdk::pubkey::new_rand();
-    let authority_address = solana_sdk::pubkey::new_rand();
-    let custodian_address = solana_sdk::pubkey::new_rand();
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let recipient_address = solana_pubkey::new_rand();
+    let authority_address = solana_pubkey::new_rand();
+    let custodian_address = solana_pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = minimum_delegation;
     let stake_account = AccountSharedData::new_data_with_space(
@@ -2403,11 +2401,11 @@ fn test_withdraw_stake() {
         &id(),
     )
     .unwrap();
-    let vote_address = solana_sdk::pubkey::new_rand();
+    let vote_address = solana_pubkey::new_rand();
     let mut vote_account =
-        vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+        vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
     vote_account
-        .set_state(&VoteStateVersions::new_current(VoteState::default()))
+        .set_state(&VoteStateVersions::new_v3(VoteState::default()))
         .unwrap();
     #[allow(deprecated)]
     let mut transaction_accounts = vec![
@@ -2428,7 +2426,7 @@ fn test_withdraw_stake() {
             create_account_shared_data_for_test(&Rent::free()),
         ),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&StakeHistory::default()),
         ),
         (
@@ -2457,7 +2455,7 @@ fn test_withdraw_stake() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -2552,7 +2550,7 @@ fn test_withdraw_stake() {
                 is_writable: false,
             },
             AccountMeta {
-                pubkey: stake_history::id(),
+                pubkey: StakeHistory::id(),
                 is_signer: false,
                 is_writable: false,
             },
@@ -2685,8 +2683,8 @@ fn test_withdraw_stake() {
 fn test_withdraw_stake_before_warmup() {
     let mollusk = mollusk_bpf();
 
-    let recipient_address = solana_sdk::pubkey::new_rand();
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let recipient_address = solana_pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = minimum_delegation;
     let total_lamports = stake_lamports + 33;
@@ -2697,11 +2695,11 @@ fn test_withdraw_stake_before_warmup() {
         &id(),
     )
     .unwrap();
-    let vote_address = solana_sdk::pubkey::new_rand();
+    let vote_address = solana_pubkey::new_rand();
     let mut vote_account =
-        vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+        vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
     vote_account
-        .set_state(&VoteStateVersions::new_current(VoteState::default()))
+        .set_state(&VoteStateVersions::new_v3(VoteState::default()))
         .unwrap();
     let mut clock = Clock {
         epoch: 16,
@@ -2714,7 +2712,7 @@ fn test_withdraw_stake_before_warmup() {
         (recipient_address, AccountSharedData::default()),
         (clock::id(), create_account_shared_data_for_test(&clock)),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&StakeHistory::default()),
         ),
         (
@@ -2743,7 +2741,7 @@ fn test_withdraw_stake_before_warmup() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -2777,7 +2775,7 @@ fn test_withdraw_stake_before_warmup() {
                 is_writable: false,
             },
             AccountMeta {
-                pubkey: stake_history::id(),
+                pubkey: StakeHistory::id(),
                 is_signer: false,
                 is_writable: false,
             },
@@ -2799,7 +2797,7 @@ fn test_withdraw_stake_before_warmup() {
         None,
     );
     transaction_accounts[4] = (
-        stake_history::id(),
+        StakeHistory::id(),
         create_account_shared_data_for_test(&stake_history),
     );
     clock.epoch = 0;
@@ -2820,9 +2818,9 @@ fn test_withdraw_stake_before_warmup() {
 fn test_withdraw_lockup() {
     let mollusk = mollusk_bpf();
 
-    let recipient_address = solana_sdk::pubkey::new_rand();
-    let custodian_address = solana_sdk::pubkey::new_rand();
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let recipient_address = solana_pubkey::new_rand();
+    let custodian_address = solana_pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let total_lamports = 100;
     let mut meta = Meta {
         lockup: Lockup {
@@ -2846,7 +2844,7 @@ fn test_withdraw_lockup() {
         (custodian_address, AccountSharedData::default()),
         (clock::id(), create_account_shared_data_for_test(&clock)),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&StakeHistory::default()),
         ),
         (
@@ -2871,7 +2869,7 @@ fn test_withdraw_lockup() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -2945,9 +2943,9 @@ fn test_withdraw_lockup() {
 fn test_withdraw_rent_exempt() {
     let mollusk = mollusk_bpf();
 
-    let recipient_address = solana_sdk::pubkey::new_rand();
-    let custodian_address = solana_sdk::pubkey::new_rand();
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let recipient_address = solana_pubkey::new_rand();
+    let custodian_address = solana_pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let rent = Rent::default();
     let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
     let minimum_delegation = crate::get_minimum_delegation();
@@ -2971,7 +2969,7 @@ fn test_withdraw_rent_exempt() {
             create_account_shared_data_for_test(&Clock::default()),
         ),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&StakeHistory::default()),
         ),
         (
@@ -2996,7 +2994,7 @@ fn test_withdraw_rent_exempt() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -3042,7 +3040,7 @@ fn test_withdraw_rent_exempt() {
 fn test_deactivate() {
     let mollusk = mollusk_bpf();
 
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = minimum_delegation;
     let stake_account = AccountSharedData::new_data_with_space(
@@ -3052,11 +3050,11 @@ fn test_deactivate() {
         &id(),
     )
     .unwrap();
-    let vote_address = solana_sdk::pubkey::new_rand();
+    let vote_address = solana_pubkey::new_rand();
     let mut vote_account =
-        vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+        vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
     vote_account
-        .set_state(&VoteStateVersions::new_current(VoteState::default()))
+        .set_state(&VoteStateVersions::new_v3(VoteState::default()))
         .unwrap();
     #[allow(deprecated)]
     let mut transaction_accounts = vec![
@@ -3067,7 +3065,7 @@ fn test_deactivate() {
             create_account_shared_data_for_test(&Clock::default()),
         ),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&StakeHistory::default()),
         ),
         (
@@ -3135,7 +3133,7 @@ fn test_deactivate() {
                 is_writable: false,
             },
             AccountMeta {
-                pubkey: stake_history::id(),
+                pubkey: StakeHistory::id(),
                 is_signer: false,
                 is_writable: false,
             },
@@ -3173,9 +3171,9 @@ fn test_deactivate() {
 fn test_set_lockup() {
     let mollusk = mollusk_bpf();
 
-    let custodian_address = solana_sdk::pubkey::new_rand();
-    let authorized_address = solana_sdk::pubkey::new_rand();
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let custodian_address = solana_pubkey::new_rand();
+    let authorized_address = solana_pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = minimum_delegation;
     let stake_account = AccountSharedData::new_data_with_space(
@@ -3185,11 +3183,11 @@ fn test_set_lockup() {
         &id(),
     )
     .unwrap();
-    let vote_address = solana_sdk::pubkey::new_rand();
+    let vote_address = solana_pubkey::new_rand();
     let mut vote_account =
-        vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+        vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
     vote_account
-        .set_state(&VoteStateVersions::new_current(VoteState::default()))
+        .set_state(&VoteStateVersions::new_v3(VoteState::default()))
         .unwrap();
     let instruction_data = serialize(&StakeInstruction::SetLockup(LockupArgs {
         unix_timestamp: Some(1),
@@ -3212,7 +3210,7 @@ fn test_set_lockup() {
             create_account_shared_data_for_test(&Rent::free()),
         ),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&StakeHistory::default()),
         ),
         (
@@ -3324,7 +3322,7 @@ fn test_set_lockup() {
                 is_writable: false,
             },
             AccountMeta {
-                pubkey: stake_history::id(),
+                pubkey: StakeHistory::id(),
                 is_signer: false,
                 is_writable: false,
             },
@@ -3465,7 +3463,7 @@ fn test_initialize_minimum_balance() {
 
     let rent = Rent::default();
     let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let instruction_data = serialize(&StakeInstruction::Initialize(
         Authorized::auto(&stake_address),
         Lockup::default(),
@@ -3522,14 +3520,14 @@ fn test_delegate_minimum_stake_delegation() {
     let minimum_delegation = crate::get_minimum_delegation();
     let rent = Rent::default();
     let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let meta = Meta {
         rent_exempt_reserve,
         ..Meta::auto(&stake_address)
     };
-    let vote_address = solana_sdk::pubkey::new_rand();
+    let vote_address = solana_pubkey::new_rand();
     let vote_account =
-        vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+        vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
     #[allow(deprecated)]
     let instruction_accounts = vec![
         AccountMeta {
@@ -3548,7 +3546,7 @@ fn test_delegate_minimum_stake_delegation() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -3588,7 +3586,7 @@ fn test_delegate_minimum_stake_delegation() {
                         create_account_shared_data_for_test(&Clock::default()),
                     ),
                     (
-                        stake_history::id(),
+                        StakeHistory::id(),
                         create_account_shared_data_for_test(&StakeHistory::default()),
                     ),
                     (
@@ -3693,7 +3691,7 @@ fn test_split_minimum_stake_delegation() {
                 (dest_address, dest_account.clone()),
                 (rent::id(), create_account_shared_data_for_test(&rent)),
                 (
-                    stake_history::id(),
+                    StakeHistory::id(),
                     create_account_shared_data_for_test(&stake_history),
                 ),
                 (clock::id(), create_account_shared_data_for_test(&clock)),
@@ -3791,7 +3789,7 @@ fn test_split_full_amount_minimum_stake_delegation() {
                     (dest_address, dest_account.clone()),
                     (rent::id(), create_account_shared_data_for_test(&rent)),
                     (
-                        stake_history::id(),
+                        StakeHistory::id(),
                         create_account_shared_data_for_test(&stake_history),
                     ),
                     (clock::id(), create_account_shared_data_for_test(&clock)),
@@ -4047,7 +4045,7 @@ fn test_staked_split_destination_minimum_balance() {
                 (source_address, source_account.clone()),
                 (destination_address, destination_account),
                 (rent::id(), create_account_shared_data_for_test(&rent)),
-                (stake_history::id(), create_empty_stake_history_for_test()),
+                (StakeHistory::id(), create_empty_stake_history_for_test()),
                 (clock::id(), create_account_shared_data_for_test(&clock)),
                 (
                     epoch_schedule::id(),
@@ -4096,12 +4094,12 @@ fn test_withdraw_minimum_stake_delegation() {
     let minimum_delegation = crate::get_minimum_delegation();
     let rent = Rent::default();
     let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let meta = Meta {
         rent_exempt_reserve,
         ..Meta::auto(&stake_address)
     };
-    let recipient_address = solana_sdk::pubkey::new_rand();
+    let recipient_address = solana_pubkey::new_rand();
     let instruction_accounts = vec![
         AccountMeta {
             pubkey: stake_address,
@@ -4119,7 +4117,7 @@ fn test_withdraw_minimum_stake_delegation() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -4167,7 +4165,7 @@ fn test_withdraw_minimum_stake_delegation() {
                         create_account_shared_data_for_test(&Rent::free()),
                     ),
                     (
-                        stake_history::id(),
+                        StakeHistory::id(),
                         create_account_shared_data_for_test(&StakeHistory::default()),
                     ),
                     (
@@ -4204,16 +4202,16 @@ fn test_behavior_withdrawal_then_redelegate_with_less_than_minimum_stake_delegat
     let minimum_delegation = crate::get_minimum_delegation();
     let rent = Rent::default();
     let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let stake_account = AccountSharedData::new(
         rent_exempt_reserve + minimum_delegation,
         StakeStateV2::size_of(),
         &id(),
     );
-    let vote_address = solana_sdk::pubkey::new_rand();
+    let vote_address = solana_pubkey::new_rand();
     let vote_account =
-        vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
-    let recipient_address = solana_sdk::pubkey::new_rand();
+        vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
+    let recipient_address = solana_pubkey::new_rand();
     let mut clock = Clock::default();
     #[allow(deprecated)]
     let mut transaction_accounts = vec![
@@ -4224,7 +4222,7 @@ fn test_behavior_withdrawal_then_redelegate_with_less_than_minimum_stake_delegat
             AccountSharedData::new(rent_exempt_reserve, 0, &system_program::id()),
         ),
         (clock::id(), create_account_shared_data_for_test(&clock)),
-        (stake_history::id(), create_empty_stake_history_for_test()),
+        (StakeHistory::id(), create_empty_stake_history_for_test()),
         (
             stake_config::id(),
             config::create_account(0, &stake_config::Config::default()),
@@ -4253,7 +4251,7 @@ fn test_behavior_withdrawal_then_redelegate_with_less_than_minimum_stake_delegat
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -4344,7 +4342,7 @@ fn test_behavior_withdrawal_then_redelegate_with_less_than_minimum_stake_delegat
                 is_writable: false,
             },
             AccountMeta {
-                pubkey: stake_history::id(),
+                pubkey: StakeHistory::id(),
                 is_signer: false,
                 is_writable: false,
             },
@@ -4375,7 +4373,7 @@ fn test_split_source_uninitialized() {
     let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let stake_account = AccountSharedData::new_data_with_space(
         stake_lamports,
         &StakeStateV2::Uninitialized,
@@ -4383,7 +4381,7 @@ fn test_split_source_uninitialized() {
         &id(),
     )
     .unwrap();
-    let split_to_address = solana_sdk::pubkey::new_rand();
+    let split_to_address = solana_pubkey::new_rand();
     let split_to_account = AccountSharedData::new_data_with_space(
         0,
         &StakeStateV2::Uninitialized,
@@ -4473,7 +4471,7 @@ fn test_split_split_not_uninitialized() {
     let mollusk = mollusk_bpf();
 
     let stake_lamports = 42;
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let stake_account = AccountSharedData::new_data_with_space(
         stake_lamports,
         &just_stake(Meta::auto(&stake_address), stake_lamports),
@@ -4481,7 +4479,7 @@ fn test_split_split_not_uninitialized() {
         &id(),
     )
     .unwrap();
-    let split_to_address = solana_sdk::pubkey::new_rand();
+    let split_to_address = solana_pubkey::new_rand();
     let instruction_accounts = vec![
         AccountMeta {
             pubkey: stake_address,
@@ -4530,7 +4528,7 @@ fn test_split_more_than_staked() {
     let current_epoch = 100;
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let stake_account = AccountSharedData::new_data_with_space(
         stake_lamports,
         &just_stake(
@@ -4544,7 +4542,7 @@ fn test_split_more_than_staked() {
         &id(),
     )
     .unwrap();
-    let split_to_address = solana_sdk::pubkey::new_rand();
+    let split_to_address = solana_pubkey::new_rand();
     let split_to_account = AccountSharedData::new_data_with_space(
         rent_exempt_reserve,
         &StakeStateV2::Uninitialized,
@@ -4557,7 +4555,7 @@ fn test_split_more_than_staked() {
         (split_to_address, split_to_account),
         (rent::id(), create_account_shared_data_for_test(&rent)),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&stake_history),
         ),
         (
@@ -4607,8 +4605,8 @@ fn test_split_with_rent() {
         ..Clock::default()
     };
     let minimum_delegation = crate::get_minimum_delegation();
-    let stake_address = solana_sdk::pubkey::new_rand();
-    let split_to_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
+    let split_to_address = solana_pubkey::new_rand();
     let split_to_account = AccountSharedData::new_data_with_space(
         0,
         &StakeStateV2::Uninitialized,
@@ -4660,7 +4658,7 @@ fn test_split_with_rent() {
             (split_to_address, split_to_account.clone()),
             (rent::id(), create_account_shared_data_for_test(&rent)),
             (
-                stake_history::id(),
+                StakeHistory::id(),
                 create_account_shared_data_for_test(&stake_history),
             ),
             (clock::id(), create_account_shared_data_for_test(&clock)),
@@ -4740,7 +4738,7 @@ fn test_split_to_account_with_rent_exempt_reserve() {
     };
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let meta = Meta {
         authorized: Authorized::auto(&stake_address),
         rent_exempt_reserve,
@@ -4754,7 +4752,7 @@ fn test_split_to_account_with_rent_exempt_reserve() {
         &id(),
     )
     .unwrap();
-    let split_to_address = solana_sdk::pubkey::new_rand();
+    let split_to_address = solana_pubkey::new_rand();
     let instruction_accounts = vec![
         AccountMeta {
             pubkey: stake_address,
@@ -4780,7 +4778,7 @@ fn test_split_to_account_with_rent_exempt_reserve() {
             (stake_address, stake_account.clone()),
             (split_to_address, split_to_account),
             (rent::id(), create_account_shared_data_for_test(&rent)),
-            (stake_history::id(), create_empty_stake_history_for_test()),
+            (StakeHistory::id(), create_empty_stake_history_for_test()),
             (clock::id(), create_account_shared_data_for_test(&clock)),
             (
                 epoch_schedule::id(),
@@ -4915,7 +4913,7 @@ fn test_split_from_larger_sized_account() {
     };
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = (source_larger_rent_exempt_reserve + minimum_delegation) * 2;
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let meta = Meta {
         authorized: Authorized::auto(&stake_address),
         rent_exempt_reserve: source_larger_rent_exempt_reserve,
@@ -4929,7 +4927,7 @@ fn test_split_from_larger_sized_account() {
         &id(),
     )
     .unwrap();
-    let split_to_address = solana_sdk::pubkey::new_rand();
+    let split_to_address = solana_pubkey::new_rand();
     let instruction_accounts = vec![
         AccountMeta {
             pubkey: stake_address,
@@ -4955,7 +4953,7 @@ fn test_split_from_larger_sized_account() {
             (stake_address, stake_account.clone()),
             (split_to_address, split_to_account),
             (rent::id(), create_account_shared_data_for_test(&rent)),
-            (stake_history::id(), create_empty_stake_history_for_test()),
+            (StakeHistory::id(), create_empty_stake_history_for_test()),
             (clock::id(), create_account_shared_data_for_test(&clock)),
             (
                 epoch_schedule::id(),
@@ -5080,7 +5078,7 @@ fn test_split_from_smaller_sized_account() {
     let stake_history = StakeHistory::default();
     let current_epoch = 100;
     let stake_lamports = split_rent_exempt_reserve + 1;
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let meta = Meta {
         authorized: Authorized::auto(&stake_address),
         rent_exempt_reserve: source_smaller_rent_exempt_reserve,
@@ -5094,7 +5092,7 @@ fn test_split_from_smaller_sized_account() {
         &id(),
     )
     .unwrap();
-    let split_to_address = solana_sdk::pubkey::new_rand();
+    let split_to_address = solana_pubkey::new_rand();
     let instruction_accounts = vec![
         AccountMeta {
             pubkey: stake_address,
@@ -5128,7 +5126,7 @@ fn test_split_from_smaller_sized_account() {
             (split_to_address, split_to_account),
             (rent::id(), create_account_shared_data_for_test(&rent)),
             (
-                stake_history::id(),
+                StakeHistory::id(),
                 create_account_shared_data_for_test(&stake_history),
             ),
             (
@@ -5178,13 +5176,13 @@ fn test_split_100_percent_of_source() {
     };
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = rent_exempt_reserve + minimum_delegation;
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let meta = Meta {
         authorized: Authorized::auto(&stake_address),
         rent_exempt_reserve,
         ..Meta::default()
     };
-    let split_to_address = solana_sdk::pubkey::new_rand();
+    let split_to_address = solana_pubkey::new_rand();
     let split_to_account = AccountSharedData::new_data_with_space(
         0,
         &StakeStateV2::Uninitialized,
@@ -5227,7 +5225,7 @@ fn test_split_100_percent_of_source() {
             (split_to_address, split_to_account.clone()),
             (rent::id(), create_account_shared_data_for_test(&rent)),
             (
-                stake_history::id(),
+                StakeHistory::id(),
                 create_account_shared_data_for_test(&stake_history),
             ),
             (clock::id(), create_account_shared_data_for_test(&clock)),
@@ -5298,7 +5296,7 @@ fn test_split_100_percent_of_source_to_account_with_lamports() {
     };
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = rent_exempt_reserve + minimum_delegation;
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let meta = Meta {
         authorized: Authorized::auto(&stake_address),
         rent_exempt_reserve,
@@ -5312,7 +5310,7 @@ fn test_split_100_percent_of_source_to_account_with_lamports() {
         &id(),
     )
     .unwrap();
-    let split_to_address = solana_sdk::pubkey::new_rand();
+    let split_to_address = solana_pubkey::new_rand();
     let instruction_accounts = vec![
         AccountMeta {
             pubkey: stake_address,
@@ -5354,7 +5352,7 @@ fn test_split_100_percent_of_source_to_account_with_lamports() {
             (split_to_address, split_to_account),
             (rent::id(), create_account_shared_data_for_test(&rent)),
             (
-                stake_history::id(),
+                StakeHistory::id(),
                 create_account_shared_data_for_test(&stake_history),
             ),
             (clock::id(), create_account_shared_data_for_test(&clock)),
@@ -5419,13 +5417,13 @@ fn test_split_rent_exemptness() {
     };
     let minimum_delegation = crate::get_minimum_delegation();
     let stake_lamports = source_rent_exempt_reserve + minimum_delegation;
-    let stake_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
     let meta = Meta {
         authorized: Authorized::auto(&stake_address),
         rent_exempt_reserve: source_rent_exempt_reserve,
         ..Meta::default()
     };
-    let split_to_address = solana_sdk::pubkey::new_rand();
+    let split_to_address = solana_pubkey::new_rand();
     let instruction_accounts = vec![
         AccountMeta {
             pubkey: stake_address,
@@ -5463,7 +5461,7 @@ fn test_split_rent_exemptness() {
             (split_to_address, split_to_account),
             (rent::id(), create_account_shared_data_for_test(&rent)),
             (
-                stake_history::id(),
+                StakeHistory::id(),
                 create_account_shared_data_for_test(&stake_history),
             ),
             (clock::id(), create_account_shared_data_for_test(&clock)),
@@ -5506,7 +5504,7 @@ fn test_split_rent_exemptness() {
             (split_to_address, split_to_account),
             (rent::id(), create_account_shared_data_for_test(&rent)),
             (
-                stake_history::id(),
+                StakeHistory::id(),
                 create_account_shared_data_for_test(&stake_history),
             ),
             (
@@ -5640,7 +5638,7 @@ fn test_split_require_rent_exempt_destination() {
                     (source_address, source_account.clone()),
                     (destination_address, destination_account),
                     (rent::id(), create_account_shared_data_for_test(&rent)),
-                    (stake_history::id(), create_empty_stake_history_for_test()),
+                    (StakeHistory::id(), create_empty_stake_history_for_test()),
                     (clock::id(), create_account_shared_data_for_test(&clock)),
                     (
                         epoch_schedule::id(),
@@ -5776,9 +5774,9 @@ fn test_split_require_rent_exempt_destination() {
 fn test_merge() {
     let mollusk = mollusk_bpf();
 
-    let stake_address = solana_sdk::pubkey::new_rand();
-    let merge_from_address = solana_sdk::pubkey::new_rand();
-    let authorized_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
+    let merge_from_address = solana_pubkey::new_rand();
+    let authorized_address = solana_pubkey::new_rand();
     let meta = Meta::auto(&authorized_address);
     let stake_lamports = 42;
     let mut instruction_accounts = vec![
@@ -5798,7 +5796,7 @@ fn test_merge() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -5840,7 +5838,7 @@ fn test_merge() {
                     create_account_shared_data_for_test(&Clock::default()),
                 ),
                 (
-                    stake_history::id(),
+                    StakeHistory::id(),
                     create_account_shared_data_for_test(&StakeHistory::default()),
                 ),
                 (
@@ -5912,8 +5910,8 @@ fn test_merge() {
 fn test_merge_self_fails() {
     let mollusk = mollusk_bpf();
 
-    let stake_address = solana_sdk::pubkey::new_rand();
-    let authorized_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
+    let authorized_address = solana_pubkey::new_rand();
     let rent = Rent::default();
     let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
     let stake_amount = 4242424242;
@@ -5945,7 +5943,7 @@ fn test_merge_self_fails() {
             create_account_shared_data_for_test(&Clock::default()),
         ),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&StakeHistory::default()),
         ),
     ];
@@ -5966,7 +5964,7 @@ fn test_merge_self_fails() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -5990,10 +5988,10 @@ fn test_merge_self_fails() {
 fn test_merge_incorrect_authorized_staker() {
     let mollusk = mollusk_bpf();
 
-    let stake_address = solana_sdk::pubkey::new_rand();
-    let merge_from_address = solana_sdk::pubkey::new_rand();
-    let authorized_address = solana_sdk::pubkey::new_rand();
-    let wrong_authorized_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
+    let merge_from_address = solana_pubkey::new_rand();
+    let authorized_address = solana_pubkey::new_rand();
+    let wrong_authorized_address = solana_pubkey::new_rand();
     let stake_lamports = 42;
     let mut instruction_accounts = vec![
         AccountMeta {
@@ -6012,7 +6010,7 @@ fn test_merge_incorrect_authorized_staker() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -6055,7 +6053,7 @@ fn test_merge_incorrect_authorized_staker() {
                     create_account_shared_data_for_test(&Clock::default()),
                 ),
                 (
-                    stake_history::id(),
+                    StakeHistory::id(),
                     create_account_shared_data_for_test(&StakeHistory::default()),
                 ),
                 (
@@ -6089,9 +6087,9 @@ fn test_merge_incorrect_authorized_staker() {
 fn test_merge_invalid_account_data() {
     let mollusk = mollusk_bpf();
 
-    let stake_address = solana_sdk::pubkey::new_rand();
-    let merge_from_address = solana_sdk::pubkey::new_rand();
-    let authorized_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
+    let merge_from_address = solana_pubkey::new_rand();
+    let authorized_address = solana_pubkey::new_rand();
     let stake_lamports = 42;
     let instruction_accounts = vec![
         AccountMeta {
@@ -6110,7 +6108,7 @@ fn test_merge_invalid_account_data() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -6151,7 +6149,7 @@ fn test_merge_invalid_account_data() {
                     create_account_shared_data_for_test(&Clock::default()),
                 ),
                 (
-                    stake_history::id(),
+                    StakeHistory::id(),
                     create_account_shared_data_for_test(&StakeHistory::default()),
                 ),
                 (
@@ -6175,9 +6173,9 @@ fn test_merge_invalid_account_data() {
 fn test_merge_fake_stake_source() {
     let mollusk = mollusk_bpf();
 
-    let stake_address = solana_sdk::pubkey::new_rand();
-    let merge_from_address = solana_sdk::pubkey::new_rand();
-    let authorized_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
+    let merge_from_address = solana_pubkey::new_rand();
+    let authorized_address = solana_pubkey::new_rand();
     let stake_lamports = 42;
     let stake_account = AccountSharedData::new_data_with_space(
         stake_lamports,
@@ -6190,7 +6188,7 @@ fn test_merge_fake_stake_source() {
         stake_lamports,
         &just_stake(Meta::auto(&authorized_address), stake_lamports),
         StakeStateV2::size_of(),
-        &solana_sdk::pubkey::new_rand(),
+        &solana_pubkey::new_rand(),
     )
     .unwrap();
     let transaction_accounts = vec![
@@ -6202,7 +6200,7 @@ fn test_merge_fake_stake_source() {
             create_account_shared_data_for_test(&Clock::default()),
         ),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&StakeHistory::default()),
         ),
     ];
@@ -6223,7 +6221,7 @@ fn test_merge_fake_stake_source() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -6247,9 +6245,9 @@ fn test_merge_fake_stake_source() {
 fn test_merge_active_stake() {
     let mollusk = mollusk_bpf();
 
-    let stake_address = solana_sdk::pubkey::new_rand();
-    let merge_from_address = solana_sdk::pubkey::new_rand();
-    let authorized_address = solana_sdk::pubkey::new_rand();
+    let stake_address = solana_pubkey::new_rand();
+    let merge_from_address = solana_pubkey::new_rand();
+    let authorized_address = solana_pubkey::new_rand();
     let base_lamports = 4242424242;
     let rent = Rent::default();
     let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
@@ -6311,7 +6309,7 @@ fn test_merge_active_stake() {
         (authorized_address, AccountSharedData::default()),
         (clock::id(), create_account_shared_data_for_test(&clock)),
         (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&stake_history),
         ),
         (
@@ -6336,7 +6334,7 @@ fn test_merge_active_stake() {
             is_writable: false,
         },
         AccountMeta {
-            pubkey: stake_history::id(),
+            pubkey: StakeHistory::id(),
             is_signer: false,
             is_writable: false,
         },
@@ -6405,7 +6403,7 @@ fn test_merge_active_stake() {
         );
         transaction_accounts[3] = (clock::id(), create_account_shared_data_for_test(&clock));
         transaction_accounts[4] = (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&stake_history),
         );
         if stake_amount == stake.stake(clock.epoch, &stake_history, new_warmup_cooldown_rate_epoch)
@@ -6489,7 +6487,7 @@ fn test_merge_active_stake() {
         );
         transaction_accounts[3] = (clock::id(), create_account_shared_data_for_test(&clock));
         transaction_accounts[4] = (
-            stake_history::id(),
+            StakeHistory::id(),
             create_account_shared_data_for_test(&stake_history),
         );
         if 0 == stake.stake(clock.epoch, &stake_history, new_warmup_cooldown_rate_epoch)
@@ -6652,7 +6650,7 @@ fn test_deactivate_delinquent() {
 
     let mut vote_account = AccountSharedData::new_data_with_space(
         1, /* lamports */
-        &VoteStateVersions::new_current(VoteState::default()),
+        &VoteStateVersions::new_v3(VoteState::default()),
         VoteState::size_of(),
         &solana_vote_program::id(),
     )
@@ -6660,7 +6658,7 @@ fn test_deactivate_delinquent() {
 
     let mut reference_vote_account = AccountSharedData::new_data_with_space(
         1, /* lamports */
-        &VoteStateVersions::new_current(VoteState::default()),
+        &VoteStateVersions::new_v3(VoteState::default()),
         VoteState::size_of(),
         &solana_vote_program::id(),
     )
@@ -6689,7 +6687,7 @@ fn test_deactivate_delinquent() {
                         }),
                     ),
                     (
-                        stake_history::id(),
+                        StakeHistory::id(),
                         create_account_shared_data_for_test(&StakeHistory::default()),
                     ),
                 ],
@@ -6731,7 +6729,7 @@ fn test_deactivate_delinquent() {
         reference_vote_state.increment_credits(epoch as Epoch, 1);
     }
     reference_vote_account
-        .serialize_data(&VoteStateVersions::new_current(reference_vote_state))
+        .serialize_data(&VoteStateVersions::new_v3(reference_vote_state))
         .unwrap();
 
     process_instruction_deactivate_delinquent(
@@ -6761,7 +6759,7 @@ fn test_deactivate_delinquent() {
         current_epoch - 1
     );
     reference_vote_account
-        .serialize_data(&VoteStateVersions::new_current(reference_vote_state))
+        .serialize_data(&VoteStateVersions::new_v3(reference_vote_state))
         .unwrap();
 
     process_instruction_deactivate_delinquent(
@@ -6779,7 +6777,7 @@ fn test_deactivate_delinquent() {
         reference_vote_state.increment_credits(epoch, 1);
     }
     reference_vote_account
-        .serialize_data(&VoteStateVersions::new_current(reference_vote_state))
+        .serialize_data(&VoteStateVersions::new_v3(reference_vote_state))
         .unwrap();
 
     let post_stake_account = &process_instruction_deactivate_delinquent(
@@ -6807,7 +6805,7 @@ fn test_deactivate_delinquent() {
         vote_state.increment_credits(epoch as Epoch, 1);
     }
     vote_account
-        .serialize_data(&VoteStateVersions::new_current(vote_state))
+        .serialize_data(&VoteStateVersions::new_v3(vote_state))
         .unwrap();
 
     let post_stake_account = &process_instruction_deactivate_delinquent(
@@ -6863,7 +6861,7 @@ fn test_deactivate_delinquent() {
         1,
     );
     vote_account
-        .serialize_data(&VoteStateVersions::new_current(vote_state))
+        .serialize_data(&VoteStateVersions::new_v3(vote_state))
         .unwrap();
     process_instruction_deactivate_delinquent(
         &stake_address,
@@ -6882,7 +6880,7 @@ fn test_deactivate_delinquent() {
         1,
     );
     vote_account
-        .serialize_data(&VoteStateVersions::new_current(vote_state))
+        .serialize_data(&VoteStateVersions::new_v3(vote_state))
         .unwrap();
     process_instruction_deactivate_delinquent(
         &stake_address,


### PR DESCRIPTION
Does the whole "busting up" of `solana-program` and `solana-sdk` wherever necessary, upgrading the program up to use the isolated crates on SDK 3.0.