### PR TITLE
feat(interface): derive StableAbi and StableAbiSample on AbiExample types

### DIFF
--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -25,8 +25,8 @@ serde = { version = "1.0.210", optional = true }
 serde_derive = { version = "1.0.210", optional = true }
 solana-clock = "3.1.0"
 solana-cpi = { version = "3.0.0", optional = true }
-solana-frozen-abi = { version = "3.5.0", features = ["frozen-abi"], optional = true }
-solana-frozen-abi-macro = { version = "3.4.0", features = ["frozen-abi"], optional = true }
+solana-frozen-abi = { version = "3.6.0", features = ["frozen-abi"], optional = true }
+solana-frozen-abi-macro = { version = "3.6.0", features = ["frozen-abi"], optional = true }
 solana-instruction = "3.4.0"
 solana-program-error = "3.0.1"
 solana-pubkey = { version = "4.2.0", default-features = false }

--- a/interface/src/stake_flags.rs
+++ b/interface/src/stake_flags.rs
@@ -5,7 +5,14 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 #[repr(transparent)]
 #[cfg_attr(feature = "codama", derive(codama_macros::CodamaType))]
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "borsh",
     derive(BorshSerialize, BorshDeserialize, BorshSchema),

--- a/interface/src/stake_history.rs
+++ b/interface/src/stake_history.rs
@@ -19,7 +19,14 @@ pub const SIZE: usize = LEN_PREFIX + MAX_ENTRIES * EPOCH_AND_ENTRY_SERIALIZED_SI
 const _: () = assert!(SIZE == 16_392);
 
 #[repr(C)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
@@ -94,7 +101,14 @@ impl std::ops::Add for StakeHistoryEntry {
 }
 
 #[repr(C)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -99,7 +99,14 @@ macro_rules! impl_borsh_stake_state {
     codama(enum_discriminator(size = number(u32)))
 )]
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
@@ -165,7 +172,14 @@ impl StakeState {
     codama(enum_discriminator(size = number(u32)))
 )]
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
@@ -290,7 +304,14 @@ impl StakeStateV2 {
     codama(enum_discriminator(size = number(u32)))
 )]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
@@ -304,7 +325,14 @@ pub enum StakeAuthorize {
 #[repr(C)]
 #[cfg_attr(feature = "codama", derive(CodamaType))]
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "borsh",
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
@@ -338,7 +366,14 @@ impl Lockup {
 #[repr(C)]
 #[cfg_attr(feature = "codama", derive(CodamaType))]
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "borsh",
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
@@ -423,7 +458,14 @@ impl Authorized {
 #[repr(C)]
 #[cfg_attr(feature = "codama", derive(CodamaType))]
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "borsh",
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
@@ -485,7 +527,14 @@ impl Meta {
 #[repr(C)]
 #[cfg_attr(feature = "codama", derive(CodamaType))]
 #[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "borsh",
     derive(BorshSerialize, BorshDeserialize, BorshSchema),
@@ -925,7 +974,14 @@ impl Delegation {
 #[repr(C)]
 #[cfg_attr(feature = "codama", derive(CodamaType))]
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "borsh",
     derive(BorshSerialize, BorshDeserialize, BorshSchema),


### PR DESCRIPTION
Add the `StableAbi` and `StableAbiSample` derives alongside every `AbiExample`
derive in the stake interface, enabling random-sample ABI digesting for
these types.