### PR TITLE
interface: Use `doc_cfg` instead of `doc_auto_cfg`

### DIFF
--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1,7 +1,7 @@
 //! The Stake program interface.
 
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[allow(deprecated)]
 pub mod config;


### PR DESCRIPTION
#### Problem

The docs.rs build is currently failing due to the changes in <https://github.com/rust-lang/rust/pull/138907>.

#### Solution

As recommended there, use `doc_cfg` instead of `doc_auto_cfg`.