### PR TITLE
Bump the JS client to v0.7.0

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana-program/stake",
-    "version": "0.6.1",
+    "version": "0.7.0",
     "description": "JavaScript client for the Stake program",
     "homepage": "https://github.com/solana-program/stake#readme",
     "bugs": {


### PR DESCRIPTION
This PR bumps the JS client's version to `0.7.0` to match the version already published to npm. The previous publish succeeded on npm but could not push the version-bump commit back to `main`, so this realigns `main` with the published package and lets the next release cut a clean patch version.