### PR TITLE
Add clear-signing display directives to the interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,44 +1141,29 @@ dependencies = [
 
 [[package]]
 name = "codama"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f4cabc7026336c6099175bcdc43e63c5f09893f5b9d1a778983c4e4d21c3bd"
+checksum = "6d3f54c527ab6dad39190e0ed5be39d964c81c842eb08971c26de8214c18dc9a"
 dependencies = [
- "codama-errors 0.9.2",
+ "codama-errors",
  "codama-korok-visitors",
- "codama-koroks 0.9.2",
- "codama-macros 0.9.2",
- "codama-nodes 0.9.2",
+ "codama-koroks",
+ "codama-macros",
+ "codama-nodes",
  "codama-plugin-core",
- "codama-stores 0.9.2",
+ "codama-stores",
  "proc-macro2",
 ]
 
 [[package]]
 name = "codama-attributes"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c34b31b763f2ed669199c636730170749b68672c9d14da17fca7eff946fbe14"
+checksum = "4fbc65cfb6876d02c21eb6fbbb188708351574e44f5848a1b682f4e9f6826a37"
 dependencies = [
- "codama-errors 0.9.2",
- "codama-nodes 0.9.2",
- "codama-syn-helpers 0.9.2",
- "derive_more",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "codama-attributes"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319da8de964230be2786ae5ddc96144e7ef634e3d270fd8d8e8a4c3f3b03cc75"
-dependencies = [
- "codama-errors 0.10.0",
- "codama-nodes 0.10.0",
- "codama-syn-helpers 0.10.0",
+ "codama-errors",
+ "codama-nodes",
+ "codama-syn-helpers",
  "derive_more",
  "proc-macro2",
  "quote",
@@ -1187,22 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "codama-errors"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85538d4d1aaf7219715efc0fff04f61460a52ea3e2951785fba2259c93fe000a"
-dependencies = [
- "cargo_toml",
- "proc-macro2",
- "serde_json",
- "syn 2.0.117",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "codama-errors"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1469342ef520f878f9dffa2b92339bb738024d18f67c695710b706ddbb7f65a5"
+checksum = "9c4e65ee3ef3464d660567139bc313368c3d13c1f4a84f455f4b20ba90ba0320"
 dependencies = [
  "cargo_toml",
  "proc-macro2",
@@ -1213,47 +1185,31 @@ dependencies = [
 
 [[package]]
 name = "codama-korok-visitors"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c693af98c9064e1c987c2e9ba12e2e6e5941abdfd88751a681804ef4a8e4389f"
+checksum = "2dabf0f200df043e7deed645fad5f60befaebc0991aa170cbdceb295d8da91d4"
 dependencies = [
  "cargo_toml",
- "codama-attributes 0.9.2",
- "codama-errors 0.9.2",
- "codama-koroks 0.9.2",
- "codama-nodes 0.9.2",
- "codama-syn-helpers 0.9.2",
+ "codama-attributes",
+ "codama-errors",
+ "codama-koroks",
+ "codama-nodes",
+ "codama-syn-helpers",
  "serde_json",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "codama-koroks"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38335ee8c470ab62af63026f9d1af6ab5d71bff2e8fedad33c1605111ec86824"
+checksum = "7aaf54ba9b675911ef6baff152df96d55e2228cbe5e103fd0c76d823932d7ae9"
 dependencies = [
- "codama-attributes 0.9.2",
- "codama-errors 0.9.2",
- "codama-nodes 0.9.2",
- "codama-stores 0.9.2",
- "codama-syn-helpers 0.9.2",
- "derive_more",
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "codama-koroks"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a5a9cf35ff01d3c64835f0b8661e6eab552aaffc5acbd22fe81b99b4412631"
-dependencies = [
- "codama-attributes 0.10.0",
- "codama-errors 0.10.0",
- "codama-nodes 0.10.0",
- "codama-stores 0.10.0",
- "codama-syn-helpers 0.10.0",
+ "codama-attributes",
+ "codama-errors",
+ "codama-nodes",
+ "codama-stores",
+ "codama-syn-helpers",
  "derive_more",
  "proc-macro2",
  "syn 2.0.117",
@@ -1261,29 +1217,14 @@ dependencies = [
 
 [[package]]
 name = "codama-macros"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258c2a0694979368cdb960ee76a527ce52cad67d1503bd74b544b5de1394c5b9"
+checksum = "a7eb88686d13afa2983ad1ab294bc1ee226ddcd63ef290b6d44bb78e42c87a6f"
 dependencies = [
- "codama-attributes 0.9.2",
- "codama-errors 0.9.2",
- "codama-koroks 0.9.2",
- "codama-stores 0.9.2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "codama-macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f106658328f05ed9018110788a8251f048b3fa56487fbafe005a38cfb34046e"
-dependencies = [
- "codama-attributes 0.10.0",
- "codama-errors 0.10.0",
- "codama-koroks 0.10.0",
- "codama-stores 0.10.0",
+ "codama-attributes",
+ "codama-errors",
+ "codama-koroks",
+ "codama-stores",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1291,25 +1232,12 @@ dependencies = [
 
 [[package]]
 name = "codama-nodes"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928d41d2febe047f2e3e0e266b5d5badfda3239b39f9c4e85df6db985f161d6e"
+checksum = "4c233b476fe665182fde18ca7afc43b5385622367ac6d98661c0c6748f93a9b0"
 dependencies = [
- "codama-errors 0.9.2",
- "codama-nodes-derive 0.9.2",
- "derive_more",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "codama-nodes"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87b3d1b268882b1f1f2a43b536ba4bdaf422488e62f7f67731822aa5681ca5b"
-dependencies = [
- "codama-errors 0.10.0",
- "codama-nodes-derive 0.10.0",
+ "codama-errors",
+ "codama-nodes-derive",
  "derive_more",
  "serde",
  "serde_json",
@@ -1317,26 +1245,12 @@ dependencies = [
 
 [[package]]
 name = "codama-nodes-derive"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8c8b06f2b3fe7b749b0bc01c302d93a90820ff113ab8da48e9d84041bea0c4b"
+checksum = "86315bc36007da03157be9657e24f3235e5cf53b384f15a4b03c484a2b087487"
 dependencies = [
- "codama-errors 0.9.2",
- "codama-syn-helpers 0.9.2",
- "derive_more",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "codama-nodes-derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5d290c129a35225acf486daaf66d4c3896aee44086cbdb07f0e4f20d67365f"
-dependencies = [
- "codama-errors 0.10.0",
- "codama-syn-helpers 0.10.0",
+ "codama-errors",
+ "codama-syn-helpers",
  "derive_more",
  "proc-macro2",
  "quote",
@@ -1345,61 +1259,36 @@ dependencies = [
 
 [[package]]
 name = "codama-plugin-core"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1609ed645d756f5ac769abd2624d24e5eab1364559da0d0ecb66059a33d91460"
+checksum = "9c481fd44427b6088c2903cb93ad1322f9fd83e6ab08c5b7fbb9b8c59c7f4e24"
 dependencies = [
- "codama-attributes 0.9.2",
- "codama-errors 0.9.2",
+ "codama-attributes",
+ "codama-errors",
  "codama-korok-visitors",
- "codama-koroks 0.9.2",
- "codama-nodes 0.9.2",
+ "codama-koroks",
+ "codama-nodes",
 ]
 
 [[package]]
 name = "codama-stores"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48465cb08e1c294eb56208ad3fee277fcc046340eaae89fb33803c04ad438abe"
+checksum = "55cd34fddc3f7ec44f62d5a75fcde422f7bdfa7662a1432ea38957482ec52750"
 dependencies = [
  "cargo_toml",
- "codama-errors 0.9.2",
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "codama-stores"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f2b32f6053220c34877fa0267c006b8419fce78ee0cf286e04df7095f93133"
-dependencies = [
- "cargo_toml",
- "codama-errors 0.10.0",
+ "codama-errors",
  "proc-macro2",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "codama-syn-helpers"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6349406e9f5fc9d4a0db2e34eae883ef638633146482884de442bcf95c9f310"
+checksum = "0c32b8d72d636d82ffe8cb2e614fbc5c84d897b5969eb27dfac226d944efe361"
 dependencies = [
- "codama-errors 0.9.2",
- "derive_more",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "codama-syn-helpers"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef1c5c5ca7519e115a6d2ed240dbc4cbe16c05f241f3aaf5f1fb623b8d3b17e"
-dependencies = [
- "codama-errors 0.10.0",
+ "codama-errors",
  "derive_more",
  "proc-macro2",
  "quote",
@@ -7210,7 +7099,7 @@ dependencies = [
  "bincode",
  "borsh",
  "codama",
- "codama-macros 0.10.0",
+ "codama-macros",
  "num-traits",
  "proptest",
  "serde",

--- a/clients/rust/src/generated/instructions/authorize.rs
+++ b/clients/rust/src/generated/instructions/authorize.rs
@@ -280,8 +280,8 @@ impl<'a, 'b> AuthorizeCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = AuthorizeInstructionData::new().try_to_vec().unwrap();

--- a/clients/rust/src/generated/instructions/authorize_checked.rs
+++ b/clients/rust/src/generated/instructions/authorize_checked.rs
@@ -301,8 +301,8 @@ impl<'a, 'b> AuthorizeCheckedCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = AuthorizeCheckedInstructionData::new().try_to_vec().unwrap();

--- a/clients/rust/src/generated/instructions/authorize_checked_with_seed.rs
+++ b/clients/rust/src/generated/instructions/authorize_checked_with_seed.rs
@@ -326,8 +326,8 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = AuthorizeCheckedWithSeedInstructionData::new()

--- a/clients/rust/src/generated/instructions/authorize_with_seed.rs
+++ b/clients/rust/src/generated/instructions/authorize_with_seed.rs
@@ -313,8 +313,8 @@ impl<'a, 'b> AuthorizeWithSeedCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = AuthorizeWithSeedInstructionData::new()

--- a/clients/rust/src/generated/instructions/deactivate.rs
+++ b/clients/rust/src/generated/instructions/deactivate.rs
@@ -209,8 +209,8 @@ impl<'a, 'b> DeactivateCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = DeactivateInstructionData::new().try_to_vec().unwrap();

--- a/clients/rust/src/generated/instructions/deactivate_delinquent.rs
+++ b/clients/rust/src/generated/instructions/deactivate_delinquent.rs
@@ -208,8 +208,8 @@ impl<'a, 'b> DeactivateDelinquentCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = DeactivateDelinquentInstructionData::new()

--- a/clients/rust/src/generated/instructions/delegate_stake.rs
+++ b/clients/rust/src/generated/instructions/delegate_stake.rs
@@ -283,8 +283,8 @@ impl<'a, 'b> DelegateStakeCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = DelegateStakeInstructionData::new().try_to_vec().unwrap();

--- a/clients/rust/src/generated/instructions/get_minimum_delegation.rs
+++ b/clients/rust/src/generated/instructions/get_minimum_delegation.rs
@@ -131,8 +131,8 @@ impl<'a, 'b> GetMinimumDelegationCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = GetMinimumDelegationInstructionData::new()

--- a/clients/rust/src/generated/instructions/initialize.rs
+++ b/clients/rust/src/generated/instructions/initialize.rs
@@ -223,8 +223,8 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = InitializeInstructionData::new().try_to_vec().unwrap();

--- a/clients/rust/src/generated/instructions/initialize_checked.rs
+++ b/clients/rust/src/generated/instructions/initialize_checked.rs
@@ -237,8 +237,8 @@ impl<'a, 'b> InitializeCheckedCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = InitializeCheckedInstructionData::new()

--- a/clients/rust/src/generated/instructions/merge.rs
+++ b/clients/rust/src/generated/instructions/merge.rs
@@ -268,8 +268,8 @@ impl<'a, 'b> MergeCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = MergeInstructionData::new().try_to_vec().unwrap();

--- a/clients/rust/src/generated/instructions/move_lamports.rs
+++ b/clients/rust/src/generated/instructions/move_lamports.rs
@@ -244,8 +244,8 @@ impl<'a, 'b> MoveLamportsCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = MoveLamportsInstructionData::new().try_to_vec().unwrap();

--- a/clients/rust/src/generated/instructions/move_stake.rs
+++ b/clients/rust/src/generated/instructions/move_stake.rs
@@ -241,8 +241,8 @@ impl<'a, 'b> MoveStakeCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = MoveStakeInstructionData::new().try_to_vec().unwrap();

--- a/clients/rust/src/generated/instructions/set_lockup.rs
+++ b/clients/rust/src/generated/instructions/set_lockup.rs
@@ -232,8 +232,8 @@ impl<'a, 'b> SetLockupCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = SetLockupInstructionData::new().try_to_vec().unwrap();

--- a/clients/rust/src/generated/instructions/set_lockup_checked.rs
+++ b/clients/rust/src/generated/instructions/set_lockup_checked.rs
@@ -254,8 +254,8 @@ impl<'a, 'b> SetLockupCheckedCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = SetLockupCheckedInstructionData::new().try_to_vec().unwrap();

--- a/clients/rust/src/generated/instructions/split.rs
+++ b/clients/rust/src/generated/instructions/split.rs
@@ -233,8 +233,8 @@ impl<'a, 'b> SplitCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = SplitInstructionData::new().try_to_vec().unwrap();

--- a/clients/rust/src/generated/instructions/withdraw.rs
+++ b/clients/rust/src/generated/instructions/withdraw.rs
@@ -318,8 +318,8 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = WithdrawInstructionData::new().try_to_vec().unwrap();

--- a/codama.mjs
+++ b/codama.mjs
@@ -37,8 +37,13 @@ export default {
                                 definedTypes: [
                                     // Add Epoch type alias
                                     c.definedTypeNode({ name: 'epoch', type: c.numberTypeNode('u64') }),
-                                    // Add UnixTimestamp type alias
-                                    c.definedTypeNode({ name: 'unixTimestamp', type: c.numberTypeNode('i64') }),
+                                    // Add UnixTimestamp type alias, displayed as a date-time
+                                    c.definedTypeNode({
+                                        name: 'unixTimestamp',
+                                        type: c.numberTypeNode('i64', 'le', {
+                                            display: c.dateTimeNumberDisplayNode({}),
+                                        }),
+                                    }),
                                     ...node.definedTypes,
                                 ],
                             };
@@ -58,7 +63,7 @@ export default {
                             return {
                                 ...node,
                                 accounts: [
-                                    ...node.accounts,
+                                    ...(node.accounts ?? []),
                                     // Stake account wrapper for client convenience
                                     c.accountNode({
                                         name: 'stakeStateAccount',
@@ -96,6 +101,9 @@ export default {
                             c.assertIsNode(node, 'instructionNode');
                             return {
                                 ...node,
+                                // The Rust-generated IDL omits empty account lists, which some
+                                // renderers still expect to be present.
+                                accounts: node.accounts ?? [],
                                 optionalAccountStrategy: 'omitted',
                                 arguments: node.arguments.map(arg =>
                                     arg.name === 'discriminator' ? { ...arg, type: c.numberTypeNode('u32') } : arg,
@@ -129,6 +137,22 @@ export default {
             {
                 from: 'codama#updateAccountsVisitor',
                 args: [{ stakeStateAccount: { delete: true } }],
+            },
+            {
+                // Codama node helpers omit empty account lists when rebuilding nodes,
+                // but the Rust renderer templates expect them to be present.
+                from: 'codama#bottomUpTransformerVisitor',
+                args: [
+                    [
+                        {
+                            select: '[instructionNode]',
+                            transform: node => {
+                                c.assertIsNode(node, 'instructionNode');
+                                return { ...node, accounts: node.accounts ?? [] };
+                            },
+                        },
+                    ],
+                ],
             },
             {
                 from: '@codama/renderers-rust',

--- a/idl.json
+++ b/idl.json
@@ -878,7 +878,7 @@
         ],
         "display": {
           "intent": "Update stake authority",
-          "interpolatedIntent": "Set an authority of ${accounts.stake} to ${data.arg0}",
+          "interpolatedIntent": "Set the ${data.arg1} authority of ${accounts.stake} to ${data.arg0}",
           "kind": "instructionDisplayNode"
         },
         "kind": "instructionNode",
@@ -1785,7 +1785,7 @@
         ],
         "display": {
           "intent": "Update stake authority",
-          "interpolatedIntent": "Set an authority of ${accounts.stake} to ${accounts.newAuthority}",
+          "interpolatedIntent": "Set the ${data.stakeAuthorize} authority of ${accounts.stake} to ${accounts.newAuthority}",
           "kind": "instructionDisplayNode"
         },
         "kind": "instructionNode",

--- a/idl.json
+++ b/idl.json
@@ -1,8 +1,6 @@
 {
-  "additionalPrograms": [],
   "kind": "rootNode",
   "program": {
-    "accounts": [],
     "definedTypes": [
       {
         "kind": "definedTypeNode",
@@ -10,6 +8,10 @@
         "type": {
           "fields": [
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "label": "Locked Until"
+              },
               "kind": "structFieldTypeNode",
               "name": "unixTimestamp",
               "type": {
@@ -26,6 +28,10 @@
               }
             },
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "label": "Locked Until Epoch"
+              },
               "kind": "structFieldTypeNode",
               "name": "epoch",
               "type": {
@@ -66,6 +72,10 @@
         "type": {
           "fields": [
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "label": "Locked Until"
+              },
               "kind": "structFieldTypeNode",
               "name": "unixTimestamp",
               "type": {
@@ -82,6 +92,10 @@
               }
             },
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "label": "Locked Until Epoch"
+              },
               "kind": "structFieldTypeNode",
               "name": "epoch",
               "type": {
@@ -107,6 +121,10 @@
         "type": {
           "fields": [
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "label": "New Authority"
+              },
               "kind": "structFieldTypeNode",
               "name": "newAuthorizedPubkey",
               "type": {
@@ -114,6 +132,10 @@
               }
             },
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "label": "Authority Type"
+              },
               "kind": "structFieldTypeNode",
               "name": "stakeAuthorize",
               "type": {
@@ -154,6 +176,10 @@
         "type": {
           "fields": [
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "label": "Authority Type"
+              },
               "kind": "structFieldTypeNode",
               "name": "stakeAuthorize",
               "type": {
@@ -342,6 +368,10 @@
         "type": {
           "fields": [
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "label": "Locked Until"
+              },
               "kind": "structFieldTypeNode",
               "name": "unixTimestamp",
               "type": {
@@ -350,6 +380,10 @@
               }
             },
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "label": "Locked Until Epoch"
+              },
               "kind": "structFieldTypeNode",
               "name": "epoch",
               "type": {
@@ -400,6 +434,17 @@
               "kind": "structFieldTypeNode",
               "name": "rentExemptReserve",
               "type": {
+                "display": {
+                  "decimals": {
+                    "kind": "numberValueNode",
+                    "number": 9
+                  },
+                  "kind": "amountNumberDisplayNode",
+                  "unit": {
+                    "kind": "stringValueNode",
+                    "string": "SOL"
+                  }
+                },
                 "endian": "le",
                 "format": "u64",
                 "kind": "numberTypeNode"
@@ -431,6 +476,10 @@
         "type": {
           "fields": [
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "label": "Vote Account"
+              },
               "kind": "structFieldTypeNode",
               "name": "voterPubkey",
               "type": {
@@ -438,9 +487,24 @@
               }
             },
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "label": "Delegated Amount"
+              },
               "kind": "structFieldTypeNode",
               "name": "stake",
               "type": {
+                "display": {
+                  "decimals": {
+                    "kind": "numberValueNode",
+                    "number": 9
+                  },
+                  "kind": "amountNumberDisplayNode",
+                  "unit": {
+                    "kind": "stringValueNode",
+                    "string": "SOL"
+                  }
+                },
                 "endian": "le",
                 "format": "u64",
                 "kind": "numberTypeNode"
@@ -463,6 +527,10 @@
               }
             },
             {
+              "display": {
+                "kind": "structFieldDisplayNode",
+                "skip": "always"
+              },
               "kind": "structFieldTypeNode",
               "name": "reserved",
               "type": {
@@ -613,11 +681,14 @@
         "name": "epochRewardsActive"
       }
     ],
-    "events": [],
     "instructions": [
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Uninitialized stake account"
             ],
@@ -630,6 +701,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarRent111111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             },
             "docs": [
               "Rent sysvar"
@@ -647,6 +722,10 @@
               "number": 0
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -656,6 +735,10 @@
             }
           },
           {
+            "display": {
+              "flatten": true,
+              "kind": "structFieldDisplayNode"
+            },
             "kind": "instructionArgumentNode",
             "name": "arg0",
             "type": {
@@ -664,6 +747,10 @@
             }
           },
           {
+            "display": {
+              "flatten": true,
+              "kind": "structFieldDisplayNode"
+            },
             "kind": "instructionArgumentNode",
             "name": "arg1",
             "type": {
@@ -679,12 +766,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Initialize stake account",
+          "interpolatedIntent": "Initialize stake account ${accounts.stake}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "initialize"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Stake account to be updated"
             ],
@@ -697,6 +793,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarC1ock11111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             },
             "docs": [
               "Clock sysvar"
@@ -733,6 +833,10 @@
               "number": 1
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -742,6 +846,10 @@
             }
           },
           {
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "New Authority"
+            },
             "kind": "instructionArgumentNode",
             "name": "arg0",
             "type": {
@@ -749,6 +857,10 @@
             }
           },
           {
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "Authority Type"
+            },
             "kind": "instructionArgumentNode",
             "name": "arg1",
             "type": {
@@ -764,12 +876,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Update stake authority",
+          "interpolatedIntent": "Set an authority of ${accounts.stake} to ${data.arg0}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "authorize"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Initialized stake account to be delegated"
             ],
@@ -779,6 +900,10 @@
             "name": "stake"
           },
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Vote Account"
+            },
             "docs": [
               "Vote account to which this stake will be delegated"
             ],
@@ -791,6 +916,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarC1ock11111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             },
             "docs": [
               "Clock sysvar"
@@ -805,6 +934,10 @@
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarStakeHistory1111111111111111111111111"
             },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
+            },
             "docs": [
               "Stake history sysvar that carries stake warmup/cooldown history"
             ],
@@ -814,6 +947,10 @@
             "name": "stakeHistory"
           },
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
+            },
             "docs": [
               "Unused account, formerly the stake config"
             ],
@@ -839,6 +976,10 @@
               "number": 2
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -855,12 +996,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Delegate stake",
+          "interpolatedIntent": "Delegate ${accounts.stake} to vote account ${accounts.vote}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "delegateStake"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Stake account to be split; must be in the Initialized or Stake state"
             ],
@@ -870,6 +1020,10 @@
             "name": "stake"
           },
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "New Stake Account"
+            },
             "docs": [
               "Uninitialized stake account that will take the split-off amount"
             ],
@@ -895,6 +1049,10 @@
               "number": 3
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -904,9 +1062,24 @@
             }
           },
           {
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "Amount"
+            },
             "kind": "instructionArgumentNode",
             "name": "args",
             "type": {
+              "display": {
+                "decimals": {
+                  "kind": "numberValueNode",
+                  "number": 9
+                },
+                "kind": "amountNumberDisplayNode",
+                "unit": {
+                  "kind": "stringValueNode",
+                  "string": "SOL"
+                }
+              },
               "endian": "le",
               "format": "u64",
               "kind": "numberTypeNode"
@@ -920,12 +1093,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Split stake",
+          "interpolatedIntent": "Split ${data.args} from ${accounts.stake} into ${accounts.splitStake}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "split"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Stake account from which to withdraw"
             ],
@@ -948,6 +1130,10 @@
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarC1ock11111111111111111111111111111111"
             },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
+            },
             "docs": [
               "Clock sysvar"
             ],
@@ -960,6 +1146,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarStakeHistory1111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             },
             "docs": [
               "Stake history sysvar that carries stake warmup/cooldown history"
@@ -996,6 +1186,10 @@
               "number": 4
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1005,9 +1199,24 @@
             }
           },
           {
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "Amount"
+            },
             "kind": "instructionArgumentNode",
             "name": "args",
             "type": {
+              "display": {
+                "decimals": {
+                  "kind": "numberValueNode",
+                  "number": 9
+                },
+                "kind": "amountNumberDisplayNode",
+                "unit": {
+                  "kind": "stringValueNode",
+                  "string": "SOL"
+                }
+              },
               "endian": "le",
               "format": "u64",
               "kind": "numberTypeNode"
@@ -1021,12 +1230,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Withdraw stake",
+          "interpolatedIntent": "Withdraw ${data.args} from ${accounts.stake} to ${accounts.recipient}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "withdraw"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Delegated stake account to be deactivated"
             ],
@@ -1039,6 +1257,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarC1ock11111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             },
             "docs": [
               "Clock sysvar"
@@ -1065,6 +1287,10 @@
               "number": 5
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1081,12 +1307,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Deactivate stake",
+          "interpolatedIntent": "Deactivate ${accounts.stake}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "deactivate"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Initialized stake account"
             ],
@@ -1112,6 +1347,10 @@
               "number": 6
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1121,6 +1360,10 @@
             }
           },
           {
+            "display": {
+              "flatten": true,
+              "kind": "structFieldDisplayNode"
+            },
             "kind": "instructionArgumentNode",
             "name": "arg0",
             "type": {
@@ -1136,12 +1379,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Set stake lockup",
+          "interpolatedIntent": "Update the lockup of ${accounts.stake}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "setLockup"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "To"
+            },
             "docs": [
               "Destination stake account for the merge"
             ],
@@ -1151,6 +1403,10 @@
             "name": "destinationStake"
           },
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "From"
+            },
             "docs": [
               "Source stake account for to merge.  This account will be drained"
             ],
@@ -1164,6 +1420,10 @@
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarC1ock11111111111111111111111111111111"
             },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
+            },
             "docs": [
               "Clock sysvar"
             ],
@@ -1176,6 +1436,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarStakeHistory1111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             },
             "docs": [
               "Stake history sysvar that carries stake warmup/cooldown history"
@@ -1202,6 +1466,10 @@
               "number": 7
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1218,12 +1486,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Merge stake accounts",
+          "interpolatedIntent": "Merge ${accounts.sourceStake} into ${accounts.destinationStake}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "merge"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Stake account to be updated"
             ],
@@ -1233,6 +1510,10 @@
             "name": "stake"
           },
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Base Key"
+            },
             "docs": [
               "Base key of stake or withdraw authority"
             ],
@@ -1245,6 +1526,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarC1ock11111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             },
             "docs": [
               "Clock sysvar"
@@ -1272,6 +1557,10 @@
               "number": 8
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1281,6 +1570,10 @@
             }
           },
           {
+            "display": {
+              "flatten": true,
+              "kind": "structFieldDisplayNode"
+            },
             "kind": "instructionArgumentNode",
             "name": "arg0",
             "type": {
@@ -1296,12 +1589,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Update stake authority",
+          "interpolatedIntent": "Change an authority of ${accounts.stake}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "authorizeWithSeed"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Uninitialized stake account"
             ],
@@ -1314,6 +1616,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarRent111111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             },
             "docs": [
               "Rent sysvar"
@@ -1349,6 +1655,10 @@
               "number": 9
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1365,12 +1675,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Initialize stake account",
+          "interpolatedIntent": "Initialize stake account ${accounts.stake}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "initializeChecked"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Stake account to be updated"
             ],
@@ -1383,6 +1702,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarC1ock11111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             },
             "docs": [
               "Clock sysvar"
@@ -1428,6 +1751,10 @@
               "number": 10
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1437,6 +1764,10 @@
             }
           },
           {
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "Authority Type"
+            },
             "kind": "instructionArgumentNode",
             "name": "stakeAuthorize",
             "type": {
@@ -1452,12 +1783,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Update stake authority",
+          "interpolatedIntent": "Set an authority of ${accounts.stake} to ${accounts.newAuthority}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "authorizeChecked"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Stake account to be updated"
             ],
@@ -1467,6 +1807,10 @@
             "name": "stake"
           },
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Base Key"
+            },
             "docs": [
               "Base key of stake or withdraw authority"
             ],
@@ -1479,6 +1823,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarC1ock11111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             },
             "docs": [
               "Clock sysvar"
@@ -1515,6 +1863,10 @@
               "number": 11
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1524,6 +1876,10 @@
             }
           },
           {
+            "display": {
+              "flatten": true,
+              "kind": "structFieldDisplayNode"
+            },
             "kind": "instructionArgumentNode",
             "name": "arg0",
             "type": {
@@ -1539,12 +1895,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Update stake authority",
+          "interpolatedIntent": "Set an authority of ${accounts.stake} to ${accounts.newAuthority}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "authorizeCheckedWithSeed"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Initialized stake account"
             ],
@@ -1580,6 +1945,10 @@
               "number": 12
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1589,6 +1958,10 @@
             }
           },
           {
+            "display": {
+              "flatten": true,
+              "kind": "structFieldDisplayNode"
+            },
             "kind": "instructionArgumentNode",
             "name": "arg0",
             "type": {
@@ -1604,11 +1977,15 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Set stake lockup",
+          "interpolatedIntent": "Update the lockup of ${accounts.stake}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "setLockupChecked"
       },
       {
-        "accounts": [],
         "arguments": [
           {
             "defaultValue": {
@@ -1616,6 +1993,10 @@
               "number": 13
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1632,12 +2013,20 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Get minimum stake delegation",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "getMinimumDelegation"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Stake Account"
+            },
             "docs": [
               "Delegated stake account"
             ],
@@ -1647,6 +2036,10 @@
             "name": "stake"
           },
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Delinquent Vote Account"
+            },
             "docs": [
               "Delinquent vote account for the delegated stake account"
             ],
@@ -1656,6 +2049,10 @@
             "name": "delinquentVote"
           },
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Reference Vote Account"
+            },
             "docs": [
               "Reference vote account that has voted at least once in the last `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION` epochs"
             ],
