### PR TITLE
idl: Bump to v3

### DIFF
--- a/interface/idl.json
+++ b/interface/idl.json
@@ -1846,7 +1846,7 @@
     "name": "solanaStakeInterface",
     "pdas": [],
     "publicKey": "Stake11111111111111111111111111111111111111",
-    "version": "2.0.2"
+    "version": "3.0.0"
   },
   "standard": "codama",
   "version": "1.0.0"


### PR DESCRIPTION
#### Problem

The IDL generation step is failing because it doesn't take into account the new version of the interface crate, which is v3.

#### Summary of changes

Commit the bumped version