### PR TITLE
Add attestation permissions to publish-rust workflow

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -68,6 +68,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: write
+      artifact-metadata: write
     with:
       sbpf-program-packages: "program"
       solana-cli-version: ${{ needs.set_env.outputs.SOLANA_CLI_VERSION }}


### PR DESCRIPTION
This PR adds `attestations: write` and `artifact-metadata: write` to the `main` job of the `publish-rust.yml` caller workflow. The reusable `publish-rust.yml` workflow in `solana-program/actions` declares these permissions on its `publish` job to generate SLSA provenance attestations, but since a called workflow cannot be granted more permissions than its caller, they were being silently dropped and the attestation step failed during publishing. This was validated on token-2022 first and is now being rolled out across the fleet.