@@ -1672,6 +2069,10 @@
               "number": 14
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1688,11 +2089,15 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Deactivate delinquent stake",
+          "interpolatedIntent": "Deactivate delinquent stake ${accounts.stake}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "deactivateDelinquent"
       },
       {
-        "accounts": [],
         "arguments": [
           {
             "defaultValue": {
@@ -1700,6 +2105,10 @@
               "number": 15
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1722,6 +2131,10 @@
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "From"
+            },
             "docs": [
               "Active source stake account"
             ],
@@ -1731,6 +2144,10 @@
             "name": "sourceStake"
           },
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "To"
+            },
             "docs": [
               "Active or inactive destination stake account"
             ],
@@ -1756,6 +2173,10 @@
               "number": 16
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1765,9 +2186,24 @@
             }
           },
           {
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "Amount"
+            },
             "kind": "instructionArgumentNode",
             "name": "args",
             "type": {
+              "display": {
+                "decimals": {
+                  "kind": "numberValueNode",
+                  "number": 9
+                },
+                "kind": "amountNumberDisplayNode",
+                "unit": {
+                  "kind": "stringValueNode",
+                  "string": "SOL"
+                }
+              },
               "endian": "le",
               "format": "u64",
               "kind": "numberTypeNode"
@@ -1781,12 +2217,21 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Move stake",
+          "interpolatedIntent": "Move ${data.args} of active stake from ${accounts.sourceStake} to ${accounts.destinationStake}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "moveStake"
       },
       {
         "accounts": [
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "From"
+            },
             "docs": [
               "Active or inactive source stake account"
             ],
@@ -1796,6 +2241,10 @@
             "name": "sourceStake"
           },
           {
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "To"
+            },
             "docs": [
               "Mergeable destination stake account"
             ],
