### PR TITLE
program: add solana-security-txt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2156,8 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -6561,6 +6569,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-security-txt"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "156bb61a96c605fa124e052d630dba2f6fb57e08c7d15b757e1e958b3ed7b3fe"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "solana-seed-derivable"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6864,6 +6881,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-rent 3.0.0",
  "solana-sdk-ids",
+ "solana-security-txt",
  "solana-signature",
  "solana-signer",
  "solana-stake-interface 2.0.1",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -19,6 +19,7 @@ solana-program-entrypoint = "3.0.0"
 solana-program-error = "3.0.1"
 solana-pubkey = "4.2.0"
 solana-rent = "3.0.0"
+solana-security-txt = "1.1.2"
 solana-stake-interface = { version = "2", features = ["bincode", "borsh", "sysvar"] }
 solana-sysvar = "3.0.0"
 solana-sysvar-id = "3.1.0"

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -6,6 +6,7 @@ use {
     solana_msg::msg,
     solana_program_entrypoint::{entrypoint, ProgramResult},
     solana_pubkey::Pubkey,
+    solana_security_txt::security_txt,
 };
 
 entrypoint!(process_instruction);
@@ -20,4 +21,18 @@ fn process_instruction(
     } else {
         Ok(())
     }
+}
+
+security_txt! {
+    // Required fields
+    name: "Solana Stake Program",
+    project_url: "https://solana.com/docs/core/programs/builtin-programs#all-core-programs",
+    contacts: "link:https://github.com/solana-program/stake/security/advisories/new,email:security@anza.xyz,discord:https://discord.gg/solana",
+    policy: "https://github.com/solana-program/stake/blob/main/SECURITY.md",
+
+    // Optional Fields
+    preferred_languages: "en",
+    source_code: "https://github.com/solana-program/stake/tree/main/program",
+    source_release: concat!("program@v", env!("CARGO_PKG_VERSION")),
+    auditors: "https://github.com/solana-program/stake/tree/main?tab=readme-ov-file#security-audits"
 }


### PR DESCRIPTION
i remember someone last month on discord confused about how to figure out _what_ bpf stake they were supposed to verify against so i thought itd be nice to add this. doesnt help us for v5 but will next time!

in the spl repos we never filled out `source_release` because it doesnt really work with the github actions release flow, but i think this is a nice solution. no new commit needed, automatically the correct thing _for releases we actually do_. it will be wrong for ad hoc builds obviously. but i think this is fine since the whole point is for people to go `deployed build -> github tag -> self-verification` and we only deploy tagged releases

the project url is less than ideal but seems like the least bad thing, solana.com has a few pages on staking and stake accounts but nothing that actually mentions the stake program

```
query-security-txt ../target/deploy/solana_stake_program.so
Name: Solana Stake Program
Project URL: https://solana.com/docs/core/programs/builtin-programs#all-core-programs

Contacts:
  Link: https://github.com/solana-program/stake/security/advisories/new
  Email: security@anza.xyz
  Discord: https://discord.gg/solana

Policy:
https://github.com/solana-program/stake/blob/main/SECURITY.md

Preferred Languages:
  en
Source code: https://github.com/solana-program/stake/tree/main/program
Source release: program@v5.0.0

Auditors:
  https://github.com/solana-program/stake/tree/main?tab=readme-ov-file#security-audits
```