### PR TITLE
program: Remove bpf-entrypoint / test-sbf features, test all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ format-rust:
 	cargo $(nightly) fmt --all $(ARGS)
 
 build-sbf-%:
-	cargo build-sbf --manifest-path $(call make-path,$*)/Cargo.toml --features bpf-entrypoint $(ARGS)
+	cargo build-sbf --manifest-path $(call make-path,$*)/Cargo.toml $(ARGS)
 
 build-wasm-%:
 	cargo $(nightly) build --target wasm32-unknown-unknown --manifest-path $(call make-path,$*)/Cargo.toml --all-features $(ARGS)
@@ -60,12 +60,6 @@ test-js-%:
 	make restart-test-validator
 	cd $(call make-path,$*) && pnpm install && pnpm build && pnpm test $(ARGS)
 	make stop-test-validator
-
-# TODO program_test is too unreliable to run in ci
-# the tests are fine, but the underlying transport panics frequently, even with `--test-threads 1`
-# we exclude these tests for now because mollusk tests at least provide decent ci coverage
-# in the future if we cannot debug the cause we should move program_test to a different execution engine
-test-program: ARGS = --features bpf-entrypoint -- --skip program_test
 
 test-%:
 	SBF_OUT_DIR=$(PWD)/target/deploy cargo $(nightly) test --manifest-path $(call make-path,$*)/Cargo.toml $(ARGS)

--- a/README.md
+++ b/README.md
@@ -22,20 +22,24 @@ The BPF Stake Program has received one external audit:
 
 ## Building and Verifying
 
-To build the BPF Stake Program, you must pass the `bpf-entrypoint` flag:
+To build the BPF Stake Program, you can run `cargo-build-sbf` or use the Makefile
+command:
 
-```
-cargo build-sbf --features bpf-entrypoint
+```console
+cargo build-sbf --manifest-path program/Cargo.toml
+make build-sbf-program
 ```
 
 The BPF program deployed on all clusters is built with [solana-verify](https://solana.com/developers/guides/advanced/verified-builds). It may be verified independently by comparing the output of:
 
-```solana-verify get-program-hash -um Stake11111111111111111111111111111111111111```
+```console
+solana-verify get-program-hash -um Stake11111111111111111111111111111111111111
+```
 
 with:
 
-```
-solana-verify build --library-name program -- --features bpf-entrypoint
+```console
+solana-verify build --library-name program
 solana-verify get-executable-hash target/deploy/solana_stake_program.so
 ```
 

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 license-file = "../../LICENSE"
 
 [features]
-test-sbf = []
 serde = ["dep:serde", "dep:serde_with"]
 
 [dependencies]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -7,10 +7,6 @@ repository = "https://github.com/solana-program/stake-program"
 license = "Apache-2.0"
 edition = "2021"
 
-[features]
-bpf-entrypoint = []
-test-sbf = []
-
 [dependencies]
 bincode = "1.3.3"
 solana-account-info = { version = "3.0.0", features = ["bincode"] }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -3,7 +3,6 @@ use solana_native_token::LAMPORTS_PER_SOL;
 pub mod helpers;
 pub mod processor;
 
-#[cfg(feature = "bpf-entrypoint")]
 pub mod entrypoint;
 
 solana_pubkey::declare_id!("Stake11111111111111111111111111111111111111");


### PR DESCRIPTION
#### Problem

During the makefile transition, we kept the tests using program-test as disabled. Also, the program still has the `bpf-entrypoint`, and the repo still has `test-sbf` as features, which aren't needed anymore.

#### Summary of changes

Remove `test-sbf` and `bpf-entrypoint`, test everything in CI, see what happens!

~~Note: Leaving in draft to see if CI passes~~ Let's give it a shot!