@@ -1821,6 +2270,10 @@
               "number": 17
             },
             "defaultValueStrategy": "omitted",
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
+            },
             "kind": "instructionArgumentNode",
             "name": "discriminator",
             "type": {
@@ -1830,9 +2283,24 @@
             }
           },
           {
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "Amount"
+            },
             "kind": "instructionArgumentNode",
             "name": "args",
             "type": {
+              "display": {
+                "decimals": {
+                  "kind": "numberValueNode",
+                  "number": 9
+                },
+                "kind": "amountNumberDisplayNode",
+                "unit": {
+                  "kind": "stringValueNode",
+                  "string": "SOL"
+                }
+              },
               "endian": "le",
               "format": "u64",
               "kind": "numberTypeNode"
@@ -1846,16 +2314,20 @@
             "offset": 0
           }
         ],
+        "display": {
+          "intent": "Move unstaked SOL",
+          "interpolatedIntent": "Move ${data.args} from ${accounts.sourceStake} to ${accounts.destinationStake}",
+          "kind": "instructionDisplayNode"
+        },
         "kind": "instructionNode",
         "name": "moveLamports"
       }
     ],
     "kind": "programNode",
     "name": "solanaStakeInterface",
-    "pdas": [],
     "publicKey": "Stake11111111111111111111111111111111111111",
     "version": "4.4.0"
   },
   "standard": "codama",
