### PR TITLE
Widen ulp tolerance

### DIFF
--- a/interface/src/ulp.rs
+++ b/interface/src/ulp.rs
@@ -36,14 +36,14 @@ pub fn max_ulp_tolerance(candidate: u64, oracle: u64) -> u64 {
     // Get the ULP spacing
     let ulp = ulp_of_u64(mag);
 
-    // Use a 4x ULP tolerance to account for precision error accumulation in the
+    // Use a 10x ULP tolerance to account for precision error accumulation in the
     // legacy `f64` impl:
     // - Three `u64` to `f64` conversions
     // - One division and two multiplications are rounded
     // - The `as u64` cast truncates the final `f64` result
     //
-    // Proptest confirmed these can accumulate to >3 ULPs, so 4x is a safe margin.
-    ulp.saturating_mul(4)
+    // Formal proof verified it will not exceed 10 ULPs (1280 lamports).
+    ulp.saturating_mul(10)
 }
 
 #[cfg(test)]
@@ -61,24 +61,24 @@ mod test {
 
     #[test]
     fn tolerance_small_magnitudes_use_single_ulp() {
-        // For magnitudes < 2^53, ULP = 1, so tolerance = 4 * 1 = 4.
-        assert_eq!(max_ulp_tolerance(0, 0), 4);
-        assert_eq!(max_ulp_tolerance(0, 1), 4);
-        assert_eq!(max_ulp_tolerance((1u64 << 53) - 1, 1), 4);
+        // For magnitudes < 2^53, ULP = 1, so tolerance = 10 * 1 = 10.
+        assert_eq!(max_ulp_tolerance(0, 0), 10);
+        assert_eq!(max_ulp_tolerance(0, 1), 10);
+        assert_eq!(max_ulp_tolerance((1u64 << 53) - 1, 1), 10);
     }
 
     #[test]
     fn tolerance_scales_with_magnitude_powers_of_two() {
-        // Around powers of two, ULP doubles each time, so tolerance (4 * ULP) doubles.
+        // Around powers of two, ULP doubles each time, so tolerance (10 * ULP) doubles.
         let below_2_53 = max_ulp_tolerance((1u64 << 53) - 1, 0); // ULP = 1
         let at_2_53 = max_ulp_tolerance(1u64 << 53, 0); // ULP = 2
         let at_2_54 = max_ulp_tolerance(1u64 << 54, 0); // ULP = 4
         let at_2_55 = max_ulp_tolerance(1u64 << 55, 0); // ULP = 8
 
-        assert_eq!(below_2_53, 4); // 4 * 1
-        assert_eq!(at_2_53, 8); // 4 * 2
-        assert_eq!(at_2_54, 16); // 4 * 4
-        assert_eq!(at_2_55, 32); // 4 * 8
+        assert_eq!(below_2_53, 10); // 10 * 1
+        assert_eq!(at_2_53, 20); // 10 * 2
+        assert_eq!(at_2_54, 40); // 10 * 4
+        assert_eq!(at_2_55, 80); // 10 * 8
     }
 
     #[test]
@@ -99,8 +99,8 @@ mod test {
     #[test]
     fn tolerance_at_u64_max_matches_expected_ulp() {
         // From ulp_standard_calc: ulp_of_u64(u64::MAX) == 4096
-        // So tolerance = 4 * 4096 = 16384
-        assert_eq!(max_ulp_tolerance(u64::MAX, 0), 4096 * 4);
-        assert_eq!(max_ulp_tolerance(0, u64::MAX), 4096 * 4);
+        // So tolerance = 10 * 4096 = 40960
+        assert_eq!(max_ulp_tolerance(u64::MAX, 0), 4096 * 10);
+        assert_eq!(max_ulp_tolerance(0, u64::MAX), 4096 * 10);
     }
 }

--- a/interface/src/warmup_cooldown_allowance.rs
+++ b/interface/src/warmup_cooldown_allowance.rs
@@ -359,6 +359,43 @@ mod test {
         (weight * newly_effective_cluster_stake) as u64
     }
 
+    #[test]
+    fn high_ulp_case() {
+        // Differs by 5 ULPs (difficult to find a higher diff)
+        let account_portion = 342_898_401_157_885_026;
+        let cluster_portion = 2_426_138_261_763_124_479;
+        let cluster_effective = 708_104_488_956_562_499;
+        let current_epoch = 10;
+        let rate_change_activation_epoch = Some(0);
+
+        let integer_math_result = calculate_stake_change_allowance(
+            current_epoch,
+            account_portion,
+            cluster_portion,
+            cluster_effective,
+            rate_change_activation_epoch,
+        );
+        let float_math_result = calculate_stake_delta_f64_legacy(
+            account_portion,
+            cluster_portion,
+            cluster_effective,
+            current_epoch,
+            rate_change_activation_epoch,
+        )
+        .min(account_portion);
+
+        assert_eq!(integer_math_result, 9_007_199_253_579_461);
+        assert_eq!(float_math_result, 9_007_199_253_579_466);
+
+        let diff = integer_math_result.abs_diff(float_math_result);
+        let tolerance = max_ulp_tolerance(integer_math_result, float_math_result);
+        let ulp = tolerance / 10;
+
+        assert_eq!(ulp, 1);
+        assert_eq!(diff, 5 * ulp);
+        assert!(diff <= tolerance);
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(10_000))]
 


### PR DESCRIPTION
During audit was provided a case where the ULP diff was > 4. Recommended widening to 10:

> With 5 axioms on f64's behavior, I've formally proven, assuming the triple multiply does not overflow and no division by 0 occurs, that a tolerance of 10*ulp is maintained regardless of the account_portion, cluster_effective, or rate_bps in all scenarios.

Practically speaking, this means the integer and float implementations (not including highly unlikely overflow cases) do not differ more than 1280 lamports. 

No impact to product code, just tests.