### PR TITLE
program: use `assume_init()` for VoteStateV4

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -35,7 +35,7 @@ fn get_vote_state(vote_account_info: &AccountInfo) -> Result<Box<VoteStateV4>, P
         vote_account_info.key,
     )
     .map_err(|_| ProgramError::InvalidAccountData)?;
-    let vote_state = unsafe { Box::from_raw(Box::into_raw(vote_state) as *mut VoteStateV4) };
+    let vote_state = unsafe { vote_state.assume_init() };
 
     Ok(vote_state)
 }


### PR DESCRIPTION
previously we had to use raw pointer casts after parsing `VoteState` because `assume_init()` did not support boxed values prior to rust 1.82. `cargo build-bpf` is now ahead of 1.82, so we can simplify

more details for the curious: https://github.com/solana-program/stake/pull/11#discussion_r1816167504