### PR TITLE
tests: remove use of `solana-vote-program`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7205,7 +7205,6 @@ dependencies = [
  "solana-sysvar-id 3.0.0",
  "solana-transaction",
  "solana-vote-interface 4.0.2",
- "solana-vote-program",
  "test-case",
 ]
 
@@ -7915,7 +7914,6 @@ dependencies = [
  "solana-hash 3.0.0",
  "solana-instruction 3.0.0",
  "solana-keypair",
- "solana-metrics",
  "solana-packet",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -48,7 +48,6 @@ solana-signer = "3.0.0"
 solana-system-interface = { version = "2.0.0", features = ["bincode"] }
 solana-sysvar-id = "3.0.0"
 solana-transaction = "3.0.0"
-solana-vote-program = "3.0.0"
 test-case = "3.3.1"
 
 [lib]


### PR DESCRIPTION
Removes the dev-dependency of `solana-vote-program`. The idea here is to decouple this repo from ongoing changes to the Vote program as much as possible, and instead opt for the interface.

A few key points:
* Every test except for one that works with a vote account just needed a "default" vote account, since it was already creating semi-default accounts (no credits, etc.) but with certain keys set like `authorized_voter = vote_pubkey`, which weren't required.
* The one test that does care about vote state was calling `process_next_vote_slot`, but the Stake program only cares about the vote account's credits, so I just cranked those directly.