-  "version": "1.0.0"
+  "version": "1.8.0"
 }

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -18,8 +18,8 @@ program-id = "Stake11111111111111111111111111111111111111"
 
 [dependencies]
 borsh = { version = "1.6.1", features = ["derive", "unstable__schema"], optional = true }
-codama = { version = "0.9.2", optional = true }
-codama-macros = { version = "0.10.0", optional = true }
+codama = { version = "0.11.0", optional = true }
+codama-macros = { version = "0.11.0", optional = true }
 num-traits = "0.2"
 serde = { version = "1.0.210", optional = true }
 serde_derive = { version = "1.0.210", optional = true }

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -87,7 +87,7 @@ pub enum StakeInstruction {
         feature = "codama",
         codama(display(
             intent = "Update stake authority",
-            interpolated_intent = "Set an authority of ${accounts.stake} to ${data.arg0}"
+            interpolated_intent = "Set the ${data.arg1} authority of ${accounts.stake} to ${data.arg0}"
         )),
         codama(account(
             name = "stake",
@@ -460,7 +460,7 @@ pub enum StakeInstruction {
         feature = "codama",
         codama(display(
             intent = "Update stake authority",
-            interpolated_intent = "Set an authority of ${accounts.stake} to ${accounts.newAuthority}"
+            interpolated_intent = "Set the ${data.stakeAuthorize} authority of ${accounts.stake} to ${accounts.newAuthority}"
         )),
         codama(account(
             name = "stake",

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -53,10 +53,27 @@ pub enum StakeInstruction {
     /// withdrawal restrictions.
     #[cfg_attr(
         feature = "codama",
-        codama(account(name = "stake", writable, docs = "Uninitialized stake account")),
-        codama(account(name = "rent_sysvar", docs = "Rent sysvar", default_value = sysvar("rent")))
+        codama(display(
+            intent = "Initialize stake account",
+            interpolated_intent = "Initialize stake account ${accounts.stake}"
+        )),
+        codama(account(
+            name = "stake",
+            writable,
+            docs = "Uninitialized stake account",
+            display(label = "Stake Account")
+        )),
+        codama(account(
+            name = "rent_sysvar",
+            docs = "Rent sysvar",
+            default_value = sysvar("rent"),
+            display(skip = always)
+        ))
     )]
-    Initialize(Authorized, Lockup),
+    Initialize(
+        #[cfg_attr(feature = "codama", codama(display(flatten = true)))] Authorized,
+        #[cfg_attr(feature = "codama", codama(display(flatten = true)))] Lockup,
+    ),
 
     /// Authorize a key to manage stake or withdrawal
     ///
@@ -68,8 +85,22 @@ pub enum StakeInstruction {
     ///      lockup expiration
     #[cfg_attr(
         feature = "codama",
-        codama(account(name = "stake", writable, docs = "Stake account to be updated")),
-        codama(account(name = "clock_sysvar", docs = "Clock sysvar", default_value = sysvar("clock"))),
+        codama(display(
+            intent = "Update stake authority",
+            interpolated_intent = "Set an authority of ${accounts.stake} to ${data.arg0}"
+        )),
+        codama(account(
+            name = "stake",
+            writable,
+            docs = "Stake account to be updated",
+            display(label = "Stake Account")
+        )),
+        codama(account(
+            name = "clock_sysvar",
+            docs = "Clock sysvar",
+            default_value = sysvar("clock"),
+            display(skip = always)
+        )),
         codama(account(name = "authority", signer, docs = "The stake or withdraw authority")),
         codama(account(
             name = "lockup_authority",
@@ -78,7 +109,10 @@ pub enum StakeInstruction {
             docs = "Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration"
         ))
     )]
-    Authorize(Pubkey, StakeAuthorize),
+    Authorize(
+        #[cfg_attr(feature = "codama", codama(display(label = "New Authority")))] Pubkey,
+        #[cfg_attr(feature = "codama", codama(display(label = "Authority Type")))] StakeAuthorize,
+    ),
 
     /// Delegate a stake to a particular vote account
     ///
@@ -94,22 +128,38 @@ pub enum StakeInstruction {
     /// can be called multiple times, but re-delegation is delayed by one epoch.
     #[cfg_attr(
         feature = "codama",
+        codama(display(
+            intent = "Delegate stake",
+            interpolated_intent = "Delegate ${accounts.stake} to vote account ${accounts.vote}"
+        )),
         codama(account(
             name = "stake",
             writable,
-            docs = "Initialized stake account to be delegated"
+            docs = "Initialized stake account to be delegated",
+            display(label = "Stake Account")
         )),
         codama(account(
             name = "vote",
-            docs = "Vote account to which this stake will be delegated"
+            docs = "Vote account to which this stake will be delegated",
+            display(label = "Vote Account")
         )),
-        codama(account(name = "clock_sysvar", docs = "Clock sysvar", default_value = sysvar("clock"))),
+        codama(account(
+            name = "clock_sysvar",
+            docs = "Clock sysvar",
+            default_value = sysvar("clock"),
+            display(skip = always)
+        )),
         codama(account(
             name = "stake_history",
             docs = "Stake history sysvar that carries stake warmup/cooldown history",
-            default_value = sysvar("stake_history")
+            default_value = sysvar("stake_history"),
+            display(skip = always)
         )),
-        codama(account(name = "unused", docs = "Unused account, formerly the stake config")),
+        codama(account(
+            name = "unused",
+            docs = "Unused account, formerly the stake config",
+            display(skip = always)
+        )),
         codama(account(name = "stake_authority", signer, docs = "Stake authority"))
     )]
     DelegateStake,
@@ -122,21 +172,34 @@ pub enum StakeInstruction {
     ///   2. `[SIGNER]` Stake authority
     #[cfg_attr(
         feature = "codama",
+        codama(display(
+            intent = "Split stake",
+            interpolated_intent = "Split ${data.args} from ${accounts.stake} into ${accounts.splitStake}"
+        )),
         codama(account(
             name = "stake",
             writable,
-            docs = "Stake account to be split; must be in the Initialized or Stake state"
+            docs = "Stake account to be split; must be in the Initialized or Stake state",
+            display(label = "Stake Account")
         )),
         codama(account(
             name = "split_stake",
             writable,
-            docs = "Uninitialized stake account that will take the split-off amount"
+            docs = "Uninitialized stake account that will take the split-off amount",
+            display(label = "New Stake Account")
         )),
         codama(account(name = "stake_authority", signer, docs = "Stake authority"))
     )]
     // `args` name is required for backwards compatibility with the old Anchor-generated
     // IDL. Changing this name could break existing clients.
-    Split(#[cfg_attr(feature = "codama", codama(name = "args"))] u64),
+    Split(
+        #[cfg_attr(
+            feature = "codama",
+            codama(name = "args"),
+            codama(display(label = "Amount", amount(decimals = 9, unit = "SOL")))
+        )]
+        u64,
+    ),
 
     /// Withdraw unstaked lamports from the stake account
     ///
@@ -152,17 +215,28 @@ pub enum StakeInstruction {
     /// must be `<= StakeAccount.lamports - staked_lamports`.
     #[cfg_attr(
         feature = "codama",
+        codama(display(
+            intent = "Withdraw stake",
+            interpolated_intent = "Withdraw ${data.args} from ${accounts.stake} to ${accounts.recipient}"
+        )),
         codama(account(
             name = "stake",
             writable,
-            docs = "Stake account from which to withdraw"
+            docs = "Stake account from which to withdraw",
+            display(label = "Stake Account")
         )),
         codama(account(name = "recipient", writable, docs = "Recipient account")),
-        codama(account(name = "clock_sysvar", docs = "Clock sysvar", default_value = sysvar("clock"))),
+        codama(account(
+            name = "clock_sysvar",
+            docs = "Clock sysvar",
+            default_value = sysvar("clock"),
+            display(skip = always)
+        )),
         codama(account(
             name = "stake_history",
             docs = "Stake history sysvar that carries stake warmup/cooldown history",
-            default_value = sysvar("stake_history")
+            default_value = sysvar("stake_history"),
+            display(skip = always)
         )),
         codama(account(name = "withdraw_authority", signer, docs = "Withdraw authority")),
         codama(account(
@@ -174,7 +248,14 @@ pub enum StakeInstruction {
     )]
     // `args` name is required for backwards compatibility with the old Anchor-generated
     // IDL. Changing this name could break existing clients.
-    Withdraw(#[cfg_attr(feature = "codama", codama(name = "args"))] u64),
+    Withdraw(
+        #[cfg_attr(
+            feature = "codama",
+            codama(name = "args"),
+            codama(display(label = "Amount", amount(decimals = 9, unit = "SOL")))
+        )]
+        u64,
+    ),
 
     /// Deactivates the stake in the account
     ///
@@ -184,12 +265,19 @@ pub enum StakeInstruction {
     ///   2. `[SIGNER]` Stake authority
     #[cfg_attr(
         feature = "codama",
+        codama(display(intent = "Deactivate stake", interpolated_intent = "Deactivate ${accounts.stake}")),
         codama(account(
             name = "stake",
             writable,
-            docs = "Delegated stake account to be deactivated"
+            docs = "Delegated stake account to be deactivated",
+            display(label = "Stake Account")
         )),
-        codama(account(name = "clock_sysvar", docs = "Clock sysvar", default_value = sysvar("clock"))),
+        codama(account(
+            name = "clock_sysvar",
+            docs = "Clock sysvar",
+            default_value = sysvar("clock"),
+            display(skip = always)
+        )),
         codama(account(name = "stake_authority", signer, docs = "Stake authority"))
     )]
     Deactivate,
@@ -204,14 +292,23 @@ pub enum StakeInstruction {
     ///   1. `[SIGNER]` Lockup authority or withdraw authority
     #[cfg_attr(
         feature = "codama",
-        codama(account(name = "stake", writable, docs = "Initialized stake account")),
+        codama(display(
+            intent = "Set stake lockup",
+            interpolated_intent = "Update the lockup of ${accounts.stake}"
+        )),
+        codama(account(
+            name = "stake",
+            writable,
+            docs = "Initialized stake account",
+            display(label = "Stake Account")
+        )),
         codama(account(
             name = "authority",
             signer,
             docs = "Lockup authority or withdraw authority"
         ))
     )]
-    SetLockup(LockupArgs),
+    SetLockup(#[cfg_attr(feature = "codama", codama(display(flatten = true)))] LockupArgs),
 
     /// Merge two stake accounts.
     ///
@@ -239,21 +336,33 @@ pub enum StakeInstruction {
     ///   4. `[SIGNER]` Stake authority
     #[cfg_attr(
         feature = "codama",
+        codama(display(
+            intent = "Merge stake accounts",
+            interpolated_intent = "Merge ${accounts.sourceStake} into ${accounts.destinationStake}"
+        )),
         codama(account(
             name = "destination_stake",
             writable,
-            docs = "Destination stake account for the merge"
+            docs = "Destination stake account for the merge",
+            display(label = "To")
         )),
         codama(account(
             name = "source_stake",
             writable,
-            docs = "Source stake account for to merge.  This account will be drained"
+            docs = "Source stake account for to merge.  This account will be drained",
+            display(label = "From")
         )),
-        codama(account(name = "clock_sysvar", docs = "Clock sysvar", default_value = sysvar("clock"))),
+        codama(account(
+            name = "clock_sysvar",
+            docs = "Clock sysvar",
+            default_value = sysvar("clock"),
+            display(skip = always)
+        )),
         codama(account(
             name = "stake_history",
             docs = "Stake history sysvar that carries stake warmup/cooldown history",
-            default_value = sysvar("stake_history")
+            default_value = sysvar("stake_history"),
+            display(skip = always)
         )),
         codama(account(name = "stake_authority", signer, docs = "Stake authority"))
     )]
@@ -269,13 +378,28 @@ pub enum StakeInstruction {
     ///      before lockup expiration
     #[cfg_attr(
         feature = "codama",
-        codama(account(name = "stake", writable, docs = "Stake account to be updated")),
+        codama(display(
+            intent = "Update stake authority",
+            interpolated_intent = "Change an authority of ${accounts.stake}"
+        )),
+        codama(account(
+            name = "stake",
+            writable,
+            docs = "Stake account to be updated",
+            display(label = "Stake Account")
+        )),
         codama(account(
             name = "base",
             signer,
-            docs = "Base key of stake or withdraw authority"
+            docs = "Base key of stake or withdraw authority",
+            display(label = "Base Key")
         )),
-        codama(account(name = "clock_sysvar", docs = "Clock sysvar", default_value = sysvar("clock"))),
+        codama(account(
+            name = "clock_sysvar",
+            docs = "Clock sysvar",
+            default_value = sysvar("clock"),
+            display(skip = always)
+        )),
         codama(account(
             name = "lockup_authority",
             optional,
@@ -283,7 +407,9 @@ pub enum StakeInstruction {
             docs = "Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration"
         ))
     )]
-    AuthorizeWithSeed(AuthorizeWithSeedArgs),
+    AuthorizeWithSeed(
+        #[cfg_attr(feature = "codama", codama(display(flatten = true)))] AuthorizeWithSeedArgs,
+    ),
 
     /// Initialize a stake with authorization information
     ///
@@ -297,8 +423,22 @@ pub enum StakeInstruction {
     ///   3. `[SIGNER]` The withdraw authority
     #[cfg_attr(
         feature = "codama",
-        codama(account(name = "stake", writable, docs = "Uninitialized stake account")),
-        codama(account(name = "rent_sysvar", docs = "Rent sysvar", default_value = sysvar("rent"))),
+        codama(display(
+            intent = "Initialize stake account",
+            interpolated_intent = "Initialize stake account ${accounts.stake}"
+        )),
+        codama(account(
+            name = "stake",
+            writable,
+            docs = "Uninitialized stake account",
+            display(label = "Stake Account")
+        )),
+        codama(account(
+            name = "rent_sysvar",
+            docs = "Rent sysvar",
+            default_value = sysvar("rent"),
+            display(skip = always)
+        )),
         codama(account(name = "stake_authority", docs = "The stake authority")),
         codama(account(name = "withdraw_authority", signer, docs = "The withdraw authority"))
     )]
