### PR TITLE
feat: Add methods for checked arithmetics to `StakeHistoryEntry`

### DIFF
--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -43,6 +43,30 @@ impl StakeHistoryEntry {
             ..Self::default()
         }
     }
+
+    pub fn checked_add(self, rhs: StakeHistoryEntry) -> Option<Self> {
+        Some(Self {
+            effective: self.effective.checked_add(rhs.effective)?,
+            activating: self.activating.checked_add(rhs.activating)?,
+            deactivating: self.deactivating.checked_add(rhs.deactivating)?,
+        })
+    }
+
+    pub fn wrapping_add(self, rhs: StakeHistoryEntry) -> Self {
+        Self {
+            effective: self.effective.wrapping_add(rhs.effective),
+            activating: self.activating.wrapping_add(rhs.activating),
+            deactivating: self.deactivating.wrapping_add(rhs.deactivating),
+        }
+    }
+
+    pub fn saturating_add(self, rhs: StakeHistoryEntry) -> Self {
+        Self {
+            effective: self.effective.saturating_add(rhs.effective),
+            activating: self.activating.saturating_add(rhs.activating),
+            deactivating: self.deactivating.saturating_add(rhs.deactivating),
+        }
+    }
 }
 
 impl std::ops::Add for StakeHistoryEntry {


### PR DESCRIPTION
The usage of existing `std::ops::Add` implementation triggers the `arithmetic_side_effects` clippy lint.

To allow addressing it, add the following methods to `StakeHistoryEntry`:

* `checked_add`
* `wrapping_add`
* `saturating_add`