### PR TITLE
fix(codama): Update authority seed to size_prefix to match bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,13 +901,36 @@ dependencies = [
 
 [[package]]
 name = "borsh"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
+dependencies = [
+ "borsh-derive 0.10.4",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 1.6.1",
  "bytes",
  "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831213f80d9423998dd696e2c5345aba6be7a0bd8cd19e31c5243e13df1cef89"
+dependencies = [
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -917,10 +940,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
- "proc-macro-crate",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65d6ba50644c98714aa2a70d13d7df3cd75cd2b523a2b452bf010443800976b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276691d96f063427be83e6692b86148e488ebba9f48f77788724ca027ba3b6d4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1054,7 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88da5a13c620b4ca0078845707ea9c3faf11edbc3ffd8497d11d686211cd1ac0"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.8.20",
 ]
 
 [[package]]
@@ -3047,6 +3092,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kaigan"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "358444e00cb7d2efdbe986f90c05466f222e0554c38834d03d994b0705621ab0"
+dependencies = [
+ "borsh 0.10.4",
+ "borsh 1.6.1",
+ "serde",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,7 +3647,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3908,6 +3964,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -5159,7 +5224,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1384b52c435a750cc9c538760fc7bb472fd78e65a9900a2d07312c5bb335b72"
 dependencies = [
- "borsh",
+ "borsh 1.6.1",
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
@@ -5212,7 +5277,7 @@ version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1443f9b60434d0c9886afe5e006249725f7e732fd71020450dc5da4be81820c1"
 dependencies = [
- "borsh",
+ "borsh 1.6.1",
  "futures",
  "solana-account 3.2.0",
  "solana-banks-interface",
@@ -5362,7 +5427,7 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c04abbae16f57178a163125805637b8a076175bb5c0002fb04f4792bea901cf7"
 dependencies = [
- "borsh",
+ "borsh 1.6.1",
 ]
 
 [[package]]
@@ -5591,7 +5656,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8292c436b269ad23cecc8b24f7da3ab07ca111661e25e00ce0e1d22771951ab9"
 dependencies = [
- "borsh",
+ "borsh 1.6.1",
  "solana-instruction",
  "solana-sdk-ids",
 ]
@@ -5950,7 +6015,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1b113239362cee7093bfb250467138f079a2a03673181dc15bff6ccd677912d"
 dependencies = [
- "borsh",
+ "borsh 1.6.1",
  "bytemuck",
  "bytemuck_derive",
  "five8",
@@ -5978,7 +6043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
 dependencies = [
  "bincode",
- "borsh",
+ "borsh 1.6.1",
  "serde",
  "serde_derive",
  "solana-define-syscall 5.0.0",
@@ -6365,7 +6430,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
 dependencies = [
- "borsh",
+ "borsh 1.6.1",
 ]
 
 [[package]]
@@ -7162,7 +7227,8 @@ name = "solana-stake-client"
 version = "0.0.0"
 dependencies = [
  "assert_matches",
- "borsh",
+ "borsh 1.6.1",
+ "kaigan",
  "num-derive",
  "num-traits",
  "serde",
@@ -7201,7 +7267,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "bincode",
- "borsh",
+ "borsh 1.6.1",
  "codama",
  "codama-macros",
  "num-traits",
@@ -7916,7 +7982,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a91404c7de468dd80658cdb5d894ec803d1092ea6e2bfdf84eee6f07559c0d"
 dependencies = [
- "borsh",
+ "borsh 1.6.1",
  "bytemuck",
  "bytemuck_derive",
 ]
@@ -8097,7 +8163,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f9c6e142cdf1e7e77f480053ec9f0ce989890768ddf91f619b50f39d1b456f5"
 dependencies = [
- "borsh",
+ "borsh 1.6.1",
  "bytemuck",
  "bytemuck_derive",
  "num-derive",
@@ -8214,7 +8280,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c467c7c3bd056f8fe60119e7ec34ddd6f23052c2fa8f1f51999098063b72676"
 dependencies = [
- "borsh",
+ "borsh 1.6.1",
  "num-derive",
  "num-traits",
  "solana-borsh",
@@ -8695,6 +8761,15 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/clients/js/src/generated/instructions/authorizeCheckedWithSeed.ts
+++ b/clients/js/src/generated/instructions/authorizeCheckedWithSeed.ts
@@ -16,6 +16,8 @@ import {
     getStructEncoder,
     getU32Decoder,
     getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
     getUtf8Decoder,
     getUtf8Encoder,
     transformEncoder,
@@ -98,7 +100,7 @@ export function getAuthorizeCheckedWithSeedInstructionDataEncoder(): Encoder<Aut
         getStructEncoder([
             ['discriminator', getU32Encoder()],
             ['stakeAuthorize', getStakeAuthorizeEncoder()],
-            ['authoritySeed', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+            ['authoritySeed', addEncoderSizePrefix(getUtf8Encoder(), getU64Encoder())],
             ['authorityOwner', getAddressEncoder()],
         ]),
         value => ({ ...value, discriminator: AUTHORIZE_CHECKED_WITH_SEED_DISCRIMINATOR }),
@@ -109,7 +111,7 @@ export function getAuthorizeCheckedWithSeedInstructionDataDecoder(): Decoder<Aut
     return getStructDecoder([
         ['discriminator', getU32Decoder()],
         ['stakeAuthorize', getStakeAuthorizeDecoder()],
-        ['authoritySeed', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['authoritySeed', addDecoderSizePrefix(getUtf8Decoder(), getU64Decoder())],
         ['authorityOwner', getAddressDecoder()],
     ]);
 }

--- a/clients/js/src/generated/instructions/authorizeWithSeed.ts
+++ b/clients/js/src/generated/instructions/authorizeWithSeed.ts
@@ -16,6 +16,8 @@ import {
     getStructEncoder,
     getU32Decoder,
     getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
     getUtf8Decoder,
     getUtf8Encoder,
     transformEncoder,
@@ -97,7 +99,7 @@ export function getAuthorizeWithSeedInstructionDataEncoder(): Encoder<AuthorizeW
             ['discriminator', getU32Encoder()],
             ['newAuthorizedPubkey', getAddressEncoder()],
             ['stakeAuthorize', getStakeAuthorizeEncoder()],
-            ['authoritySeed', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+            ['authoritySeed', addEncoderSizePrefix(getUtf8Encoder(), getU64Encoder())],
             ['authorityOwner', getAddressEncoder()],
         ]),
         value => ({ ...value, discriminator: AUTHORIZE_WITH_SEED_DISCRIMINATOR }),
@@ -109,7 +111,7 @@ export function getAuthorizeWithSeedInstructionDataDecoder(): Decoder<AuthorizeW
         ['discriminator', getU32Decoder()],
         ['newAuthorizedPubkey', getAddressDecoder()],
         ['stakeAuthorize', getStakeAuthorizeDecoder()],
-        ['authoritySeed', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['authoritySeed', addDecoderSizePrefix(getUtf8Decoder(), getU64Decoder())],
         ['authorityOwner', getAddressDecoder()],
     ]);
 }

--- a/clients/js/src/generated/types/stakeAuthorize.ts
+++ b/clients/js/src/generated/types/stakeAuthorize.ts
@@ -10,6 +10,8 @@ import {
     combineCodec,
     getEnumDecoder,
     getEnumEncoder,
+    getU32Decoder,
+    getU32Encoder,
     type FixedSizeCodec,
     type FixedSizeDecoder,
     type FixedSizeEncoder,
@@ -23,11 +25,11 @@ export enum StakeAuthorize {
 export type StakeAuthorizeArgs = StakeAuthorize;
 
 export function getStakeAuthorizeEncoder(): FixedSizeEncoder<StakeAuthorizeArgs> {
-    return getEnumEncoder(StakeAuthorize);
+    return getEnumEncoder(StakeAuthorize, { size: getU32Encoder() });
 }
 
 export function getStakeAuthorizeDecoder(): FixedSizeDecoder<StakeAuthorize> {
-    return getEnumDecoder(StakeAuthorize);
+    return getEnumDecoder(StakeAuthorize, { size: getU32Decoder() });
 }
 
 export function getStakeAuthorizeCodec(): FixedSizeCodec<StakeAuthorizeArgs, StakeAuthorize> {

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -8,10 +8,11 @@ readme = "README.md"
 license-file = "../../LICENSE"
 
 [features]
-serde = ["dep:serde", "dep:serde_with"]
+serde = ["dep:serde", "dep:serde_with", "kaigan/serde"]
 
 [dependencies]
 borsh = { version = "1.6", features = ["derive"] }
+kaigan = { version = "0.5.0", features = ["borsh-v1"] }
 num-derive = "0.4"
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/clients/rust/src/generated/instructions/authorize_checked_with_seed.rs
+++ b/clients/rust/src/generated/instructions/authorize_checked_with_seed.rs
@@ -8,6 +8,7 @@
 use {
     crate::generated::types::StakeAuthorize,
     borsh::{BorshDeserialize, BorshSerialize},
+    kaigan::types::U64PrefixString,
     solana_pubkey::Pubkey,
 };
 
@@ -102,7 +103,7 @@ impl Default for AuthorizeCheckedWithSeedInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthorizeCheckedWithSeedInstructionArgs {
     pub stake_authorize: StakeAuthorize,
-    pub authority_seed: String,
+    pub authority_seed: U64PrefixString,
     pub authority_owner: Pubkey,
 }
 
@@ -129,7 +130,7 @@ pub struct AuthorizeCheckedWithSeedBuilder {
     new_authority: Option<solana_pubkey::Pubkey>,
     lockup_authority: Option<solana_pubkey::Pubkey>,
     stake_authorize: Option<StakeAuthorize>,
-    authority_seed: Option<String>,
+    authority_seed: Option<U64PrefixString>,
     authority_owner: Option<Pubkey>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
@@ -179,7 +180,7 @@ impl AuthorizeCheckedWithSeedBuilder {
         self
     }
     #[inline(always)]
-    pub fn authority_seed(&mut self, authority_seed: String) -> &mut Self {
+    pub fn authority_seed(&mut self, authority_seed: U64PrefixString) -> &mut Self {
         self.authority_seed = Some(authority_seed);
         self
     }
@@ -439,7 +440,7 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn authority_seed(&mut self, authority_seed: String) -> &mut Self {
+    pub fn authority_seed(&mut self, authority_seed: U64PrefixString) -> &mut Self {
         self.instruction.authority_seed = Some(authority_seed);
         self
     }
@@ -535,7 +536,7 @@ struct AuthorizeCheckedWithSeedCpiBuilderInstruction<'a, 'b> {
     new_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     lockup_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     stake_authorize: Option<StakeAuthorize>,
-    authority_seed: Option<String>,
+    authority_seed: Option<U64PrefixString>,
     authority_owner: Option<Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,

--- a/clients/rust/src/generated/instructions/authorize_with_seed.rs
+++ b/clients/rust/src/generated/instructions/authorize_with_seed.rs
@@ -8,6 +8,7 @@
 use {
     crate::generated::types::StakeAuthorize,
     borsh::{BorshDeserialize, BorshSerialize},
+    kaigan::types::U64PrefixString,
     solana_pubkey::Pubkey,
 };
 
@@ -97,7 +98,7 @@ impl Default for AuthorizeWithSeedInstructionData {
 pub struct AuthorizeWithSeedInstructionArgs {
     pub new_authorized_pubkey: Pubkey,
     pub stake_authorize: StakeAuthorize,
-    pub authority_seed: String,
+    pub authority_seed: U64PrefixString,
     pub authority_owner: Pubkey,
 }
 
@@ -123,7 +124,7 @@ pub struct AuthorizeWithSeedBuilder {
     lockup_authority: Option<solana_pubkey::Pubkey>,
     new_authorized_pubkey: Option<Pubkey>,
     stake_authorize: Option<StakeAuthorize>,
-    authority_seed: Option<String>,
+    authority_seed: Option<U64PrefixString>,
     authority_owner: Option<Pubkey>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
@@ -172,7 +173,7 @@ impl AuthorizeWithSeedBuilder {
         self
     }
     #[inline(always)]
-    pub fn authority_seed(&mut self, authority_seed: String) -> &mut Self {
+    pub fn authority_seed(&mut self, authority_seed: U64PrefixString) -> &mut Self {
         self.authority_seed = Some(authority_seed);
         self
     }
@@ -420,7 +421,7 @@ impl<'a, 'b> AuthorizeWithSeedCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn authority_seed(&mut self, authority_seed: String) -> &mut Self {
+    pub fn authority_seed(&mut self, authority_seed: U64PrefixString) -> &mut Self {
         self.instruction.authority_seed = Some(authority_seed);
         self
     }
@@ -516,7 +517,7 @@ struct AuthorizeWithSeedCpiBuilderInstruction<'a, 'b> {
     lockup_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     new_authorized_pubkey: Option<Pubkey>,
     stake_authorize: Option<StakeAuthorize>,
-    authority_seed: Option<String>,
+    authority_seed: Option<U64PrefixString>,
     authority_owner: Option<Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -19,7 +19,7 @@ program-id = "Stake11111111111111111111111111111111111111"
 [dependencies]
 borsh = { version = "1.6.1", features = ["derive", "unstable__schema"], optional = true }
 codama = { version = "0.9.2", optional = true }
-codama-macros = { version = "0.9.1", optional = true }
+codama-macros = { version = "0.9.2", optional = true }
 num-traits = "0.2"
 serde = { version = "1.0.210", optional = true }
 serde_derive = { version = "1.0.210", optional = true }

--- a/interface/idl.json
+++ b/interface/idl.json
@@ -128,7 +128,7 @@
                 "kind": "sizePrefixTypeNode",
                 "prefix": {
                   "endian": "le",
-                  "format": "u32",
+                  "format": "u64",
                   "kind": "numberTypeNode"
                 },
                 "type": {
@@ -168,7 +168,7 @@
                 "kind": "sizePrefixTypeNode",
                 "prefix": {
                   "endian": "le",
-                  "format": "u32",
+                  "format": "u64",
                   "kind": "numberTypeNode"
                 },
                 "type": {
@@ -213,7 +213,7 @@
           "kind": "enumTypeNode",
           "size": {
             "endian": "le",
-            "format": "u8",
+            "format": "u32",
             "kind": "numberTypeNode"
           },
           "variants": [
@@ -265,7 +265,7 @@
           "kind": "enumTypeNode",
           "size": {
             "endian": "le",
-            "format": "u8",
+            "format": "u32",
             "kind": "numberTypeNode"
           },
           "variants": [
@@ -321,7 +321,7 @@
           "kind": "enumTypeNode",
           "size": {
             "endian": "le",
-            "format": "u8",
+            "format": "u32",
             "kind": "numberTypeNode"
           },
           "variants": [
@@ -1854,7 +1854,7 @@
     "name": "solanaStakeInterface",
     "pdas": [],
     "publicKey": "Stake11111111111111111111111111111111111111",
-    "version": "3.1.0"
+    "version": "4.0.0"
   },
   "standard": "codama",
   "version": "1.0.0"

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -565,6 +565,7 @@ pub struct LockupCheckedArgs {
 pub struct AuthorizeWithSeedArgs {
     pub new_authorized_pubkey: Pubkey,
     pub stake_authorize: StakeAuthorize,
+    #[cfg_attr(feature = "codama", codama(size_prefix = number(u64)))]
     pub authority_seed: String,
     pub authority_owner: Pubkey,
 }
@@ -581,6 +582,7 @@ pub struct AuthorizeWithSeedArgs {
 )]
 pub struct AuthorizeCheckedWithSeedArgs {
     pub stake_authorize: StakeAuthorize,
+    #[cfg_attr(feature = "codama", codama(size_prefix = number(u64)))]
     pub authority_seed: String,
     pub authority_owner: Pubkey,
 }

--- a/interface/tests/codama_schema.rs
+++ b/interface/tests/codama_schema.rs
@@ -1,0 +1,53 @@
+#![cfg(feature = "codama")]
+
+use {codama::Codama, serde_json::Value, std::path::Path};
+
+#[test]
+fn test_all_codama_strings_use_u64_size_prefix() {
+    let idl = load_idl();
+
+    json_value_iter(&idl)
+        .filter(|value| {
+            value["kind"] == "sizePrefixTypeNode" && value["type"]["kind"] == "stringTypeNode"
+        })
+        .for_each(|value| {
+            assert_eq!(value["prefix"]["kind"], "numberTypeNode");
+            assert_eq!(value["prefix"]["endian"], "le");
+            assert_eq!(value["prefix"]["format"], "u64");
+        });
+}
+
+#[test]
+fn test_all_codama_enums_use_u32_discriminators() {
+    let idl = load_idl();
+
+    json_value_iter(&idl)
+        .filter(|value| value["kind"] == "enumTypeNode")
+        .for_each(|value| {
+            assert_eq!(value["size"]["kind"], "numberTypeNode");
+            assert_eq!(value["size"]["endian"], "le");
+            assert_eq!(value["size"]["format"], "u32");
+        });
+}
+
+fn load_idl() -> Value {
+    let crate_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let idl_json = Codama::load(crate_path).unwrap().get_json_idl().unwrap();
+    serde_json::from_str(&idl_json).unwrap()
+}
+
+fn json_value_iter(root: &Value) -> impl Iterator<Item = &Value> {
+    let mut stack = vec![root];
+
+    std::iter::from_fn(move || {
+        let value = stack.pop()?;
+
+        match value {
+            Value::Array(values) => stack.extend(values.iter()),
+            Value::Object(values) => stack.extend(values.values()),
+            _ => {}
+        }
+
+        Some(value)
+    })
+}


### PR DESCRIPTION
This also brings in the enum_discriminator fix from codama 0.9.2