@@ -318,8 +458,22 @@ pub enum StakeInstruction {
     ///      before lockup expiration
     #[cfg_attr(
         feature = "codama",
-        codama(account(name = "stake", writable, docs = "Stake account to be updated")),
-        codama(account(name = "clock_sysvar", docs = "Clock sysvar", default_value = sysvar("clock"))),
+        codama(display(
+            intent = "Update stake authority",
+            interpolated_intent = "Set an authority of ${accounts.stake} to ${accounts.newAuthority}"
+        )),
+        codama(account(
+            name = "stake",
+            writable,
+            docs = "Stake account to be updated",
+            display(label = "Stake Account")
+        )),
+        codama(account(
+            name = "clock_sysvar",
+            docs = "Clock sysvar",
+            default_value = sysvar("clock"),
+            display(skip = always)
+        )),
         codama(account(name = "authority", signer, docs = "The stake or withdraw authority")),
         codama(account(
             name = "new_authority",
@@ -334,7 +488,12 @@ pub enum StakeInstruction {
         ))
     )]
     AuthorizeChecked(
-        #[cfg_attr(feature = "codama", codama(name = "stakeAuthorize"))] StakeAuthorize,
+        #[cfg_attr(
+            feature = "codama",
+            codama(name = "stakeAuthorize"),
+            codama(display(label = "Authority Type"))
+        )]
+        StakeAuthorize,
     ),
 
     /// Authorize a key to manage stake or withdrawal with a derived key
@@ -351,13 +510,28 @@ pub enum StakeInstruction {
     ///      before lockup expiration
     #[cfg_attr(
         feature = "codama",
-        codama(account(name = "stake", writable, docs = "Stake account to be updated")),
+        codama(display(
+            intent = "Update stake authority",
+            interpolated_intent = "Set an authority of ${accounts.stake} to ${accounts.newAuthority}"
+        )),
+        codama(account(
+            name = "stake",
+            writable,
+            docs = "Stake account to be updated",
+            display(label = "Stake Account")
+        )),
         codama(account(
             name = "base",
             signer,
-            docs = "Base key of stake or withdraw authority"
+            docs = "Base key of stake or withdraw authority",
+            display(label = "Base Key")
         )),
-        codama(account(name = "clock_sysvar", docs = "Clock sysvar", default_value = sysvar("clock"))),
+        codama(account(
+            name = "clock_sysvar",
+            docs = "Clock sysvar",
+            default_value = sysvar("clock"),
+            display(skip = always)
+        )),
         codama(account(
             name = "new_authority",
             signer,
@@ -370,7 +544,10 @@ pub enum StakeInstruction {
             docs = "Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration"
         ))
     )]
