### PR TITLE
program: update to support vote state v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7204,7 +7204,7 @@ dependencies = [
  "solana-sysvar 3.0.0",
  "solana-sysvar-id 3.0.0",
  "solana-transaction",
- "solana-vote-interface 4.0.2",
+ "solana-vote-interface 4.0.3",
  "test-case",
 ]
 
@@ -7870,9 +7870,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33f1a30b1e61944e52afef0992a2be93720c5770eaf1f6d8e6e34f87d90e754"
+checksum = "d6970d0b048a7b2c80203fe54e10e0cc6d52a88ef7115bb7214908415e33b930"
 dependencies = [
  "bincode",
  "cfg_eval",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -25,7 +25,7 @@ solana-pubkey = "3.0.0"
 solana-rent = "3.0.0"
 solana-stake-interface = { version = "2", features = ["bincode", "borsh", "sysvar"] }
 solana-sysvar = "3.0.0"
-solana-vote-interface = { version = "4.0.1", features = ["bincode"] }
+solana-vote-interface = { version = "4.0.3", features = ["bincode"] }
 
 [dev-dependencies]
 agave-feature-set = "3.0.0"

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -19,19 +19,23 @@ use {
         tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
     },
     solana_sysvar::{epoch_rewards::EpochRewards, Sysvar, SysvarSerialize},
-    solana_vote_interface::{program as solana_vote_program, state::VoteStateV3 as VoteState},
+    solana_vote_interface::{program as solana_vote_program, state::VoteStateV4},
     std::{collections::HashSet, mem::MaybeUninit},
 };
 
-fn get_vote_state(vote_account_info: &AccountInfo) -> Result<Box<VoteState>, ProgramError> {
+fn get_vote_state(vote_account_info: &AccountInfo) -> Result<Box<VoteStateV4>, ProgramError> {
     if *vote_account_info.owner != solana_vote_program::id() {
         return Err(ProgramError::IncorrectProgramId);
     }
 
     let mut vote_state = Box::new(MaybeUninit::uninit());
-    VoteState::deserialize_into_uninit(&vote_account_info.try_borrow_data()?, vote_state.as_mut())
-        .map_err(|_| ProgramError::InvalidAccountData)?;
-    let vote_state = unsafe { Box::from_raw(Box::into_raw(vote_state) as *mut VoteState) };
+    VoteStateV4::deserialize_into_uninit(
+        &vote_account_info.try_borrow_data()?,
+        vote_state.as_mut(),
+        vote_account_info.key,
+    )
+    .map_err(|_| ProgramError::InvalidAccountData)?;
+    let vote_state = unsafe { Box::from_raw(Box::into_raw(vote_state) as *mut VoteStateV4) };
 
     Ok(vote_state)
 }

--- a/program/tests/interface.rs
+++ b/program/tests/interface.rs
@@ -25,7 +25,7 @@ use {
     solana_sysvar_id::SysvarId,
     solana_vote_interface::{
         program as vote_program,
-        state::{VoteStateV3 as VoteState, VoteStateVersions},
+        state::{VoteStateV4, VoteStateVersions},
     },
     std::{
         collections::{HashMap, HashSet},
@@ -163,8 +163,8 @@ impl Env {
         base_accounts.insert(PAYER, payer_account);
 
         // create two vote accounts
-        let vote_rent_exemption = Rent::default().minimum_balance(VoteState::size_of());
-        let vote_state_versions = VoteStateVersions::new_v3(VoteState::default());
+        let vote_rent_exemption = Rent::default().minimum_balance(VoteStateV4::size_of());
+        let vote_state_versions = VoteStateVersions::new_v4(VoteStateV4::default());
         let vote_data = bincode::serialize(&vote_state_versions).unwrap();
         let vote_account = Account::create(
             vote_rent_exemption,

--- a/program/tests/program_test.rs
+++ b/program/tests/program_test.rs
@@ -23,7 +23,7 @@ use {
     solana_transaction::{Signers, Transaction, TransactionError},
     solana_vote_interface::{
         instruction as vote_instruction,
-        state::{VoteInit, VoteStateV3 as VoteState},
+        state::{VoteInit, VoteStateV4},
     },
     test_case::{test_case, test_matrix},
 };
@@ -93,7 +93,7 @@ pub async fn create_vote(
     vote_account: &Keypair,
 ) {
     let rent = context.banks_client.get_rent().await.unwrap();
-    let rent_voter = rent.minimum_balance(VoteState::size_of());
+    let rent_voter = rent.minimum_balance(VoteStateV4::size_of());
 
     let mut instructions = vec![system_instruction::create_account(
         &context.payer.pubkey(),
@@ -113,7 +113,7 @@ pub async fn create_vote(
         },
         rent_voter,
         vote_instruction::CreateVoteAccountConfig {
-            space: VoteState::size_of() as u64,
+            space: VoteStateV4::size_of() as u64,
             ..Default::default()
         },
     ));


### PR DESCRIPTION
Simply changes `VoteStateV3::deserialize` to `VoteStateV4::deserialize`, which adds v4 to the list of supported vote state versions for deserialization.

Both of these methods operate exactly the same. They deserialize whatever vote state version into `T` to read its fields. I've also added tests to show that the Stake program can now effectively read vote state versions 2, 3, and 4, noting that it never could read version 1 beforehand.

There are no vote state v1 accounts on any network anymore.