### PR TITLE
Remove symlink fixture

### DIFF
--- a/program/tests/fixtures/solana_stake_program.so
+++ b/program/tests/fixtures/solana_stake_program.so
@@ -1,1 +1,0 @@
-../../../target/deploy/solana_stake_program.so


### PR DESCRIPTION
Giving trouble to package publishing: https://github.com/solana-program/stake/actions/runs/19864581104/job/56924196677

The publish job attempts to bundle the file, can't find it, and throws. We don't want the binary bundled anyway. Deleting the symlink resolves the packaging failure.