### PR TITLE
Add semver check option

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -40,6 +40,14 @@ on:
         required: true
         type: boolean
         default: true
+      run-semver:
+        description: |
+          Run semver checks.
+          Only disable checks if you are sure of the semver impact of your change and have a good reason
+          to skip it.
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   set_env:
@@ -81,4 +89,5 @@ jobs:
       version: ${{ inputs.version }}
       create-release: ${{ inputs['create-release'] }}
       dry-run: ${{ inputs['dry-run'] }}
+      run-semver: ${{ inputs['run-semver'] }}
     secrets: inherit


### PR DESCRIPTION
Utilizes semver option in the UI for crate publshing. Copies description from https://github.com/anza-xyz/solana-sdk/blob/master/.github/workflows/publish-rust.yml#L45-L52.

Relevant after https://github.com/solana-program/stake/pull/448 and a [failed publish](https://github.com/solana-program/stake/actions/runs/28351304959) due to the semver check (which needs disabling for this next run).