-    AuthorizeCheckedWithSeed(AuthorizeCheckedWithSeedArgs),
+    AuthorizeCheckedWithSeed(
+        #[cfg_attr(feature = "codama", codama(display(flatten = true)))]
+        AuthorizeCheckedWithSeedArgs,
+    ),
 
     /// Set stake lockup
     ///
@@ -386,7 +563,16 @@ pub enum StakeInstruction {
     ///   2. Optional: `[SIGNER]` New lockup authority
     #[cfg_attr(
         feature = "codama",
-        codama(account(name = "stake", writable, docs = "Initialized stake account")),
+        codama(display(
+            intent = "Set stake lockup",
+            interpolated_intent = "Update the lockup of ${accounts.stake}"
+        )),
+        codama(account(
+            name = "stake",
+            writable,
+            docs = "Initialized stake account",
+            display(label = "Stake Account")
+        )),
         codama(account(
             name = "authority",
             signer,
@@ -399,7 +585,9 @@ pub enum StakeInstruction {
             docs = "New lockup authority"
         ))
     )]
-    SetLockupChecked(LockupCheckedArgs),
+    SetLockupChecked(
+        #[cfg_attr(feature = "codama", codama(display(flatten = true)))] LockupCheckedArgs,
+    ),
 
     /// Get the minimum stake delegation, in lamports
     ///
@@ -411,6 +599,10 @@ pub enum StakeInstruction {
     /// retrieve the return value for this instruction.
     ///
     /// [`get_minimum_delegation()`]: crate::tools::get_minimum_delegation
+    #[cfg_attr(
+        feature = "codama",
+        codama(display(intent = "Get minimum stake delegation"))
+    )]
     GetMinimumDelegation,
 
     /// Deactivate stake delegated to a vote account that has been delinquent for at least
@@ -426,14 +618,25 @@ pub enum StakeInstruction {
     ///      `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION` epochs
     #[cfg_attr(
         feature = "codama",
-        codama(account(name = "stake", writable, docs = "Delegated stake account")),
+        codama(display(
+            intent = "Deactivate delinquent stake",
+            interpolated_intent = "Deactivate delinquent stake ${accounts.stake}"
+        )),
+        codama(account(
+            name = "stake",
+            writable,
+            docs = "Delegated stake account",
+            display(label = "Stake Account")
+        )),
         codama(account(
             name = "delinquent_vote",
-            docs = "Delinquent vote account for the delegated stake account"
+            docs = "Delinquent vote account for the delegated stake account",
+            display(label = "Delinquent Vote Account")
         )),
         codama(account(
             name = "reference_vote",
-            docs = "Reference vote account that has voted at least once in the last `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION` epochs"
+            docs = "Reference vote account that has voted at least once in the last `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION` epochs",
+            display(label = "Reference Vote Account")
         ))
     )]
     DeactivateDelinquent,
@@ -483,16 +686,33 @@ pub enum StakeInstruction {
     /// The `u64` is the portion of the stake to move, which may be the entire delegation
     #[cfg_attr(
         feature = "codama",
-        codama(account(name = "sourceStake", writable, docs = "Active source stake account")),
+        codama(display(
+            intent = "Move stake",
+            interpolated_intent = "Move ${data.args} of active stake from ${accounts.sourceStake} to ${accounts.destinationStake}"
+        )),
+        codama(account(
+            name = "sourceStake",
+            writable,
+            docs = "Active source stake account",
+            display(label = "From")
+        )),
         codama(account(
             name = "destinationStake",
             writable,
-            docs = "Active or inactive destination stake account"
+            docs = "Active or inactive destination stake account",
+            display(label = "To")
         )),
         codama(account(name = "stake_authority", signer, docs = "Stake authority"))
     )]
     // sadly named `args` to avoid breaking users of old IDL
-    MoveStake(#[cfg_attr(feature = "codama", codama(name = "args"))] u64),
+    MoveStake(
+        #[cfg_attr(
+            feature = "codama",
+            codama(name = "args"),
+            codama(display(label = "Amount", amount(decimals = 9, unit = "SOL")))
+        )]
+        u64,
+    ),
 
     /// Move unstaked lamports between accounts with the same authorities and lockups, using Staker
     /// authority.
@@ -509,20 +729,33 @@ pub enum StakeInstruction {
     /// The `u64` is the portion of available lamports to move
     #[cfg_attr(
         feature = "codama",
+        codama(display(
+            intent = "Move unstaked SOL",
+            interpolated_intent = "Move ${data.args} from ${accounts.sourceStake} to ${accounts.destinationStake}"
+        )),
         codama(account(
             name = "source_stake",
             writable,
-            docs = "Active or inactive source stake account"
+            docs = "Active or inactive source stake account",
+            display(label = "From")
         )),
         codama(account(
             name = "destination_stake",
             writable,
-            docs = "Mergeable destination stake account"
+            docs = "Mergeable destination stake account",
+            display(label = "To")
         )),
         codama(account(name = "stake_authority", signer, docs = "Stake authority"))
     )]
     // sadly named `args` to avoid breaking users of old IDL
-    MoveLamports(#[cfg_attr(feature = "codama", codama(name = "args"))] u64),
+    MoveLamports(
+        #[cfg_attr(
+            feature = "codama",
+            codama(name = "args"),
+            codama(display(label = "Amount", amount(decimals = 9, unit = "SOL")))
+        )]
+        u64,
+    ),
 }
 
 #[cfg_attr(feature = "codama", derive(CodamaType), codama(name = "lockupParams"))]
