### PR TITLE
Author IDL transforms with codama macros instead of render-time visitors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "codama"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91798ab2e821564d327ac3b41c6c83826269457f36093c88d4d5b98a7ee7d5"
+checksum = "b641d5affd79989fe9a9b7be594d1b9dd9ccef58aabf3283269526e7bbffe48b"
 dependencies = [
  "codama-errors",
  "codama-korok-visitors",
@@ -1157,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "codama-attributes"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44e135c09f5f16992a3fcc6592beac00fa6a0a7c9648d93422e71cc9ac143a6"
+checksum = "136b9565d9da736c68a4caa0c88582bcebd8099a18c90507472d164baffb5add"
 dependencies = [
  "codama-errors",
  "codama-nodes",
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "codama-errors"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5ad68c06b8830856b3b3c087479cec0b007d7ceb960ca345694c546e3d4559"
+checksum = "0cb25d60d8e91b359b89858fed2c49f761c9609fa0544ef2e8f64d088d752385"
 dependencies = [
  "cargo_toml",
  "proc-macro2",
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "codama-korok-visitors"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9967d3e6c4161772aa14b45c7f60e92eb6b52c75846fc9c66836d7ca44fe2c77"
+checksum = "7c1eac1352ec6226e741a5bf03f438ffc7006a6688092555b707adb27900db5b"
 dependencies = [
  "cargo_toml",
  "codama-attributes",
@@ -1201,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "codama-koroks"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296aba520a57be8aed918531ff3a8f0d80e2701411d232c7edf2d826996dadda"
+checksum = "5c7f9f32ab7af999646d2b5319e1399676e439e1ec4052f439dfe7e6dd1e0187"
 dependencies = [
  "codama-attributes",
  "codama-errors",
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "codama-macros"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea604597fafeaa94200d7a6f05d172941b4151ba6ad8614992845c011f341de3"
+checksum = "7aed9a45a961296ec4066494f51322f4a89d5dd14613222fddcbe95df7c8cb63"
 dependencies = [
  "codama-attributes",
  "codama-errors",
@@ -1232,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "codama-nodes"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7e59fb5ebce27ff68d12504074587277c68588454defb9e38bd88a5f885f82"
+checksum = "3c7788486027503f96ad7c5dc98d8957d3cee76402b7669fd86be370a7c25975"
 dependencies = [
  "codama-errors",
  "codama-nodes-derive",
@@ -1245,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "codama-nodes-derive"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d182823460b84415779fcf7925612c8188b49c0427659da4822598bf642f85"
+checksum = "7f7c61234c4180396044aa83cd0ab8bccdc71bf04f581d7a1edd0db0855f86d9"
 dependencies = [
  "codama-errors",
  "codama-syn-helpers",
@@ -1259,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "codama-plugin-core"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e278376d9619a08249383b8ae884888d999dac1fea57e3b54fde0d5bf75388"
+checksum = "949cf2b20680ef4409f3687ee47a13098540b49742d150271d5d3da148620f35"
 dependencies = [
  "codama-attributes",
  "codama-errors",
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "codama-stores"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e7f646f888ca401f2eb36f64cbf36f721fb20a590b97e901d3d3697bdd9708"
+checksum = "5fc4961d3084a7ca007cdbfbf110ee4f31b360ec24c0945a3dc898ac835be0ef"
 dependencies = [
  "cargo_toml",
  "codama-errors",
@@ -1284,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "codama-syn-helpers"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6895b16c0da9f8a432f182b29e95facd2d3d5d8aa31cb1a36f97cc35f130419d"
+checksum = "0dedfeef7f2a5ff918bb07a065a7f5bffeaa54cc13b1b2453d959dacd504dc74"
 dependencies = [
  "codama-errors",
  "derive_more",

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ generate-clients:
 	pnpm codama run --all $(ARGS)
 
 generate-idl-%:
-	@cargo install --locked --version =0.13.0 codama-cli
-	codama-rs generate-idl ./$(call make-path,$*) -o idl.json --pretty $(ARGS)
+	@cargo install --locked --version =0.13.1 codama-cli
+	codama-rs generate-idl $(call make-path,$*) -o idl.json --pretty $(ARGS)
 
 # Helpers for publishing
 tag-name = $(lastword $(subst /, ,$(call make-path,$1)))

--- a/codama.mjs
+++ b/codama.mjs
@@ -7,17 +7,6 @@ export default {
             from: 'codama#updateInstructionsVisitor',
             args: [{ redelegate: { delete: true } }],
         },
-        {
-            from: 'codama#updateDefinedTypesVisitor',
-            args: [
-                {
-                    lockupArgs: { name: 'lockupParams' },
-                    lockupCheckedArgs: { name: 'lockupCheckedParams' },
-                    authorizeWithSeedArgs: { name: 'authorizeWithSeedParams' },
-                    authorizeCheckedWithSeedArgs: { name: 'authorizeCheckedWithSeedParams' },
-                },
-            ],
-        },
         'codama#unwrapInstructionArgsDefinedTypesVisitor',
         'codama#flattenInstructionDataArgumentsVisitor',
         {
@@ -71,39 +60,6 @@ export default {
                                         ]),
                                     }),
                                 ],
-                            };
-                        },
-                    },
-                    {
-                        // enum discriminator -> u32
-                        select: '[definedTypeNode]stakeState.[enumTypeNode]',
-                        transform: node => {
-                            c.assertIsNode(node, 'enumTypeNode');
-                            return { ...node, size: c.numberTypeNode('u32') };
-                        },
-                    },
-                    {
-                        // enum discriminator -> u32
-                        select: '[definedTypeNode]stakeStateV2.[enumTypeNode]',
-                        transform: node => {
-                            c.assertIsNode(node, 'enumTypeNode');
-                            return { ...node, size: c.numberTypeNode('u32') };
-                        },
-                    },
-                    {
-                        // Use omitted optional account strategy for all instructions.
-                        select: '[instructionNode]',
-                        transform: node => {
-                            c.assertIsNode(node, 'instructionNode');
-                            return {
-                                ...node,
-                                // The Rust-generated IDL omits empty account lists, which some
-                                // renderers still expect to be present.
-                                accounts: node.accounts ?? [],
-                                optionalAccountStrategy: 'omitted',
-                                arguments: node.arguments.map(arg =>
-                                    arg.name === 'discriminator' ? { ...arg, type: c.numberTypeNode('u32') } : arg,
-                                ),
                             };
                         },
                     },

--- a/idl.json
+++ b/idl.json
@@ -11,6 +11,7 @@
       {
         "kind": "instructionNode",
         "name": "initialize",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -50,7 +51,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -103,6 +104,7 @@
       {
         "kind": "instructionNode",
         "name": "authorize",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -161,7 +163,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -213,6 +215,7 @@
       {
         "kind": "instructionNode",
         "name": "delegateStake",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -304,7 +307,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -333,6 +336,7 @@
       {
         "kind": "instructionNode",
         "name": "split",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -377,7 +381,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -430,6 +434,7 @@
       {
         "kind": "instructionNode",
         "name": "withdraw",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -514,7 +519,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -567,6 +572,7 @@
       {
         "kind": "instructionNode",
         "name": "deactivate",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -615,7 +621,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -644,6 +650,7 @@
       {
         "kind": "instructionNode",
         "name": "setLockup",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -675,7 +682,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -692,7 +699,7 @@
             "name": "arg0",
             "type": {
               "kind": "definedTypeLinkNode",
-              "name": "lockupArgs"
+              "name": "lockupParams"
             },
             "display": {
               "kind": "structFieldDisplayNode",
@@ -716,6 +723,7 @@
       {
         "kind": "instructionNode",
         "name": "merge",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -794,7 +802,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -823,6 +831,7 @@
       {
         "kind": "instructionNode",
         "name": "authorizeWithSeed",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -885,7 +894,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -902,7 +911,7 @@
             "name": "arg0",
             "type": {
               "kind": "definedTypeLinkNode",
-              "name": "authorizeWithSeedArgs"
+              "name": "authorizeWithSeedParams"
             },
             "display": {
               "kind": "structFieldDisplayNode",
@@ -926,6 +935,7 @@
       {
         "kind": "instructionNode",
         "name": "initializeChecked",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -983,7 +993,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -1012,6 +1022,7 @@
       {
         "kind": "instructionNode",
         "name": "authorizeChecked",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -1079,7 +1090,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -1120,6 +1131,7 @@
       {
         "kind": "instructionNode",
         "name": "authorizeCheckedWithSeed",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -1191,7 +1203,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -1208,7 +1220,7 @@
             "name": "arg0",
             "type": {
               "kind": "definedTypeLinkNode",
-              "name": "authorizeCheckedWithSeedArgs"
+              "name": "authorizeCheckedWithSeedParams"
             },
             "display": {
               "kind": "structFieldDisplayNode",
@@ -1232,6 +1244,7 @@
       {
         "kind": "instructionNode",
         "name": "setLockupChecked",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -1273,7 +1286,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -1290,7 +1303,7 @@
             "name": "arg0",
             "type": {
               "kind": "definedTypeLinkNode",
-              "name": "lockupCheckedArgs"
+              "name": "lockupCheckedParams"
             },
             "display": {
               "kind": "structFieldDisplayNode",
@@ -1314,6 +1327,7 @@
       {
         "kind": "instructionNode",
         "name": "getMinimumDelegation",
+        "optionalAccountStrategy": "omitted",
         "arguments": [
           {
             "kind": "instructionArgumentNode",
@@ -1321,7 +1335,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -1349,6 +1363,7 @@
       {
         "kind": "instructionNode",
         "name": "deactivateDelinquent",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -1397,7 +1412,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -1426,6 +1441,7 @@
       {
         "kind": "instructionNode",
         "name": "redelegate",
+        "optionalAccountStrategy": "omitted",
         "arguments": [
           {
             "kind": "instructionArgumentNode",
@@ -1433,7 +1449,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -1457,6 +1473,7 @@
       {
         "kind": "instructionNode",
         "name": "moveStake",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -1501,7 +1518,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -1554,6 +1571,7 @@
       {
         "kind": "instructionNode",
         "name": "moveLamports",
+        "optionalAccountStrategy": "omitted",
         "accounts": [
           {
             "kind": "instructionAccountNode",
@@ -1598,7 +1616,7 @@
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -18,8 +18,8 @@ program-id = "Stake11111111111111111111111111111111111111"
 
 [dependencies]
 borsh = { version = "1.6.1", features = ["derive", "unstable__schema"], optional = true }
-codama = { version = "0.13.0", optional = true }
-codama-macros = { version = "0.13.0", optional = true }
+codama = { version = "0.13.1", optional = true }
+codama-macros = { version = "0.13.1", optional = true }
 num-traits = "0.2"
 serde = { version = "1.0.210", optional = true }
 serde_derive = { version = "1.0.210", optional = true }

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -40,6 +40,8 @@ const STAKE_HISTORY_ID: Pubkey =
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
 #[cfg_attr(feature = "codama", derive(CodamaInstructions))]
+#[cfg_attr(feature = "codama", codama(enum_discriminator(size = number(u32))))]
+#[cfg_attr(feature = "codama", codama(optional_account_strategy = omitted))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum StakeInstruction {
     /// Initialize a stake with lockup and authorization information
@@ -308,7 +310,14 @@ pub enum StakeInstruction {
             docs = "Lockup authority or withdraw authority"
         ))
     )]
-    SetLockup(#[cfg_attr(feature = "codama", codama(display(flatten = true)))] LockupArgs),
+    SetLockup(
+        #[cfg_attr(
+            feature = "codama",
+            codama(type = link("lockupParams")),
+            codama(display(flatten = true))
+        )]
+        LockupArgs,
+    ),
 
     /// Merge two stake accounts.
     ///
@@ -408,7 +417,12 @@ pub enum StakeInstruction {
         ))
     )]
     AuthorizeWithSeed(
-        #[cfg_attr(feature = "codama", codama(display(flatten = true)))] AuthorizeWithSeedArgs,
+        #[cfg_attr(
+            feature = "codama",
+            codama(type = link("authorizeWithSeedParams")),
+            codama(display(flatten = true))
+        )]
+        AuthorizeWithSeedArgs,
     ),
 
     /// Initialize a stake with authorization information
@@ -545,7 +559,11 @@ pub enum StakeInstruction {
         ))
     )]
     AuthorizeCheckedWithSeed(
-        #[cfg_attr(feature = "codama", codama(display(flatten = true)))]
+        #[cfg_attr(
+            feature = "codama",
+            codama(type = link("authorizeCheckedWithSeedParams")),
+            codama(display(flatten = true))
+        )]
         AuthorizeCheckedWithSeedArgs,
     ),
 
@@ -586,7 +604,12 @@ pub enum StakeInstruction {
         ))
     )]
     SetLockupChecked(
-        #[cfg_attr(feature = "codama", codama(display(flatten = true)))] LockupCheckedArgs,
+        #[cfg_attr(
+            feature = "codama",
+            codama(type = link("lockupCheckedParams")),
+            codama(display(flatten = true))
+        )]
+        LockupCheckedArgs,
     ),
 
     /// Get the minimum stake delegation, in lamports


### PR DESCRIPTION
This PR moves several IDL transforms from render-time `codama.mjs` visitors into codama macros on the interface crate, so the canonical `idl.json` carries them directly:

- The `StakeInstruction` discriminator is authored as a `u32` via `codama(enum_discriminator(size = number(u32)))`.
- Every instruction uses the omitted optional-account strategy via an enum-level `codama(optional_account_strategy = omitted)` (new in codama-rs 0.13.1).
- The four `*Args` tuple arguments now link to their renamed `*Params` defined types via `codama(type = link(...))`, fixing links that dangled in the committed IDL, and retiring the `updateDefinedTypesVisitor`.
- Two dead visitors forcing `stakeState`/`stakeStateV2` enum sizes to `u32` are removed — those enums already carry `enum_discriminator` attributes, so the raw IDL was already correct.
- The empty-account-list backfill in the `before` section is removed as redundant; the one in the `rust` script remains, since `@codama/renderers-rust` 3.1.3 renders `NaN` into zero-account instructions without it.

Also bumps `codama`/`codama-macros` and the pinned `codama-cli` to `0.13.1`, and drops the `./` path workaround in the Makefile now that the CLI handles bare relative paths.

## `idl.json` semantic diff (key-sorted comparison vs `main`)

- Discriminators: `u8` → `u32` on every instruction.
- `optionalAccountStrategy: "omitted"` on every instruction.
- Four of the six dangling `definedTypeLinkNode`s fixed (`lockupArgs` → `lockupParams` etc.); only `epoch`/`unixTimestamp` remain, resolved at render time as before.

## Verification

- `make generate-clients` leaves a clean tree — the generated JS/Rust clients are byte-identical.
- Builds with and without `--features codama`; all interface + codama_schema tests pass.
- `cargo fmt --check` and `cargo clippy --all-targets --features codama -- --deny=warnings` clean.