@@ -532,7 +765,9 @@ pub enum StakeInstruction {
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
 pub struct LockupArgs {
+    #[cfg_attr(feature = "codama", codama(display(label = "Locked Until")))]
     pub unix_timestamp: Option<UnixTimestamp>,
+    #[cfg_attr(feature = "codama", codama(display(label = "Locked Until Epoch")))]
     pub epoch: Option<Epoch>,
     pub custodian: Option<Pubkey>,
 }
@@ -548,7 +783,9 @@ pub struct LockupArgs {
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
 pub struct LockupCheckedArgs {
+    #[cfg_attr(feature = "codama", codama(display(label = "Locked Until")))]
     pub unix_timestamp: Option<UnixTimestamp>,
+    #[cfg_attr(feature = "codama", codama(display(label = "Locked Until Epoch")))]
     pub epoch: Option<Epoch>,
 }
 
@@ -563,7 +800,9 @@ pub struct LockupCheckedArgs {
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
 pub struct AuthorizeWithSeedArgs {
+    #[cfg_attr(feature = "codama", codama(display(label = "New Authority")))]
     pub new_authorized_pubkey: Pubkey,
+    #[cfg_attr(feature = "codama", codama(display(label = "Authority Type")))]
     pub stake_authorize: StakeAuthorize,
     #[cfg_attr(feature = "codama", codama(size_prefix = number(u64)))]
     pub authority_seed: String,
@@ -581,6 +820,7 @@ pub struct AuthorizeWithSeedArgs {
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
 pub struct AuthorizeCheckedWithSeedArgs {
+    #[cfg_attr(feature = "codama", codama(display(label = "Authority Type")))]
     pub stake_authorize: StakeAuthorize,
     #[cfg_attr(feature = "codama", codama(size_prefix = number(u64)))]
     pub authority_seed: String,

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -346,9 +346,11 @@ pub enum StakeAuthorize {
 pub struct Lockup {
     /// `UnixTimestamp` at which this stake will allow withdrawal, unless the
     ///   transaction is signed by the custodian
+    #[cfg_attr(feature = "codama", codama(display(label = "Locked Until")))]
     pub unix_timestamp: UnixTimestamp,
     /// epoch height at which this stake will allow withdrawal, unless the
     ///   transaction is signed by the custodian
+    #[cfg_attr(feature = "codama", codama(display(label = "Locked Until Epoch")))]
     pub epoch: Epoch,
     /// custodian signature on a transaction exempts the operation from
     ///  lockup constraints
@@ -482,6 +484,10 @@ pub struct Meta {
         note = "Stake account rent must be calculated via the `Rent` sysvar. \
         This value will cease to be correct once lamports-per-byte is adjusted."
     )]
+    #[cfg_attr(
+        feature = "codama",
+        codama(display(amount(decimals = 9, unit = "SOL")))
+    )]
     pub rent_exempt_reserve: u64,
     pub authorized: Authorized,
     pub lockup: Lockup,
@@ -547,8 +553,13 @@ impl Meta {
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaRead, wincode::SchemaWrite))]
 pub struct Delegation {
     /// to whom the stake is delegated
+    #[cfg_attr(feature = "codama", codama(display(label = "Vote Account")))]
     pub voter_pubkey: Pubkey,
     /// activated stake amount, set at delegate() time
+    #[cfg_attr(
+        feature = "codama",
+        codama(display(label = "Delegated Amount", amount(decimals = 9, unit = "SOL")))
+    )]
     pub stake: u64,
     /// epoch at which this stake was activated, `std::u64::MAX` if is a bootstrap stake
     pub activation_epoch: Epoch,
@@ -556,6 +567,7 @@ pub struct Delegation {
     pub deactivation_epoch: Epoch,
     /// Formerly the `warmup_cooldown_rate: f64`, but floats are not eBPF-compatible.
     /// It is unused, but this field is now reserved to maintain layout compatibility.
+    #[cfg_attr(feature = "codama", codama(display(skip = always)))]
     pub _reserved: [u8; 8],
 }
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "private": true,
     "devDependencies": {
         "@codama/renderers-js": "^2.3.1",
-        "@codama/renderers-rust": "^3.1.0",
-        "codama": "^1.9.0",
+        "@codama/renderers-rust": "^3.1.3",
+        "codama": "^1.10.1",
         "typescript": "^7.0.2"
     },
     "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,35 +12,28 @@ importers:
         specifier: ^2.3.1
         version: 2.3.1(typescript@7.0.2)
       '@codama/renderers-rust':
-        specifier: ^3.1.0
-        version: 3.1.0(typescript@7.0.2)
+        specifier: ^3.1.3
+        version: 3.1.3(typescript@7.0.2)
       codama:
-        specifier: ^1.9.0
-        version: 1.9.0
+        specifier: ^1.10.1
+        version: 1.10.1
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
 
 packages:
 
-  '@codama/cli@1.5.4':
-    resolution: {integrity: sha512-l4xEPJvXhQ4mvCg0fgESoDe6Ub2NHtK79M2D8nni46eHO4NRmsDh5Gq88m/K/fBPwZDuTJCAyvWojlaVxr3oHw==}
+  '@codama/cli@1.6.1':
+    resolution: {integrity: sha512-U7YtSNIz2AeNue0TM+lZhVtQgoYD9zbuNzRIzaicnrdpAWvVGPfZhoKBOjDyVt7xxr00VF6ilu2wDCgak1yQfQ==}
     hasBin: true
 
   '@codama/errors@1.10.0':
     resolution: {integrity: sha512-/qiWQcbPIsyFlP1LrLqJfHt1QNbkY2wtC4UxZyKLnuZtc62YPlgDrN2wp4wcfRuE/DC0n3Y6ZSwYUrDBZyAnvA==}
     hasBin: true
 
-  '@codama/errors@1.7.0':
-    resolution: {integrity: sha512-N1E4LT3XRYqHHJAnL+eVQ5V3Pc0uSPjsn4Xt6QEO6Fz1p0slF6hbD+/axkFUc7+lNCAfgnkKzhk+6SpFLU/WrQ==}
+  '@codama/errors@1.10.1':
+    resolution: {integrity: sha512-AOeZ7SuSuCHlhh2irN6nI/YSkEDh+v7+/1ihqstJpYM5mYx67MuKNw1X3COe9nF8e3lkU+eVtq51ILdAJa34jA==}
     hasBin: true
-
-  '@codama/errors@1.9.0':
-    resolution: {integrity: sha512-VUfCl0qZ0/rmvojoqHs26ESL4XuVJiFRLQDZlzrUIuHDewdKdIH2xXBhZyiMktftNNG9FUWMHSU/Ld89dfFXJg==}
-    hasBin: true
-
-  '@codama/fragments@0.1.0':
-    resolution: {integrity: sha512-rWnSKw4UA9LS7mMQyzKnR1woibVEYrYgp66+i+JB+O1lnvU/i/KCH4TmoV+S6Y3ADL2WyznrwfDA3rBET6U5Cg==}
 
   '@codama/fragments@0.1.3':
     resolution: {integrity: sha512-ITa3UYs74AWx7se/6EZN+YXqV1Vu89L3n2v0/irsQNbPcy8wP26p/GKns/1H4a8vGvAKuzWdIGO535dwcauInw==}
@@ -48,73 +41,43 @@ packages:
   '@codama/node-types@1.10.0':
     resolution: {integrity: sha512-fMoJQ8TgB9A5Pl+GA8ffhDbGK63cV1nrbDrYTgIhPDKeVqBSdkSAoAuAtvWfRd7X2ML73H6RRi6jZRJmo2xfHQ==}
 
-  '@codama/node-types@1.7.0':
-    resolution: {integrity: sha512-VDytcSgN6jOGEh4aJ1LgSnqCe1drSEUSdAeKOV92aU0MOYiDi2s2B18+Gx7dx40mex2GfVc3zamu7KGzTlxegA==}
-
-  '@codama/node-types@1.9.0':
-    resolution: {integrity: sha512-nfkbgvtLOKnYh3vk3YnMivzq6tuCukIt/A90D74N1piWHGYtMsfGFDE9un3+cxmN/Va7X9xf8Y4j5L55w4ao/w==}
+  '@codama/node-types@1.10.1':
+    resolution: {integrity: sha512-PANkfJ0/1rWwgWPWPRQoCoVbozWOb5YPvYDkEEvqXbnofC1qIioglMwy8pT3N1nJybMwS4J1prk05hSPmhRvag==}
 
   '@codama/nodes@1.10.0':
     resolution: {integrity: sha512-P3NXVw6kZq2VDb4wYU6zQ3xFksDqSuDYqp11P6Dpei9XIZZ11NtL2jBjBcqsIudGIx104bMgSo4SZ7Hlej056A==}
 
-  '@codama/nodes@1.7.0':
-    resolution: {integrity: sha512-PZ1zI+SbE1PEaGEka0KjdFrAJ7e9O0kPG4CCGYhjsqUo76OBbINRjNVx7pkP4r8Ksa2r/BLbVIfZV1M/n5J5Kg==}
-
-  '@codama/nodes@1.9.0':
-    resolution: {integrity: sha512-Ikth0ATwv4yoktt8EXBjoNDUE+6fJ7pZiqX8+zhNhkUmDpyoJ9qgf6feVhhPuK7h8BbepzuKF8z0rGWUelXrDw==}
+  '@codama/nodes@1.10.1':
+    resolution: {integrity: sha512-hcfCCpubRf/BA0vOSEBu95Q8R42yhs0myrqWVCYgv4DQrEqeAiTJxav5NEgmRj8kdFm04Qn854IT4vVXVLP9mA==}
 
   '@codama/renderers-core@1.3.11':
     resolution: {integrity: sha512-VSGrfmwPVv5cRAiHitgIq+rc9ktIN/Q9czbUORaqhZCmM+M3Ux5cd5r90PVTbeIt8vI0Zlw74OUFwdKqdEfSNw==}
-
-  '@codama/renderers-core@1.3.8':
-    resolution: {integrity: sha512-xy9Qb5BLYTi1OyvlRhRD7n0HUevOQ3QcHSPq9N3kqoUOgL2ziXPXvoejzzLC0OkvA16M7WvK3ihNx/nf4UEClQ==}
 
   '@codama/renderers-js@2.3.1':
     resolution: {integrity: sha512-+7WtjpcqnlPkweG+tWWiER2XkJP7SF+RJgYpI0RHc91ZP60Umt0qc+0JPuqMyiPhVrLTN2U/lpsBDQw2MeEsvA==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/renderers-rust@3.1.0':
-    resolution: {integrity: sha512-E/GSUCuiIpFj+ij3NbduH/h3sNDo39Bq14vj2atxdbbrPmu4clWvIEjXtbmP03qhudH73TxbYO8dWg/NwRi18A==}
+  '@codama/renderers-rust@3.1.3':
+    resolution: {integrity: sha512-z5hPKlqT/0umZOdVMZfRw03mfN/GkdZ0z646cIComcosDk4VKTO4AFr98sg1L/aO5MXfoBrTfNOqYzD1fyUotg==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/validators@1.9.0':
-    resolution: {integrity: sha512-CpvhqkxvrzR0NeliZYABlBaHSKi6G3OefEB6QM4kuwTLhKLTRF7ffOMiuhnePM+fwbcQWh2VQ2++Wo4UHwiYoQ==}
+  '@codama/validators@1.10.1':
+    resolution: {integrity: sha512-cUe+D4gsZttbynBCH1vxTabsW61jFXCcv+FDrb3DNokf+gJKXkiNAyzTMQPazWCAQZkEVIdRkcj+J4vv1sTE+A==}
 
   '@codama/visitors-core@1.10.0':
     resolution: {integrity: sha512-8koBGs4m/NI4nDLJZx7Q1KzRUKkBy/GAnZq4xOEFGlhTvDCIAzEgo3biAhNFynGY45gzZJSX08QTDWKsPRjnaA==}
 
-  '@codama/visitors-core@1.7.0':
-    resolution: {integrity: sha512-ii1Z39ORzssMQdpxqpjaHCLbFwO4KZbI1SrsJ1e0r+0g03gxuYEA1H6RoxcrIOuUeOnqNtLb96cErrzHdrx23Q==}
+  '@codama/visitors-core@1.10.1':
+    resolution: {integrity: sha512-l5dEZ7Ra5KU64y0Nw79CUp4bAlKRQg9m1DlW1nfQtMEByWEzqteOYesKCgK1z3ypCOXqkN9qlrLAqaYSbOa9Vw==}
 
-  '@codama/visitors-core@1.9.0':
-    resolution: {integrity: sha512-1iYkoc65yKJB65MLR2o9+TKFk+1sFviX4fXSO+t0XDdjZ6A6WodhKBQNhgMentrWyWNC0ERstasarzfCEVC+7g==}
-
-  '@codama/visitors@1.9.0':
-    resolution: {integrity: sha512-WQtaTopiniNt53IKHzWzv4oIN7PA4r8gO/UAEjMsTz1AL/RN+O+/lS0PXHgK5S3KaQAmETPiWJQeMWc5edhrMA==}
+  '@codama/visitors@1.10.1':
+    resolution: {integrity: sha512-odsT0HMGpByL4fynLEmVJVoWB1jU5+DNg6pSiJXHmWpJE68mHvgK3tXUTj7eU8zAW+lAjfQWui6pcFp8W4xhJA==}
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
-  '@solana/codecs-core@6.9.0':
-    resolution: {integrity: sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   '@solana/codecs-core@7.0.0':
     resolution: {integrity: sha512-6HtEisZEtFb6okARUgYqmKdDbn2aHRrSCDgB1/GEwr0s6fK5XNYpafaSjorbs2MEyZV3tCUFTj2j6fk/4nNcLg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/codecs-numbers@6.9.0':
-    resolution: {integrity: sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -131,18 +94,6 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@6.9.0':
-    resolution: {integrity: sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      fastestsmallesttextencoderdecoder:
-        optional: true
-      typescript:
-        optional: true
-
   '@solana/codecs-strings@7.0.0':
     resolution: {integrity: sha512-zXE1PE9HkVk6phZ6aqHTXvLZ0qIl5bJNIvG9eMB7LuFO1XBVQywJUtjKS8fE3/xmRCWSMilFSrEXGA+SpOyLrQ==}
     engines: {node: '>=20.18.0'}
@@ -152,16 +103,6 @@ packages:
     peerDependenciesMeta:
       fastestsmallesttextencoderdecoder:
         optional: true
-      typescript:
-        optional: true
-
-  '@solana/errors@6.9.0':
-    resolution: {integrity: sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
       typescript:
         optional: true
 
@@ -317,8 +258,8 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  codama@1.9.0:
-    resolution: {integrity: sha512-rmOeY/OMK57ScoJYg0+haSY2TOtvy7GFxXRr4jhVx6kszRU2ht4bgfsrCRUM3xtjSqypa9cu8AmaWEkc852rqQ==}
+  codama@1.10.1:
+    resolution: {integrity: sha512-GWbRUN+cbgfNrBNzWkpi0z9JcgQxwkkQLW3L+1xCvJQilHmOIC/Si3Wxv5+AiXUad1jSwkacWfM/utpTMtPS5w==}
     hasBin: true
 
   commander@14.0.3:
@@ -423,11 +364,6 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -447,12 +383,12 @@ packages:
 
 snapshots:
 
-  '@codama/cli@1.5.4':
+  '@codama/cli@1.6.1':
     dependencies:
-      '@codama/nodes': 1.9.0
-      '@codama/visitors': 1.9.0
-      '@codama/visitors-core': 1.9.0
-      commander: 14.0.3
+      '@codama/nodes': 1.10.1
+      '@codama/visitors': 1.10.1
+      '@codama/visitors-core': 1.10.1
+      commander: 15.0.0
       picocolors: 1.1.1
       prompts: 2.4.2
 
@@ -462,21 +398,11 @@ snapshots:
       commander: 14.0.3
       picocolors: 1.1.1
 
-  '@codama/errors@1.7.0':
+  '@codama/errors@1.10.1':
     dependencies:
-      '@codama/node-types': 1.7.0
-      commander: 14.0.3
+      '@codama/node-types': 1.10.1
+      commander: 15.0.0
       picocolors: 1.1.1
-
-  '@codama/errors@1.9.0':
-    dependencies:
-      '@codama/node-types': 1.9.0
-      commander: 14.0.3
-      picocolors: 1.1.1
-
-  '@codama/fragments@0.1.0':
-    dependencies:
-      '@codama/errors': 1.7.0
 
   '@codama/fragments@0.1.3':
     dependencies:
@@ -484,24 +410,17 @@ snapshots:
 
   '@codama/node-types@1.10.0': {}
 
-  '@codama/node-types@1.7.0': {}
-
-  '@codama/node-types@1.9.0': {}
+  '@codama/node-types@1.10.1': {}
 
   '@codama/nodes@1.10.0':
     dependencies:
       '@codama/errors': 1.10.0
       '@codama/node-types': 1.10.0
 
-  '@codama/nodes@1.7.0':
+  '@codama/nodes@1.10.1':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/node-types': 1.7.0
-
-  '@codama/nodes@1.9.0':
-    dependencies:
-      '@codama/errors': 1.9.0
-      '@codama/node-types': 1.9.0
+      '@codama/errors': 1.10.1
+      '@codama/node-types': 1.10.1
 
   '@codama/renderers-core@1.3.11':
     dependencies:
@@ -509,13 +428,6 @@ snapshots:
       '@codama/fragments': 0.1.3
       '@codama/nodes': 1.10.0
       '@codama/visitors-core': 1.10.0
-
-  '@codama/renderers-core@1.3.8':
-    dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/fragments': 0.1.0
-      '@codama/nodes': 1.7.0
-      '@codama/visitors-core': 1.7.0
 
   '@codama/renderers-js@2.3.1(typescript@7.0.2)':
     dependencies:
@@ -530,26 +442,26 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/renderers-rust@3.1.0(typescript@7.0.2)':
+  '@codama/renderers-rust@3.1.3(typescript@7.0.2)':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/renderers-core': 1.3.8
-      '@codama/visitors-core': 1.7.0
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
+      '@codama/renderers-core': 1.3.11
+      '@codama/visitors-core': 1.10.1
       '@iarna/toml': 2.2.5
-      '@solana/codecs-strings': 6.9.0(typescript@7.0.2)
+      '@solana/codecs-strings': 7.0.0(typescript@7.0.2)
       nunjucks: 3.2.4
-      semver: 7.8.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - chokidar
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/validators@1.9.0':
+  '@codama/validators@1.10.1':
     dependencies:
-      '@codama/errors': 1.9.0
-      '@codama/nodes': 1.9.0
-      '@codama/visitors-core': 1.9.0
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
+      '@codama/visitors-core': 1.10.1
 
   '@codama/visitors-core@1.10.0':
     dependencies:
@@ -557,42 +469,23 @@ snapshots:
       '@codama/nodes': 1.10.0
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors-core@1.7.0':
+  '@codama/visitors-core@1.10.1':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors-core@1.9.0':
+  '@codama/visitors@1.10.1':
     dependencies:
-      '@codama/errors': 1.9.0
-      '@codama/nodes': 1.9.0
-      json-stable-stringify: 1.3.0
-
-  '@codama/visitors@1.9.0':
-    dependencies:
-      '@codama/errors': 1.9.0
-      '@codama/nodes': 1.9.0
-      '@codama/visitors-core': 1.9.0
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
+      '@codama/visitors-core': 1.10.1
 
   '@iarna/toml@2.2.5': {}
-
-  '@solana/codecs-core@6.9.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/errors': 6.9.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
 
   '@solana/codecs-core@7.0.0(typescript@7.0.2)':
     dependencies:
       '@solana/errors': 7.0.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/codecs-numbers@6.9.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 6.9.0(typescript@7.0.2)
-      '@solana/errors': 6.9.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
 
@@ -603,26 +496,11 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/codecs-strings@6.9.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 6.9.0(typescript@7.0.2)
-      '@solana/codecs-numbers': 6.9.0(typescript@7.0.2)
-      '@solana/errors': 6.9.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
   '@solana/codecs-strings@7.0.0(typescript@7.0.2)':
     dependencies:
       '@solana/codecs-core': 7.0.0(typescript@7.0.2)
       '@solana/codecs-numbers': 7.0.0(typescript@7.0.2)
       '@solana/errors': 7.0.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/errors@6.9.0(typescript@7.0.2)':
-    dependencies:
-      chalk: 5.6.2
-      commander: 14.0.3
     optionalDependencies:
       typescript: 7.0.2
 
@@ -716,13 +594,13 @@ snapshots:
 
   chalk@5.6.2: {}
 
-  codama@1.9.0:
+  codama@1.10.1:
     dependencies:
-      '@codama/cli': 1.5.4
-      '@codama/errors': 1.9.0
-      '@codama/nodes': 1.9.0
-      '@codama/validators': 1.9.0
-      '@codama/visitors': 1.9.0
+      '@codama/cli': 1.6.1
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
+      '@codama/validators': 1.10.1
+      '@codama/visitors': 1.10.1
 
   commander@14.0.3: {}
 
@@ -814,8 +692,6 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
-
-  semver@7.8.4: {}
 
   semver@7.8.5: {}
 


### PR DESCRIPTION
This PR annotates all 17 active stake instructions with clear-signing display metadata, using the display directives introduced in codama 0.11.0, and regenerates the IDL and clients.

- Intents and interpolated sentences for every instruction (e.g. `Withdraw ${data.args} from ${accounts.stake} to ${accounts.recipient}`); the four lamport arguments (`split`, `withdraw`, `moveStake`, `moveLamports`) render as SOL (`Amount: 2.5 SOL`).
- Struct-typed tuple args (`initialize`, `setLockup*`, `authorize*WithSeed`) are flattened into the fallback list, with field labels authored on the target types (`Locked Until`, `Authority Type`, `New Authority`, …) so account-state rendering benefits too.
- The `unixTimestamp` fields carry labels in Rust; the date-time display lives on the `unixTimestamp` alias in `codama.mjs`, where the alias is created. Account-state extras: SOL displays on `rentExemptReserve` and `delegation.stake`, `_reserved` hidden.
- Sysvars, the `unused` account, and discriminators are hidden from the fallback list; renames follow the conventions of the other annotated programs (`From`/`To`, `Stake Account`, `Base Key`, …).
- Bumps `codama`/`codama-macros` to 0.11.0, JS `codama` to ^1.10.1, and `@codama/renderers-rust` to ^3.1.3 (its bundled visitors crash on the new IDL otherwise). Two small `codama.mjs` guards compensate for empty child arrays now being omitted from the generated IDL; the remaining renderer template gap is tracked upstream.

**Note on the regenerated Rust client diffs**: the changes to the 17 generated instruction files come from the renderers-rust 3.1.0 → 3.1.3 bump, not from the display work (display metadata does not affect client codegen — the JS client output is byte-identical). In particular, renderers-rust 3.1.1 ([renderers-rust#82](https://github.com/codama-idl/renderers-rust/pull/82)) fixed swapped `is_writable`/`is_signer` flags on remaining accounts in the CPI builders, which means the currently published `solana-stake-client` sets those flags incorrectly for callers of `invoke_with_remaining_accounts` / `invoke_signed_with_remaining_accounts`. This PR picks up that fix; a patch release of the Rust client may be worth cutting after merge.

Verified with `cargo check --features codama`, clippy, fmt, the interface test suite (63 tests), compilation of the regenerated Rust client, and by rendering every instruction end-to-end through `@codama/dynamic-instructions` 0.4.0.
