### PR TITLE
interface: remove sysvars and stake config

### DIFF
--- a/clients/js/src/generated/instructions/authorize.ts
+++ b/clients/js/src/generated/instructions/authorize.ts
@@ -26,7 +26,6 @@ import {
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
-    type ReadonlyAccount,
     type ReadonlySignerAccount,
     type ReadonlyUint8Array,
     type TransactionSigner,
@@ -50,7 +49,6 @@ export function getAuthorizeDiscriminatorBytes(): ReadonlyUint8Array {
 export type AuthorizeInstruction<
     TProgram extends string = typeof STAKE_PROGRAM_ADDRESS,
     TAccountStake extends string | AccountMeta<string> = string,
-    TAccountClockSysvar extends string | AccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
     TAccountAuthority extends string | AccountMeta<string> = string,
     TAccountLockupAuthority extends string | AccountMeta<string> | undefined = undefined,
     TRemainingAccounts extends readonly AccountMeta<string>[] = [],
@@ -59,7 +57,6 @@ export type AuthorizeInstruction<
     InstructionWithAccounts<
         [
             TAccountStake extends string ? WritableAccount<TAccountStake> : TAccountStake,
-            TAccountClockSysvar extends string ? ReadonlyAccount<TAccountClockSysvar> : TAccountClockSysvar,
             TAccountAuthority extends string
                 ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority>
                 : TAccountAuthority,
@@ -106,14 +103,11 @@ export function getAuthorizeInstructionDataCodec(): FixedSizeCodec<
 
 export type AuthorizeInput<
     TAccountStake extends string = string,
-    TAccountClockSysvar extends string = string,
     TAccountAuthority extends string = string,
     TAccountLockupAuthority extends string = string,
 > = {
     /** Stake account to be updated */
     stake: Address<TAccountStake>;
-    /** Clock sysvar */
-    clockSysvar?: Address<TAccountClockSysvar>;
     /** The stake or withdraw authority */
     authority: TransactionSigner<TAccountAuthority>;
     /** Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration */
@@ -124,27 +118,19 @@ export type AuthorizeInput<
 
 export function getAuthorizeInstruction<
     TAccountStake extends string,
-    TAccountClockSysvar extends string,
     TAccountAuthority extends string,
     TAccountLockupAuthority extends string,
     TProgramAddress extends Address = typeof STAKE_PROGRAM_ADDRESS,
 >(
-    input: AuthorizeInput<TAccountStake, TAccountClockSysvar, TAccountAuthority, TAccountLockupAuthority>,
+    input: AuthorizeInput<TAccountStake, TAccountAuthority, TAccountLockupAuthority>,
     config?: { programAddress?: TProgramAddress },
-): AuthorizeInstruction<
-    TProgramAddress,
-    TAccountStake,
-    TAccountClockSysvar,
-    TAccountAuthority,
-    TAccountLockupAuthority
-> {
+): AuthorizeInstruction<TProgramAddress, TAccountStake, TAccountAuthority, TAccountLockupAuthority> {
     // Program address.
     const programAddress = config?.programAddress ?? STAKE_PROGRAM_ADDRESS;
 
     // Original accounts.
     const originalAccounts = {
         stake: { value: input.stake ?? null, isWritable: true },
-        clockSysvar: { value: input.clockSysvar ?? null, isWritable: false },
         authority: { value: input.authority ?? null, isWritable: false },
         lockupAuthority: { value: input.lockupAuthority ?? null, isWritable: false },
     };
@@ -153,29 +139,16 @@ export function getAuthorizeInstruction<
     // Original args.
     const args = { ...input };
 
-    // Resolve default values.
-    if (!accounts.clockSysvar.value) {
-        accounts.clockSysvar.value =
-            'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
-    }
-
     const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
     return Object.freeze({
         accounts: [
             getAccountMeta('stake', accounts.stake),
-            getAccountMeta('clockSysvar', accounts.clockSysvar),
             getAccountMeta('authority', accounts.authority),
             getAccountMeta('lockupAuthority', accounts.lockupAuthority),
         ].filter(<T>(x: T | undefined): x is T => x !== undefined),
         data: getAuthorizeInstructionDataEncoder().encode(args as AuthorizeInstructionDataArgs),
         programAddress,
-    } as AuthorizeInstruction<
-        TProgramAddress,
-        TAccountStake,
-        TAccountClockSysvar,
-        TAccountAuthority,
-        TAccountLockupAuthority
-    >);
+    } as AuthorizeInstruction<TProgramAddress, TAccountStake, TAccountAuthority, TAccountLockupAuthority>);
 }
 
 export type ParsedAuthorizeInstruction<
@@ -186,12 +159,10 @@ export type ParsedAuthorizeInstruction<
     accounts: {
         /** Stake account to be updated */
         stake: TAccountMetas[0];
-        /** Clock sysvar */
-        clockSysvar: TAccountMetas[1];
         /** The stake or withdraw authority */
-        authority: TAccountMetas[2];
+        authority: TAccountMetas[1];
         /** Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration */
-        lockupAuthority?: TAccountMetas[3] | undefined;
+        lockupAuthority?: TAccountMetas[2] | undefined;
     };
     data: AuthorizeInstructionData;
 };
@@ -201,10 +172,10 @@ export function parseAuthorizeInstruction<TProgram extends string, TAccountMetas
         InstructionWithAccounts<TAccountMetas> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedAuthorizeInstruction<TProgram, TAccountMetas> {
-    if (instruction.accounts.length < 3) {
+    if (instruction.accounts.length < 2) {
         throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
             actualAccountMetas: instruction.accounts.length,
-            expectedAccountMetas: 3,
+            expectedAccountMetas: 2,
         });
     }
     let accountIndex = 0;
@@ -213,7 +184,7 @@ export function parseAuthorizeInstruction<TProgram extends string, TAccountMetas
         accountIndex += 1;
         return accountMeta;
     };
-    let optionalAccountsRemaining = instruction.accounts.length - 3;
+    let optionalAccountsRemaining = instruction.accounts.length - 2;
     const getNextOptionalAccount = () => {
         if (optionalAccountsRemaining === 0) return undefined;
         optionalAccountsRemaining -= 1;
@@ -221,12 +192,7 @@ export function parseAuthorizeInstruction<TProgram extends string, TAccountMetas
     };
     return {
         programAddress: instruction.programAddress,
-        accounts: {
-            stake: getNextAccount(),
-            clockSysvar: getNextAccount(),
-            authority: getNextAccount(),
-            lockupAuthority: getNextOptionalAccount(),
-        },
+        accounts: { stake: getNextAccount(), authority: getNextAccount(), lockupAuthority: getNextOptionalAccount() },
         data: getAuthorizeInstructionDataDecoder().decode(instruction.data),
     };
 }

--- a/clients/js/src/generated/instructions/authorizeChecked.ts
+++ b/clients/js/src/generated/instructions/authorizeChecked.ts
@@ -24,7 +24,6 @@ import {
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
-    type ReadonlyAccount,
     type ReadonlySignerAccount,
     type ReadonlyUint8Array,
     type TransactionSigner,
@@ -48,7 +47,6 @@ export function getAuthorizeCheckedDiscriminatorBytes(): ReadonlyUint8Array {
 export type AuthorizeCheckedInstruction<
     TProgram extends string = typeof STAKE_PROGRAM_ADDRESS,
     TAccountStake extends string | AccountMeta<string> = string,
-    TAccountClockSysvar extends string | AccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
     TAccountAuthority extends string | AccountMeta<string> = string,
     TAccountNewAuthority extends string | AccountMeta<string> = string,
     TAccountLockupAuthority extends string | AccountMeta<string> | undefined = undefined,
@@ -58,7 +56,6 @@ export type AuthorizeCheckedInstruction<
     InstructionWithAccounts<
         [
             TAccountStake extends string ? WritableAccount<TAccountStake> : TAccountStake,
-            TAccountClockSysvar extends string ? ReadonlyAccount<TAccountClockSysvar> : TAccountClockSysvar,
             TAccountAuthority extends string
                 ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority>
                 : TAccountAuthority,
@@ -106,15 +103,12 @@ export function getAuthorizeCheckedInstructionDataCodec(): FixedSizeCodec<
 
 export type AuthorizeCheckedInput<
     TAccountStake extends string = string,
-    TAccountClockSysvar extends string = string,
     TAccountAuthority extends string = string,
     TAccountNewAuthority extends string = string,
     TAccountLockupAuthority extends string = string,
 > = {
     /** Stake account to be updated */
     stake: Address<TAccountStake>;
-    /** Clock sysvar */
-    clockSysvar?: Address<TAccountClockSysvar>;
     /** The stake or withdraw authority */
     authority: TransactionSigner<TAccountAuthority>;
     /** The new stake or withdraw authority */
@@ -126,24 +120,16 @@ export type AuthorizeCheckedInput<
 
 export function getAuthorizeCheckedInstruction<
     TAccountStake extends string,
-    TAccountClockSysvar extends string,
     TAccountAuthority extends string,
     TAccountNewAuthority extends string,
     TAccountLockupAuthority extends string,
     TProgramAddress extends Address = typeof STAKE_PROGRAM_ADDRESS,
 >(
-    input: AuthorizeCheckedInput<
-        TAccountStake,
-        TAccountClockSysvar,
-        TAccountAuthority,
-        TAccountNewAuthority,
-        TAccountLockupAuthority
-    >,
+    input: AuthorizeCheckedInput<TAccountStake, TAccountAuthority, TAccountNewAuthority, TAccountLockupAuthority>,
     config?: { programAddress?: TProgramAddress },
 ): AuthorizeCheckedInstruction<
     TProgramAddress,
     TAccountStake,
-    TAccountClockSysvar,
     TAccountAuthority,
     TAccountNewAuthority,
     TAccountLockupAuthority
@@ -154,7 +140,6 @@ export function getAuthorizeCheckedInstruction<
     // Original accounts.
     const originalAccounts = {
         stake: { value: input.stake ?? null, isWritable: true },
-        clockSysvar: { value: input.clockSysvar ?? null, isWritable: false },
         authority: { value: input.authority ?? null, isWritable: false },
         newAuthority: { value: input.newAuthority ?? null, isWritable: false },
         lockupAuthority: { value: input.lockupAuthority ?? null, isWritable: false },
@@ -164,17 +149,10 @@ export function getAuthorizeCheckedInstruction<
     // Original args.
     const args = { ...input };
 
-    // Resolve default values.
-    if (!accounts.clockSysvar.value) {
-        accounts.clockSysvar.value =
-            'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
-    }
-
     const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
     return Object.freeze({
         accounts: [
             getAccountMeta('stake', accounts.stake),
-            getAccountMeta('clockSysvar', accounts.clockSysvar),
             getAccountMeta('authority', accounts.authority),
             getAccountMeta('newAuthority', accounts.newAuthority),
             getAccountMeta('lockupAuthority', accounts.lockupAuthority),
@@ -184,7 +162,6 @@ export function getAuthorizeCheckedInstruction<
     } as AuthorizeCheckedInstruction<
         TProgramAddress,
         TAccountStake,
-        TAccountClockSysvar,
         TAccountAuthority,
         TAccountNewAuthority,
         TAccountLockupAuthority
@@ -199,14 +176,12 @@ export type ParsedAuthorizeCheckedInstruction<
     accounts: {
         /** Stake account to be updated */
         stake: TAccountMetas[0];
-        /** Clock sysvar */
-        clockSysvar: TAccountMetas[1];
         /** The stake or withdraw authority */
-        authority: TAccountMetas[2];
+        authority: TAccountMetas[1];
         /** The new stake or withdraw authority */
-        newAuthority: TAccountMetas[3];
+        newAuthority: TAccountMetas[2];
         /** Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration */
-        lockupAuthority?: TAccountMetas[4] | undefined;
+        lockupAuthority?: TAccountMetas[3] | undefined;
     };
     data: AuthorizeCheckedInstructionData;
 };
@@ -216,10 +191,10 @@ export function parseAuthorizeCheckedInstruction<TProgram extends string, TAccou
         InstructionWithAccounts<TAccountMetas> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedAuthorizeCheckedInstruction<TProgram, TAccountMetas> {
-    if (instruction.accounts.length < 4) {
+    if (instruction.accounts.length < 3) {
         throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
             actualAccountMetas: instruction.accounts.length,
-            expectedAccountMetas: 4,
+            expectedAccountMetas: 3,
         });
     }
     let accountIndex = 0;
@@ -228,7 +203,7 @@ export function parseAuthorizeCheckedInstruction<TProgram extends string, TAccou
         accountIndex += 1;
         return accountMeta;
     };
-    let optionalAccountsRemaining = instruction.accounts.length - 4;
+    let optionalAccountsRemaining = instruction.accounts.length - 3;
     const getNextOptionalAccount = () => {
         if (optionalAccountsRemaining === 0) return undefined;
         optionalAccountsRemaining -= 1;
@@ -238,7 +213,6 @@ export function parseAuthorizeCheckedInstruction<TProgram extends string, TAccou
         programAddress: instruction.programAddress,
         accounts: {
             stake: getNextAccount(),
-            clockSysvar: getNextAccount(),
             authority: getNextAccount(),
             newAuthority: getNextAccount(),
             lockupAuthority: getNextOptionalAccount(),

--- a/clients/js/src/generated/instructions/authorizeCheckedWithSeed.ts
+++ b/clients/js/src/generated/instructions/authorizeCheckedWithSeed.ts
@@ -32,7 +32,6 @@ import {
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
-    type ReadonlyAccount,
     type ReadonlySignerAccount,
     type ReadonlyUint8Array,
     type TransactionSigner,
@@ -57,7 +56,6 @@ export type AuthorizeCheckedWithSeedInstruction<
     TProgram extends string = typeof STAKE_PROGRAM_ADDRESS,
     TAccountStake extends string | AccountMeta<string> = string,
     TAccountBase extends string | AccountMeta<string> = string,
-    TAccountClockSysvar extends string | AccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
     TAccountNewAuthority extends string | AccountMeta<string> = string,
     TAccountLockupAuthority extends string | AccountMeta<string> | undefined = undefined,
     TRemainingAccounts extends readonly AccountMeta<string>[] = [],
@@ -69,7 +67,6 @@ export type AuthorizeCheckedWithSeedInstruction<
             TAccountBase extends string
                 ? ReadonlySignerAccount<TAccountBase> & AccountSignerMeta<TAccountBase>
                 : TAccountBase,
-            TAccountClockSysvar extends string ? ReadonlyAccount<TAccountClockSysvar> : TAccountClockSysvar,
             TAccountNewAuthority extends string
                 ? ReadonlySignerAccount<TAccountNewAuthority> & AccountSignerMeta<TAccountNewAuthority>
                 : TAccountNewAuthority,
@@ -131,7 +128,6 @@ export function getAuthorizeCheckedWithSeedInstructionDataCodec(): Codec<
 export type AuthorizeCheckedWithSeedInput<
     TAccountStake extends string = string,
     TAccountBase extends string = string,
-    TAccountClockSysvar extends string = string,
     TAccountNewAuthority extends string = string,
     TAccountLockupAuthority extends string = string,
 > = {
@@ -139,8 +135,6 @@ export type AuthorizeCheckedWithSeedInput<
     stake: Address<TAccountStake>;
     /** Base key of stake or withdraw authority */
     base: TransactionSigner<TAccountBase>;
-    /** Clock sysvar */
-    clockSysvar?: Address<TAccountClockSysvar>;
     /** The new stake or withdraw authority */
     newAuthority: TransactionSigner<TAccountNewAuthority>;
     /** Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration */
@@ -153,24 +147,16 @@ export type AuthorizeCheckedWithSeedInput<
 export function getAuthorizeCheckedWithSeedInstruction<
     TAccountStake extends string,
     TAccountBase extends string,
-    TAccountClockSysvar extends string,
     TAccountNewAuthority extends string,
     TAccountLockupAuthority extends string,
     TProgramAddress extends Address = typeof STAKE_PROGRAM_ADDRESS,
 >(
-    input: AuthorizeCheckedWithSeedInput<
-        TAccountStake,
-        TAccountBase,
-        TAccountClockSysvar,
-        TAccountNewAuthority,
-        TAccountLockupAuthority
-    >,
+    input: AuthorizeCheckedWithSeedInput<TAccountStake, TAccountBase, TAccountNewAuthority, TAccountLockupAuthority>,
     config?: { programAddress?: TProgramAddress },
 ): AuthorizeCheckedWithSeedInstruction<
     TProgramAddress,
     TAccountStake,
     TAccountBase,
-    TAccountClockSysvar,
     TAccountNewAuthority,
     TAccountLockupAuthority
 > {
@@ -181,7 +167,6 @@ export function getAuthorizeCheckedWithSeedInstruction<
     const originalAccounts = {
         stake: { value: input.stake ?? null, isWritable: true },
         base: { value: input.base ?? null, isWritable: false },
-        clockSysvar: { value: input.clockSysvar ?? null, isWritable: false },
         newAuthority: { value: input.newAuthority ?? null, isWritable: false },
         lockupAuthority: { value: input.lockupAuthority ?? null, isWritable: false },
     };
@@ -190,18 +175,11 @@ export function getAuthorizeCheckedWithSeedInstruction<
     // Original args.
     const args = { ...input };
 
-    // Resolve default values.
-    if (!accounts.clockSysvar.value) {
-        accounts.clockSysvar.value =
-            'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
-    }
-
     const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
     return Object.freeze({
         accounts: [
             getAccountMeta('stake', accounts.stake),
             getAccountMeta('base', accounts.base),
-            getAccountMeta('clockSysvar', accounts.clockSysvar),
             getAccountMeta('newAuthority', accounts.newAuthority),
             getAccountMeta('lockupAuthority', accounts.lockupAuthority),
         ].filter(<T>(x: T | undefined): x is T => x !== undefined),
@@ -213,7 +191,6 @@ export function getAuthorizeCheckedWithSeedInstruction<
         TProgramAddress,
         TAccountStake,
         TAccountBase,
-        TAccountClockSysvar,
         TAccountNewAuthority,
         TAccountLockupAuthority
     >);
@@ -229,12 +206,10 @@ export type ParsedAuthorizeCheckedWithSeedInstruction<
         stake: TAccountMetas[0];
         /** Base key of stake or withdraw authority */
         base: TAccountMetas[1];
-        /** Clock sysvar */
-        clockSysvar: TAccountMetas[2];
         /** The new stake or withdraw authority */
-        newAuthority: TAccountMetas[3];
+        newAuthority: TAccountMetas[2];
         /** Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration */
-        lockupAuthority?: TAccountMetas[4] | undefined;
+        lockupAuthority?: TAccountMetas[3] | undefined;
     };
     data: AuthorizeCheckedWithSeedInstructionData;
 };
@@ -247,10 +222,10 @@ export function parseAuthorizeCheckedWithSeedInstruction<
         InstructionWithAccounts<TAccountMetas> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedAuthorizeCheckedWithSeedInstruction<TProgram, TAccountMetas> {
-    if (instruction.accounts.length < 4) {
+    if (instruction.accounts.length < 3) {
         throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
             actualAccountMetas: instruction.accounts.length,
-            expectedAccountMetas: 4,
+            expectedAccountMetas: 3,
         });
     }
     let accountIndex = 0;
@@ -259,7 +234,7 @@ export function parseAuthorizeCheckedWithSeedInstruction<
         accountIndex += 1;
         return accountMeta;
     };
-    let optionalAccountsRemaining = instruction.accounts.length - 4;
+    let optionalAccountsRemaining = instruction.accounts.length - 3;
     const getNextOptionalAccount = () => {
         if (optionalAccountsRemaining === 0) return undefined;
         optionalAccountsRemaining -= 1;
@@ -270,7 +245,6 @@ export function parseAuthorizeCheckedWithSeedInstruction<
         accounts: {
             stake: getNextAccount(),
             base: getNextAccount(),
-            clockSysvar: getNextAccount(),
             newAuthority: getNextAccount(),
             lockupAuthority: getNextOptionalAccount(),
         },

--- a/clients/js/src/generated/instructions/authorizeWithSeed.ts
+++ b/clients/js/src/generated/instructions/authorizeWithSeed.ts
@@ -32,7 +32,6 @@ import {
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
-    type ReadonlyAccount,
     type ReadonlySignerAccount,
     type ReadonlyUint8Array,
     type TransactionSigner,
@@ -57,7 +56,6 @@ export type AuthorizeWithSeedInstruction<
     TProgram extends string = typeof STAKE_PROGRAM_ADDRESS,
     TAccountStake extends string | AccountMeta<string> = string,
     TAccountBase extends string | AccountMeta<string> = string,
-    TAccountClockSysvar extends string | AccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
     TAccountLockupAuthority extends string | AccountMeta<string> | undefined = undefined,
     TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
@@ -68,7 +66,6 @@ export type AuthorizeWithSeedInstruction<
             TAccountBase extends string
                 ? ReadonlySignerAccount<TAccountBase> & AccountSignerMeta<TAccountBase>
                 : TAccountBase,
-            TAccountClockSysvar extends string ? ReadonlyAccount<TAccountClockSysvar> : TAccountClockSysvar,
             ...(TAccountLockupAuthority extends undefined
                 ? []
                 : [
@@ -128,15 +125,12 @@ export function getAuthorizeWithSeedInstructionDataCodec(): Codec<
 export type AuthorizeWithSeedInput<
     TAccountStake extends string = string,
     TAccountBase extends string = string,
-    TAccountClockSysvar extends string = string,
     TAccountLockupAuthority extends string = string,
 > = {
     /** Stake account to be updated */
     stake: Address<TAccountStake>;
     /** Base key of stake or withdraw authority */
     base: TransactionSigner<TAccountBase>;
-    /** Clock sysvar */
-    clockSysvar?: Address<TAccountClockSysvar>;
     /** Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration */
     lockupAuthority?: TransactionSigner<TAccountLockupAuthority>;
     newAuthorizedPubkey: AuthorizeWithSeedInstructionDataArgs['newAuthorizedPubkey'];
@@ -148,19 +142,12 @@ export type AuthorizeWithSeedInput<
 export function getAuthorizeWithSeedInstruction<
     TAccountStake extends string,
     TAccountBase extends string,
-    TAccountClockSysvar extends string,
     TAccountLockupAuthority extends string,
     TProgramAddress extends Address = typeof STAKE_PROGRAM_ADDRESS,
 >(
-    input: AuthorizeWithSeedInput<TAccountStake, TAccountBase, TAccountClockSysvar, TAccountLockupAuthority>,
+    input: AuthorizeWithSeedInput<TAccountStake, TAccountBase, TAccountLockupAuthority>,
     config?: { programAddress?: TProgramAddress },
-): AuthorizeWithSeedInstruction<
-    TProgramAddress,
-    TAccountStake,
-    TAccountBase,
-    TAccountClockSysvar,
-    TAccountLockupAuthority
-> {
+): AuthorizeWithSeedInstruction<TProgramAddress, TAccountStake, TAccountBase, TAccountLockupAuthority> {
     // Program address.
     const programAddress = config?.programAddress ?? STAKE_PROGRAM_ADDRESS;
 
@@ -168,7 +155,6 @@ export function getAuthorizeWithSeedInstruction<
     const originalAccounts = {
         stake: { value: input.stake ?? null, isWritable: true },
         base: { value: input.base ?? null, isWritable: false },
-        clockSysvar: { value: input.clockSysvar ?? null, isWritable: false },
         lockupAuthority: { value: input.lockupAuthority ?? null, isWritable: false },
     };
     const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedInstructionAccount>;
@@ -176,29 +162,16 @@ export function getAuthorizeWithSeedInstruction<
     // Original args.
     const args = { ...input };
 
-    // Resolve default values.
-    if (!accounts.clockSysvar.value) {
-        accounts.clockSysvar.value =
-            'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
-    }
-
     const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
     return Object.freeze({
         accounts: [
             getAccountMeta('stake', accounts.stake),
             getAccountMeta('base', accounts.base),
-            getAccountMeta('clockSysvar', accounts.clockSysvar),
             getAccountMeta('lockupAuthority', accounts.lockupAuthority),
         ].filter(<T>(x: T | undefined): x is T => x !== undefined),
         data: getAuthorizeWithSeedInstructionDataEncoder().encode(args as AuthorizeWithSeedInstructionDataArgs),
         programAddress,
-    } as AuthorizeWithSeedInstruction<
-        TProgramAddress,
-        TAccountStake,
-        TAccountBase,
-        TAccountClockSysvar,
-        TAccountLockupAuthority
-    >);
+    } as AuthorizeWithSeedInstruction<TProgramAddress, TAccountStake, TAccountBase, TAccountLockupAuthority>);
 }
 
 export type ParsedAuthorizeWithSeedInstruction<
@@ -211,10 +184,8 @@ export type ParsedAuthorizeWithSeedInstruction<
         stake: TAccountMetas[0];
         /** Base key of stake or withdraw authority */
         base: TAccountMetas[1];
-        /** Clock sysvar */
-        clockSysvar: TAccountMetas[2];
         /** Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration */
-        lockupAuthority?: TAccountMetas[3] | undefined;
+        lockupAuthority?: TAccountMetas[2] | undefined;
     };
     data: AuthorizeWithSeedInstructionData;
 };
@@ -227,10 +198,10 @@ export function parseAuthorizeWithSeedInstruction<
         InstructionWithAccounts<TAccountMetas> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedAuthorizeWithSeedInstruction<TProgram, TAccountMetas> {
-    if (instruction.accounts.length < 3) {
+    if (instruction.accounts.length < 2) {
         throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
             actualAccountMetas: instruction.accounts.length,
-            expectedAccountMetas: 3,
+            expectedAccountMetas: 2,
         });
     }
     let accountIndex = 0;
@@ -239,7 +210,7 @@ export function parseAuthorizeWithSeedInstruction<
         accountIndex += 1;
         return accountMeta;
     };
-    let optionalAccountsRemaining = instruction.accounts.length - 3;
+    let optionalAccountsRemaining = instruction.accounts.length - 2;
     const getNextOptionalAccount = () => {
         if (optionalAccountsRemaining === 0) return undefined;
         optionalAccountsRemaining -= 1;
@@ -247,12 +218,7 @@ export function parseAuthorizeWithSeedInstruction<
     };
     return {
         programAddress: instruction.programAddress,
-        accounts: {
-            stake: getNextAccount(),
-            base: getNextAccount(),
-            clockSysvar: getNextAccount(),
-            lockupAuthority: getNextOptionalAccount(),
-        },
+        accounts: { stake: getNextAccount(), base: getNextAccount(), lockupAuthority: getNextOptionalAccount() },
         data: getAuthorizeWithSeedInstructionDataDecoder().decode(instruction.data),
     };
 }

--- a/clients/js/src/generated/instructions/deactivate.ts
+++ b/clients/js/src/generated/instructions/deactivate.ts
@@ -24,7 +24,6 @@ import {
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
-    type ReadonlyAccount,
     type ReadonlySignerAccount,
     type ReadonlyUint8Array,
     type TransactionSigner,
@@ -42,7 +41,6 @@ export function getDeactivateDiscriminatorBytes(): ReadonlyUint8Array {
 export type DeactivateInstruction<
     TProgram extends string = typeof STAKE_PROGRAM_ADDRESS,
     TAccountStake extends string | AccountMeta<string> = string,
-    TAccountClockSysvar extends string | AccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
     TAccountStakeAuthority extends string | AccountMeta<string> = string,
     TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
@@ -50,7 +48,6 @@ export type DeactivateInstruction<
     InstructionWithAccounts<
         [
             TAccountStake extends string ? WritableAccount<TAccountStake> : TAccountStake,
-            TAccountClockSysvar extends string ? ReadonlyAccount<TAccountClockSysvar> : TAccountClockSysvar,
             TAccountStakeAuthority extends string
                 ? ReadonlySignerAccount<TAccountStakeAuthority> & AccountSignerMeta<TAccountStakeAuthority>
                 : TAccountStakeAuthority,
@@ -80,55 +77,37 @@ export function getDeactivateInstructionDataCodec(): FixedSizeCodec<
     return combineCodec(getDeactivateInstructionDataEncoder(), getDeactivateInstructionDataDecoder());
 }
 
-export type DeactivateInput<
-    TAccountStake extends string = string,
-    TAccountClockSysvar extends string = string,
-    TAccountStakeAuthority extends string = string,
-> = {
+export type DeactivateInput<TAccountStake extends string = string, TAccountStakeAuthority extends string = string> = {
     /** Delegated stake account to be deactivated */
     stake: Address<TAccountStake>;
-    /** Clock sysvar */
-    clockSysvar?: Address<TAccountClockSysvar>;
     /** Stake authority */
     stakeAuthority: TransactionSigner<TAccountStakeAuthority>;
 };
 
 export function getDeactivateInstruction<
     TAccountStake extends string,
-    TAccountClockSysvar extends string,
     TAccountStakeAuthority extends string,
     TProgramAddress extends Address = typeof STAKE_PROGRAM_ADDRESS,
 >(
-    input: DeactivateInput<TAccountStake, TAccountClockSysvar, TAccountStakeAuthority>,
+    input: DeactivateInput<TAccountStake, TAccountStakeAuthority>,
     config?: { programAddress?: TProgramAddress },
-): DeactivateInstruction<TProgramAddress, TAccountStake, TAccountClockSysvar, TAccountStakeAuthority> {
+): DeactivateInstruction<TProgramAddress, TAccountStake, TAccountStakeAuthority> {
     // Program address.
     const programAddress = config?.programAddress ?? STAKE_PROGRAM_ADDRESS;
 
     // Original accounts.
     const originalAccounts = {
         stake: { value: input.stake ?? null, isWritable: true },
-        clockSysvar: { value: input.clockSysvar ?? null, isWritable: false },
         stakeAuthority: { value: input.stakeAuthority ?? null, isWritable: false },
     };
     const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedInstructionAccount>;
 
-    // Resolve default values.
-    if (!accounts.clockSysvar.value) {
-        accounts.clockSysvar.value =
-            'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
-    }
-
     const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
     return Object.freeze({
-        accounts: [
-            getAccountMeta('stake', accounts.stake),
-            getAccountMeta('clockSysvar', accounts.clockSysvar),
-            getAccountMeta('stakeAuthority', accounts.stakeAuthority),
-        ],
+        accounts: [getAccountMeta('stake', accounts.stake), getAccountMeta('stakeAuthority', accounts.stakeAuthority)],
         data: getDeactivateInstructionDataEncoder().encode({}),
         programAddress,
-    } as DeactivateInstruction<TProgramAddress, TAccountStake, TAccountClockSysvar, TAccountStakeAuthority>);
+    } as DeactivateInstruction<TProgramAddress, TAccountStake, TAccountStakeAuthority>);
 }
 
 export type ParsedDeactivateInstruction<
@@ -139,10 +118,8 @@ export type ParsedDeactivateInstruction<
     accounts: {
         /** Delegated stake account to be deactivated */
         stake: TAccountMetas[0];
-        /** Clock sysvar */
-        clockSysvar: TAccountMetas[1];
         /** Stake authority */
-        stakeAuthority: TAccountMetas[2];
+        stakeAuthority: TAccountMetas[1];
     };
     data: DeactivateInstructionData;
 };
@@ -152,10 +129,10 @@ export function parseDeactivateInstruction<TProgram extends string, TAccountMeta
         InstructionWithAccounts<TAccountMetas> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedDeactivateInstruction<TProgram, TAccountMetas> {
-    if (instruction.accounts.length < 3) {
+    if (instruction.accounts.length < 2) {
         throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
             actualAccountMetas: instruction.accounts.length,
-            expectedAccountMetas: 3,
+            expectedAccountMetas: 2,
         });
     }
     let accountIndex = 0;
@@ -166,7 +143,7 @@ export function parseDeactivateInstruction<TProgram extends string, TAccountMeta
     };
     return {
         programAddress: instruction.programAddress,
-        accounts: { stake: getNextAccount(), clockSysvar: getNextAccount(), stakeAuthority: getNextAccount() },
+        accounts: { stake: getNextAccount(), stakeAuthority: getNextAccount() },
         data: getDeactivateInstructionDataDecoder().decode(instruction.data),
     };
 }

--- a/clients/js/src/generated/instructions/delegateStake.ts
+++ b/clients/js/src/generated/instructions/delegateStake.ts
@@ -43,9 +43,6 @@ export type DelegateStakeInstruction<
     TProgram extends string = typeof STAKE_PROGRAM_ADDRESS,
     TAccountStake extends string | AccountMeta<string> = string,
     TAccountVote extends string | AccountMeta<string> = string,
-    TAccountClockSysvar extends string | AccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
-    TAccountStakeHistory extends string | AccountMeta<string> = 'SysvarStakeHistory1111111111111111111111111',
-    TAccountUnused extends string | AccountMeta<string> = string,
     TAccountStakeAuthority extends string | AccountMeta<string> = string,
     TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
@@ -54,9 +51,6 @@ export type DelegateStakeInstruction<
         [
             TAccountStake extends string ? WritableAccount<TAccountStake> : TAccountStake,
             TAccountVote extends string ? ReadonlyAccount<TAccountVote> : TAccountVote,
-            TAccountClockSysvar extends string ? ReadonlyAccount<TAccountClockSysvar> : TAccountClockSysvar,
-            TAccountStakeHistory extends string ? ReadonlyAccount<TAccountStakeHistory> : TAccountStakeHistory,
-            TAccountUnused extends string ? ReadonlyAccount<TAccountUnused> : TAccountUnused,
             TAccountStakeAuthority extends string
                 ? ReadonlySignerAccount<TAccountStakeAuthority> & AccountSignerMeta<TAccountStakeAuthority>
                 : TAccountStakeAuthority,
@@ -89,21 +83,12 @@ export function getDelegateStakeInstructionDataCodec(): FixedSizeCodec<
 export type DelegateStakeInput<
     TAccountStake extends string = string,
     TAccountVote extends string = string,
-    TAccountClockSysvar extends string = string,
-    TAccountStakeHistory extends string = string,
-    TAccountUnused extends string = string,
     TAccountStakeAuthority extends string = string,
 > = {
     /** Initialized stake account to be delegated */
     stake: Address<TAccountStake>;
     /** Vote account to which this stake will be delegated */
     vote: Address<TAccountVote>;
-    /** Clock sysvar */
-    clockSysvar?: Address<TAccountClockSysvar>;
-    /** Stake history sysvar that carries stake warmup/cooldown history */
-    stakeHistory?: Address<TAccountStakeHistory>;
-    /** Unused account, formerly the stake config */
-    unused: Address<TAccountUnused>;
     /** Stake authority */
     stakeAuthority: TransactionSigner<TAccountStakeAuthority>;
 };
@@ -111,30 +96,12 @@ export type DelegateStakeInput<
 export function getDelegateStakeInstruction<
     TAccountStake extends string,
     TAccountVote extends string,
-    TAccountClockSysvar extends string,
-    TAccountStakeHistory extends string,
-    TAccountUnused extends string,
     TAccountStakeAuthority extends string,
     TProgramAddress extends Address = typeof STAKE_PROGRAM_ADDRESS,
 >(
-    input: DelegateStakeInput<
-        TAccountStake,
-        TAccountVote,
-        TAccountClockSysvar,
-        TAccountStakeHistory,
-        TAccountUnused,
-        TAccountStakeAuthority
-    >,
+    input: DelegateStakeInput<TAccountStake, TAccountVote, TAccountStakeAuthority>,
     config?: { programAddress?: TProgramAddress },
-): DelegateStakeInstruction<
-    TProgramAddress,
-    TAccountStake,
-    TAccountVote,
-    TAccountClockSysvar,
-    TAccountStakeHistory,
-    TAccountUnused,
-    TAccountStakeAuthority
-> {
+): DelegateStakeInstruction<TProgramAddress, TAccountStake, TAccountVote, TAccountStakeAuthority> {
     // Program address.
     const programAddress = config?.programAddress ?? STAKE_PROGRAM_ADDRESS;
 
@@ -142,44 +109,20 @@ export function getDelegateStakeInstruction<
     const originalAccounts = {
         stake: { value: input.stake ?? null, isWritable: true },
         vote: { value: input.vote ?? null, isWritable: false },
-        clockSysvar: { value: input.clockSysvar ?? null, isWritable: false },
-        stakeHistory: { value: input.stakeHistory ?? null, isWritable: false },
-        unused: { value: input.unused ?? null, isWritable: false },
         stakeAuthority: { value: input.stakeAuthority ?? null, isWritable: false },
     };
     const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedInstructionAccount>;
-
-    // Resolve default values.
-    if (!accounts.clockSysvar.value) {
-        accounts.clockSysvar.value =
-            'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
-    }
-    if (!accounts.stakeHistory.value) {
-        accounts.stakeHistory.value =
-            'SysvarStakeHistory1111111111111111111111111' as Address<'SysvarStakeHistory1111111111111111111111111'>;
-    }
 
     const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
     return Object.freeze({
         accounts: [
             getAccountMeta('stake', accounts.stake),
             getAccountMeta('vote', accounts.vote),
-            getAccountMeta('clockSysvar', accounts.clockSysvar),
-            getAccountMeta('stakeHistory', accounts.stakeHistory),
-            getAccountMeta('unused', accounts.unused),
             getAccountMeta('stakeAuthority', accounts.stakeAuthority),
         ],
         data: getDelegateStakeInstructionDataEncoder().encode({}),
         programAddress,
-    } as DelegateStakeInstruction<
-        TProgramAddress,
-        TAccountStake,
-        TAccountVote,
-        TAccountClockSysvar,
-        TAccountStakeHistory,
-        TAccountUnused,
-        TAccountStakeAuthority
-    >);
+    } as DelegateStakeInstruction<TProgramAddress, TAccountStake, TAccountVote, TAccountStakeAuthority>);
 }
 
 export type ParsedDelegateStakeInstruction<
@@ -192,14 +135,8 @@ export type ParsedDelegateStakeInstruction<
         stake: TAccountMetas[0];
         /** Vote account to which this stake will be delegated */
         vote: TAccountMetas[1];
-        /** Clock sysvar */
-        clockSysvar: TAccountMetas[2];
-        /** Stake history sysvar that carries stake warmup/cooldown history */
-        stakeHistory: TAccountMetas[3];
-        /** Unused account, formerly the stake config */
-        unused: TAccountMetas[4];
         /** Stake authority */
-        stakeAuthority: TAccountMetas[5];
+        stakeAuthority: TAccountMetas[2];
     };
     data: DelegateStakeInstructionData;
 };
@@ -209,10 +146,10 @@ export function parseDelegateStakeInstruction<TProgram extends string, TAccountM
         InstructionWithAccounts<TAccountMetas> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedDelegateStakeInstruction<TProgram, TAccountMetas> {
-    if (instruction.accounts.length < 6) {
+    if (instruction.accounts.length < 3) {
         throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
             actualAccountMetas: instruction.accounts.length,
-            expectedAccountMetas: 6,
+            expectedAccountMetas: 3,
         });
     }
     let accountIndex = 0;
@@ -223,14 +160,7 @@ export function parseDelegateStakeInstruction<TProgram extends string, TAccountM
     };
     return {
         programAddress: instruction.programAddress,
-        accounts: {
-            stake: getNextAccount(),
-            vote: getNextAccount(),
-            clockSysvar: getNextAccount(),
-            stakeHistory: getNextAccount(),
-            unused: getNextAccount(),
-            stakeAuthority: getNextAccount(),
-        },
+        accounts: { stake: getNextAccount(), vote: getNextAccount(), stakeAuthority: getNextAccount() },
         data: getDelegateStakeInstructionDataDecoder().decode(instruction.data),
     };
 }

--- a/clients/js/src/generated/instructions/initialize.ts
+++ b/clients/js/src/generated/instructions/initialize.ts
@@ -23,7 +23,6 @@ import {
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
-    type ReadonlyAccount,
     type ReadonlyUint8Array,
     type WritableAccount,
 } from '@solana/kit';
@@ -49,16 +48,11 @@ export function getInitializeDiscriminatorBytes(): ReadonlyUint8Array {
 export type InitializeInstruction<
     TProgram extends string = typeof STAKE_PROGRAM_ADDRESS,
     TAccountStake extends string | AccountMeta<string> = string,
-    TAccountRentSysvar extends string | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
     TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
     InstructionWithData<ReadonlyUint8Array> &
     InstructionWithAccounts<
-        [
-            TAccountStake extends string ? WritableAccount<TAccountStake> : TAccountStake,
-            TAccountRentSysvar extends string ? ReadonlyAccount<TAccountRentSysvar> : TAccountRentSysvar,
-            ...TRemainingAccounts,
-        ]
+        [TAccountStake extends string ? WritableAccount<TAccountStake> : TAccountStake, ...TRemainingAccounts]
     >;
 
 export type InitializeInstructionData = { discriminator: number; arg0: Authorized; arg1: Lockup };
@@ -91,48 +85,36 @@ export function getInitializeInstructionDataCodec(): FixedSizeCodec<
     return combineCodec(getInitializeInstructionDataEncoder(), getInitializeInstructionDataDecoder());
 }
 
-export type InitializeInput<TAccountStake extends string = string, TAccountRentSysvar extends string = string> = {
+export type InitializeInput<TAccountStake extends string = string> = {
     /** Uninitialized stake account */
     stake: Address<TAccountStake>;
-    /** Rent sysvar */
-    rentSysvar?: Address<TAccountRentSysvar>;
     arg0: InitializeInstructionDataArgs['arg0'];
     arg1: InitializeInstructionDataArgs['arg1'];
 };
 
 export function getInitializeInstruction<
     TAccountStake extends string,
-    TAccountRentSysvar extends string,
     TProgramAddress extends Address = typeof STAKE_PROGRAM_ADDRESS,
 >(
-    input: InitializeInput<TAccountStake, TAccountRentSysvar>,
+    input: InitializeInput<TAccountStake>,
     config?: { programAddress?: TProgramAddress },
-): InitializeInstruction<TProgramAddress, TAccountStake, TAccountRentSysvar> {
+): InitializeInstruction<TProgramAddress, TAccountStake> {
     // Program address.
     const programAddress = config?.programAddress ?? STAKE_PROGRAM_ADDRESS;
 
     // Original accounts.
-    const originalAccounts = {
-        stake: { value: input.stake ?? null, isWritable: true },
-        rentSysvar: { value: input.rentSysvar ?? null, isWritable: false },
-    };
+    const originalAccounts = { stake: { value: input.stake ?? null, isWritable: true } };
     const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedInstructionAccount>;
 
     // Original args.
     const args = { ...input };
 
-    // Resolve default values.
-    if (!accounts.rentSysvar.value) {
-        accounts.rentSysvar.value =
-            'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
-    }
-
     const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
     return Object.freeze({
-        accounts: [getAccountMeta('stake', accounts.stake), getAccountMeta('rentSysvar', accounts.rentSysvar)],
+        accounts: [getAccountMeta('stake', accounts.stake)],
         data: getInitializeInstructionDataEncoder().encode(args as InitializeInstructionDataArgs),
         programAddress,
-    } as InitializeInstruction<TProgramAddress, TAccountStake, TAccountRentSysvar>);
+    } as InitializeInstruction<TProgramAddress, TAccountStake>);
 }
 
 export type ParsedInitializeInstruction<
@@ -143,8 +125,6 @@ export type ParsedInitializeInstruction<
     accounts: {
         /** Uninitialized stake account */
         stake: TAccountMetas[0];
-        /** Rent sysvar */
-        rentSysvar: TAccountMetas[1];
     };
     data: InitializeInstructionData;
 };
@@ -154,10 +134,10 @@ export function parseInitializeInstruction<TProgram extends string, TAccountMeta
         InstructionWithAccounts<TAccountMetas> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeInstruction<TProgram, TAccountMetas> {
-    if (instruction.accounts.length < 2) {
+    if (instruction.accounts.length < 1) {
         throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
             actualAccountMetas: instruction.accounts.length,
-            expectedAccountMetas: 2,
+            expectedAccountMetas: 1,
         });
     }
     let accountIndex = 0;
@@ -168,7 +148,7 @@ export function parseInitializeInstruction<TProgram extends string, TAccountMeta
     };
     return {
         programAddress: instruction.programAddress,
-        accounts: { stake: getNextAccount(), rentSysvar: getNextAccount() },
+        accounts: { stake: getNextAccount() },
         data: getInitializeInstructionDataDecoder().decode(instruction.data),
     };
 }

--- a/clients/js/src/generated/instructions/initializeChecked.ts
+++ b/clients/js/src/generated/instructions/initializeChecked.ts
@@ -42,7 +42,6 @@ export function getInitializeCheckedDiscriminatorBytes(): ReadonlyUint8Array {
 export type InitializeCheckedInstruction<
     TProgram extends string = typeof STAKE_PROGRAM_ADDRESS,
     TAccountStake extends string | AccountMeta<string> = string,
-    TAccountRentSysvar extends string | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
     TAccountStakeAuthority extends string | AccountMeta<string> = string,
     TAccountWithdrawAuthority extends string | AccountMeta<string> = string,
     TRemainingAccounts extends readonly AccountMeta<string>[] = [],
@@ -51,7 +50,6 @@ export type InitializeCheckedInstruction<
     InstructionWithAccounts<
         [
             TAccountStake extends string ? WritableAccount<TAccountStake> : TAccountStake,
-            TAccountRentSysvar extends string ? ReadonlyAccount<TAccountRentSysvar> : TAccountRentSysvar,
             TAccountStakeAuthority extends string ? ReadonlyAccount<TAccountStakeAuthority> : TAccountStakeAuthority,
             TAccountWithdrawAuthority extends string
                 ? ReadonlySignerAccount<TAccountWithdrawAuthority> & AccountSignerMeta<TAccountWithdrawAuthority>
@@ -84,14 +82,11 @@ export function getInitializeCheckedInstructionDataCodec(): FixedSizeCodec<
 
 export type InitializeCheckedInput<
     TAccountStake extends string = string,
-    TAccountRentSysvar extends string = string,
     TAccountStakeAuthority extends string = string,
     TAccountWithdrawAuthority extends string = string,
 > = {
     /** Uninitialized stake account */
     stake: Address<TAccountStake>;
-    /** Rent sysvar */
-    rentSysvar?: Address<TAccountRentSysvar>;
     /** The stake authority */
     stakeAuthority: Address<TAccountStakeAuthority>;
     /** The withdraw authority */
@@ -100,43 +95,28 @@ export type InitializeCheckedInput<
 
 export function getInitializeCheckedInstruction<
     TAccountStake extends string,
-    TAccountRentSysvar extends string,
     TAccountStakeAuthority extends string,
     TAccountWithdrawAuthority extends string,
     TProgramAddress extends Address = typeof STAKE_PROGRAM_ADDRESS,
 >(
-    input: InitializeCheckedInput<TAccountStake, TAccountRentSysvar, TAccountStakeAuthority, TAccountWithdrawAuthority>,
+    input: InitializeCheckedInput<TAccountStake, TAccountStakeAuthority, TAccountWithdrawAuthority>,
     config?: { programAddress?: TProgramAddress },
-): InitializeCheckedInstruction<
-    TProgramAddress,
-    TAccountStake,
-    TAccountRentSysvar,
-    TAccountStakeAuthority,
-    TAccountWithdrawAuthority
-> {
+): InitializeCheckedInstruction<TProgramAddress, TAccountStake, TAccountStakeAuthority, TAccountWithdrawAuthority> {
     // Program address.
     const programAddress = config?.programAddress ?? STAKE_PROGRAM_ADDRESS;
 
     // Original accounts.
     const originalAccounts = {
         stake: { value: input.stake ?? null, isWritable: true },
-        rentSysvar: { value: input.rentSysvar ?? null, isWritable: false },
         stakeAuthority: { value: input.stakeAuthority ?? null, isWritable: false },
         withdrawAuthority: { value: input.withdrawAuthority ?? null, isWritable: false },
     };
     const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedInstructionAccount>;
 
-    // Resolve default values.
-    if (!accounts.rentSysvar.value) {
-        accounts.rentSysvar.value =
-            'SysvarRent111111111111111111111111111111111' as Address<'SysvarRent111111111111111111111111111111111'>;
-    }
-
     const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
     return Object.freeze({
         accounts: [
             getAccountMeta('stake', accounts.stake),
-            getAccountMeta('rentSysvar', accounts.rentSysvar),
             getAccountMeta('stakeAuthority', accounts.stakeAuthority),
             getAccountMeta('withdrawAuthority', accounts.withdrawAuthority),
         ],
@@ -145,7 +125,6 @@ export function getInitializeCheckedInstruction<
     } as InitializeCheckedInstruction<
         TProgramAddress,
         TAccountStake,
-        TAccountRentSysvar,
         TAccountStakeAuthority,
         TAccountWithdrawAuthority
     >);
@@ -159,12 +138,10 @@ export type ParsedInitializeCheckedInstruction<
     accounts: {
         /** Uninitialized stake account */
         stake: TAccountMetas[0];
-        /** Rent sysvar */
-        rentSysvar: TAccountMetas[1];
         /** The stake authority */
-        stakeAuthority: TAccountMetas[2];
+        stakeAuthority: TAccountMetas[1];
         /** The withdraw authority */
-        withdrawAuthority: TAccountMetas[3];
+        withdrawAuthority: TAccountMetas[2];
     };
     data: InitializeCheckedInstructionData;
 };
@@ -177,10 +154,10 @@ export function parseInitializeCheckedInstruction<
         InstructionWithAccounts<TAccountMetas> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInitializeCheckedInstruction<TProgram, TAccountMetas> {
-    if (instruction.accounts.length < 4) {
+    if (instruction.accounts.length < 3) {
         throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
             actualAccountMetas: instruction.accounts.length,
-            expectedAccountMetas: 4,
+            expectedAccountMetas: 3,
         });
     }
     let accountIndex = 0;
@@ -191,12 +168,7 @@ export function parseInitializeCheckedInstruction<
     };
     return {
         programAddress: instruction.programAddress,
-        accounts: {
-            stake: getNextAccount(),
-            rentSysvar: getNextAccount(),
-            stakeAuthority: getNextAccount(),
-            withdrawAuthority: getNextAccount(),
-        },
+        accounts: { stake: getNextAccount(), stakeAuthority: getNextAccount(), withdrawAuthority: getNextAccount() },
         data: getInitializeCheckedInstructionDataDecoder().decode(instruction.data),
     };
 }

--- a/clients/js/src/generated/instructions/merge.ts
+++ b/clients/js/src/generated/instructions/merge.ts
@@ -24,7 +24,6 @@ import {
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
-    type ReadonlyAccount,
     type ReadonlySignerAccount,
     type ReadonlyUint8Array,
     type TransactionSigner,
@@ -43,8 +42,6 @@ export type MergeInstruction<
     TProgram extends string = typeof STAKE_PROGRAM_ADDRESS,
     TAccountDestinationStake extends string | AccountMeta<string> = string,
     TAccountSourceStake extends string | AccountMeta<string> = string,
-    TAccountClockSysvar extends string | AccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
-    TAccountStakeHistory extends string | AccountMeta<string> = 'SysvarStakeHistory1111111111111111111111111',
     TAccountStakeAuthority extends string | AccountMeta<string> = string,
     TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
@@ -55,8 +52,6 @@ export type MergeInstruction<
                 ? WritableAccount<TAccountDestinationStake>
                 : TAccountDestinationStake,
             TAccountSourceStake extends string ? WritableAccount<TAccountSourceStake> : TAccountSourceStake,
-            TAccountClockSysvar extends string ? ReadonlyAccount<TAccountClockSysvar> : TAccountClockSysvar,
-            TAccountStakeHistory extends string ? ReadonlyAccount<TAccountStakeHistory> : TAccountStakeHistory,
             TAccountStakeAuthority extends string
                 ? ReadonlySignerAccount<TAccountStakeAuthority> & AccountSignerMeta<TAccountStakeAuthority>
                 : TAccountStakeAuthority,
@@ -86,18 +81,12 @@ export function getMergeInstructionDataCodec(): FixedSizeCodec<MergeInstructionD
 export type MergeInput<
     TAccountDestinationStake extends string = string,
     TAccountSourceStake extends string = string,
-    TAccountClockSysvar extends string = string,
-    TAccountStakeHistory extends string = string,
     TAccountStakeAuthority extends string = string,
 > = {
     /** Destination stake account for the merge */
     destinationStake: Address<TAccountDestinationStake>;
     /** Source stake account for to merge.  This account will be drained */
     sourceStake: Address<TAccountSourceStake>;
-    /** Clock sysvar */
-    clockSysvar?: Address<TAccountClockSysvar>;
-    /** Stake history sysvar that carries stake warmup/cooldown history */
-    stakeHistory?: Address<TAccountStakeHistory>;
     /** Stake authority */
     stakeAuthority: TransactionSigner<TAccountStakeAuthority>;
 };
@@ -105,27 +94,12 @@ export type MergeInput<
 export function getMergeInstruction<
     TAccountDestinationStake extends string,
     TAccountSourceStake extends string,
-    TAccountClockSysvar extends string,
-    TAccountStakeHistory extends string,
     TAccountStakeAuthority extends string,
     TProgramAddress extends Address = typeof STAKE_PROGRAM_ADDRESS,
 >(
-    input: MergeInput<
-        TAccountDestinationStake,
-        TAccountSourceStake,
-        TAccountClockSysvar,
-        TAccountStakeHistory,
-        TAccountStakeAuthority
-    >,
+    input: MergeInput<TAccountDestinationStake, TAccountSourceStake, TAccountStakeAuthority>,
     config?: { programAddress?: TProgramAddress },
-): MergeInstruction<
-    TProgramAddress,
-    TAccountDestinationStake,
-    TAccountSourceStake,
-    TAccountClockSysvar,
-    TAccountStakeHistory,
-    TAccountStakeAuthority
-> {
+): MergeInstruction<TProgramAddress, TAccountDestinationStake, TAccountSourceStake, TAccountStakeAuthority> {
     // Program address.
     const programAddress = config?.programAddress ?? STAKE_PROGRAM_ADDRESS;
 
@@ -133,41 +107,20 @@ export function getMergeInstruction<
     const originalAccounts = {
         destinationStake: { value: input.destinationStake ?? null, isWritable: true },
         sourceStake: { value: input.sourceStake ?? null, isWritable: true },
-        clockSysvar: { value: input.clockSysvar ?? null, isWritable: false },
-        stakeHistory: { value: input.stakeHistory ?? null, isWritable: false },
         stakeAuthority: { value: input.stakeAuthority ?? null, isWritable: false },
     };
     const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedInstructionAccount>;
-
-    // Resolve default values.
-    if (!accounts.clockSysvar.value) {
-        accounts.clockSysvar.value =
-            'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
-    }
-    if (!accounts.stakeHistory.value) {
-        accounts.stakeHistory.value =
-            'SysvarStakeHistory1111111111111111111111111' as Address<'SysvarStakeHistory1111111111111111111111111'>;
-    }
 
     const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
     return Object.freeze({
         accounts: [
             getAccountMeta('destinationStake', accounts.destinationStake),
             getAccountMeta('sourceStake', accounts.sourceStake),
-            getAccountMeta('clockSysvar', accounts.clockSysvar),
-            getAccountMeta('stakeHistory', accounts.stakeHistory),
             getAccountMeta('stakeAuthority', accounts.stakeAuthority),
         ],
         data: getMergeInstructionDataEncoder().encode({}),
         programAddress,
-    } as MergeInstruction<
-        TProgramAddress,
-        TAccountDestinationStake,
-        TAccountSourceStake,
-        TAccountClockSysvar,
-        TAccountStakeHistory,
-        TAccountStakeAuthority
-    >);
+    } as MergeInstruction<TProgramAddress, TAccountDestinationStake, TAccountSourceStake, TAccountStakeAuthority>);
 }
 
 export type ParsedMergeInstruction<
@@ -180,12 +133,8 @@ export type ParsedMergeInstruction<
         destinationStake: TAccountMetas[0];
         /** Source stake account for to merge.  This account will be drained */
         sourceStake: TAccountMetas[1];
-        /** Clock sysvar */
-        clockSysvar: TAccountMetas[2];
-        /** Stake history sysvar that carries stake warmup/cooldown history */
-        stakeHistory: TAccountMetas[3];
         /** Stake authority */
-        stakeAuthority: TAccountMetas[4];
+        stakeAuthority: TAccountMetas[2];
     };
     data: MergeInstructionData;
 };
@@ -195,10 +144,10 @@ export function parseMergeInstruction<TProgram extends string, TAccountMetas ext
         InstructionWithAccounts<TAccountMetas> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedMergeInstruction<TProgram, TAccountMetas> {
-    if (instruction.accounts.length < 5) {
+    if (instruction.accounts.length < 3) {
         throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
             actualAccountMetas: instruction.accounts.length,
-            expectedAccountMetas: 5,
+            expectedAccountMetas: 3,
         });
     }
     let accountIndex = 0;
@@ -212,8 +161,6 @@ export function parseMergeInstruction<TProgram extends string, TAccountMetas ext
         accounts: {
             destinationStake: getNextAccount(),
             sourceStake: getNextAccount(),
-            clockSysvar: getNextAccount(),
-            stakeHistory: getNextAccount(),
             stakeAuthority: getNextAccount(),
         },
         data: getMergeInstructionDataDecoder().decode(instruction.data),

--- a/clients/js/src/generated/instructions/withdraw.ts
+++ b/clients/js/src/generated/instructions/withdraw.ts
@@ -26,7 +26,6 @@ import {
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
-    type ReadonlyAccount,
     type ReadonlySignerAccount,
     type ReadonlyUint8Array,
     type TransactionSigner,
@@ -45,8 +44,6 @@ export type WithdrawInstruction<
     TProgram extends string = typeof STAKE_PROGRAM_ADDRESS,
     TAccountStake extends string | AccountMeta<string> = string,
     TAccountRecipient extends string | AccountMeta<string> = string,
-    TAccountClockSysvar extends string | AccountMeta<string> = 'SysvarC1ock11111111111111111111111111111111',
-    TAccountStakeHistory extends string | AccountMeta<string> = 'SysvarStakeHistory1111111111111111111111111',
     TAccountWithdrawAuthority extends string | AccountMeta<string> = string,
     TAccountLockupAuthority extends string | AccountMeta<string> | undefined = undefined,
     TRemainingAccounts extends readonly AccountMeta<string>[] = [],
@@ -56,8 +53,6 @@ export type WithdrawInstruction<
         [
             TAccountStake extends string ? WritableAccount<TAccountStake> : TAccountStake,
             TAccountRecipient extends string ? WritableAccount<TAccountRecipient> : TAccountRecipient,
-            TAccountClockSysvar extends string ? ReadonlyAccount<TAccountClockSysvar> : TAccountClockSysvar,
-            TAccountStakeHistory extends string ? ReadonlyAccount<TAccountStakeHistory> : TAccountStakeHistory,
             TAccountWithdrawAuthority extends string
                 ? ReadonlySignerAccount<TAccountWithdrawAuthority> & AccountSignerMeta<TAccountWithdrawAuthority>
                 : TAccountWithdrawAuthority,
@@ -103,8 +98,6 @@ export function getWithdrawInstructionDataCodec(): FixedSizeCodec<
 export type WithdrawInput<
     TAccountStake extends string = string,
     TAccountRecipient extends string = string,
-    TAccountClockSysvar extends string = string,
-    TAccountStakeHistory extends string = string,
     TAccountWithdrawAuthority extends string = string,
     TAccountLockupAuthority extends string = string,
 > = {
@@ -112,10 +105,6 @@ export type WithdrawInput<
     stake: Address<TAccountStake>;
     /** Recipient account */
     recipient: Address<TAccountRecipient>;
-    /** Clock sysvar */
-    clockSysvar?: Address<TAccountClockSysvar>;
-    /** Stake history sysvar that carries stake warmup/cooldown history */
-    stakeHistory?: Address<TAccountStakeHistory>;
     /** Withdraw authority */
     withdrawAuthority: TransactionSigner<TAccountWithdrawAuthority>;
     /** Lockup authority, if before lockup expiration */
@@ -126,27 +115,16 @@ export type WithdrawInput<
 export function getWithdrawInstruction<
     TAccountStake extends string,
     TAccountRecipient extends string,
-    TAccountClockSysvar extends string,
-    TAccountStakeHistory extends string,
     TAccountWithdrawAuthority extends string,
     TAccountLockupAuthority extends string,
     TProgramAddress extends Address = typeof STAKE_PROGRAM_ADDRESS,
 >(
-    input: WithdrawInput<
-        TAccountStake,
-        TAccountRecipient,
-        TAccountClockSysvar,
-        TAccountStakeHistory,
-        TAccountWithdrawAuthority,
-        TAccountLockupAuthority
-    >,
+    input: WithdrawInput<TAccountStake, TAccountRecipient, TAccountWithdrawAuthority, TAccountLockupAuthority>,
     config?: { programAddress?: TProgramAddress },
 ): WithdrawInstruction<
     TProgramAddress,
     TAccountStake,
     TAccountRecipient,
-    TAccountClockSysvar,
-    TAccountStakeHistory,
     TAccountWithdrawAuthority,
     TAccountLockupAuthority
 > {
@@ -157,8 +135,6 @@ export function getWithdrawInstruction<
     const originalAccounts = {
         stake: { value: input.stake ?? null, isWritable: true },
         recipient: { value: input.recipient ?? null, isWritable: true },
-        clockSysvar: { value: input.clockSysvar ?? null, isWritable: false },
-        stakeHistory: { value: input.stakeHistory ?? null, isWritable: false },
         withdrawAuthority: { value: input.withdrawAuthority ?? null, isWritable: false },
         lockupAuthority: { value: input.lockupAuthority ?? null, isWritable: false },
     };
@@ -167,23 +143,11 @@ export function getWithdrawInstruction<
     // Original args.
     const args = { ...input };
 
-    // Resolve default values.
-    if (!accounts.clockSysvar.value) {
-        accounts.clockSysvar.value =
-            'SysvarC1ock11111111111111111111111111111111' as Address<'SysvarC1ock11111111111111111111111111111111'>;
-    }
-    if (!accounts.stakeHistory.value) {
-        accounts.stakeHistory.value =
-            'SysvarStakeHistory1111111111111111111111111' as Address<'SysvarStakeHistory1111111111111111111111111'>;
-    }
-
     const getAccountMeta = getAccountMetaFactory(programAddress, 'omitted');
     return Object.freeze({
         accounts: [
             getAccountMeta('stake', accounts.stake),
             getAccountMeta('recipient', accounts.recipient),
-            getAccountMeta('clockSysvar', accounts.clockSysvar),
-            getAccountMeta('stakeHistory', accounts.stakeHistory),
             getAccountMeta('withdrawAuthority', accounts.withdrawAuthority),
             getAccountMeta('lockupAuthority', accounts.lockupAuthority),
         ].filter(<T>(x: T | undefined): x is T => x !== undefined),
@@ -193,8 +157,6 @@ export function getWithdrawInstruction<
         TProgramAddress,
         TAccountStake,
         TAccountRecipient,
-        TAccountClockSysvar,
-        TAccountStakeHistory,
         TAccountWithdrawAuthority,
         TAccountLockupAuthority
     >);
@@ -210,14 +172,10 @@ export type ParsedWithdrawInstruction<
         stake: TAccountMetas[0];
         /** Recipient account */
         recipient: TAccountMetas[1];
-        /** Clock sysvar */
-        clockSysvar: TAccountMetas[2];
-        /** Stake history sysvar that carries stake warmup/cooldown history */
-        stakeHistory: TAccountMetas[3];
         /** Withdraw authority */
-        withdrawAuthority: TAccountMetas[4];
+        withdrawAuthority: TAccountMetas[2];
         /** Lockup authority, if before lockup expiration */
-        lockupAuthority?: TAccountMetas[5] | undefined;
+        lockupAuthority?: TAccountMetas[3] | undefined;
     };
     data: WithdrawInstructionData;
 };
@@ -227,10 +185,10 @@ export function parseWithdrawInstruction<TProgram extends string, TAccountMetas 
         InstructionWithAccounts<TAccountMetas> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedWithdrawInstruction<TProgram, TAccountMetas> {
-    if (instruction.accounts.length < 5) {
+    if (instruction.accounts.length < 3) {
         throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, {
             actualAccountMetas: instruction.accounts.length,
-            expectedAccountMetas: 5,
+            expectedAccountMetas: 3,
         });
     }
     let accountIndex = 0;
@@ -239,7 +197,7 @@ export function parseWithdrawInstruction<TProgram extends string, TAccountMetas 
         accountIndex += 1;
         return accountMeta;
     };
-    let optionalAccountsRemaining = instruction.accounts.length - 5;
+    let optionalAccountsRemaining = instruction.accounts.length - 3;
     const getNextOptionalAccount = () => {
         if (optionalAccountsRemaining === 0) return undefined;
         optionalAccountsRemaining -= 1;
@@ -250,8 +208,6 @@ export function parseWithdrawInstruction<TProgram extends string, TAccountMetas 
         accounts: {
             stake: getNextAccount(),
             recipient: getNextAccount(),
-            clockSysvar: getNextAccount(),
-            stakeHistory: getNextAccount(),
             withdrawAuthority: getNextAccount(),
             lockupAuthority: getNextOptionalAccount(),
         },

--- a/clients/rust/src/generated/instructions/authorize.rs
+++ b/clients/rust/src/generated/instructions/authorize.rs
@@ -18,8 +18,6 @@ pub const AUTHORIZE_DISCRIMINATOR: u32 = 1;
 pub struct Authorize {
     /// Stake account to be updated
     pub stake: solana_address::Address,
-    /// Clock sysvar
-    pub clock_sysvar: solana_address::Address,
     /// The stake or withdraw authority
     pub authority: solana_address::Address,
     /// Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration
@@ -37,12 +35,8 @@ impl Authorize {
         args: AuthorizeInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.stake, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.clock_sysvar,
-            false,
-        ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.authority,
             true,
@@ -104,13 +98,11 @@ impl AuthorizeInstructionArgs {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[optional]` clock_sysvar (default to `SysvarC1ock11111111111111111111111111111111`)
-///   2. `[signer]` authority
-///   3. `[signer, optional]` lockup_authority
+///   1. `[signer]` authority
+///   2. `[signer, optional]` lockup_authority
 #[derive(Clone, Debug, Default)]
 pub struct AuthorizeBuilder {
     stake: Option<solana_address::Address>,
-    clock_sysvar: Option<solana_address::Address>,
     authority: Option<solana_address::Address>,
     lockup_authority: Option<solana_address::Address>,
     arg0: Option<Address>,
@@ -126,13 +118,6 @@ impl AuthorizeBuilder {
     #[inline(always)]
     pub fn stake(&mut self, stake: solana_address::Address) -> &mut Self {
         self.stake = Some(stake);
-        self
-    }
-    /// `[optional account, default to 'SysvarC1ock11111111111111111111111111111111']`
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(&mut self, clock_sysvar: solana_address::Address) -> &mut Self {
-        self.clock_sysvar = Some(clock_sysvar);
         self
     }
     /// The stake or withdraw authority
@@ -180,9 +165,6 @@ impl AuthorizeBuilder {
     pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = Authorize {
             stake: self.stake.expect("stake is not set"),
-            clock_sysvar: self.clock_sysvar.unwrap_or(solana_address::address!(
-                "SysvarC1ock11111111111111111111111111111111"
-            )),
             authority: self.authority.expect("authority is not set"),
             lockup_authority: self.lockup_authority,
         };
@@ -199,8 +181,6 @@ impl AuthorizeBuilder {
 pub struct AuthorizeCpiAccounts<'a, 'b> {
     /// Stake account to be updated
     pub stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// The stake or withdraw authority
     pub authority: &'b solana_account_info::AccountInfo<'a>,
     /// Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration
@@ -213,8 +193,6 @@ pub struct AuthorizeCpi<'a, 'b> {
     pub __program: &'b solana_account_info::AccountInfo<'a>,
     /// Stake account to be updated
     pub stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// The stake or withdraw authority
     pub authority: &'b solana_account_info::AccountInfo<'a>,
     /// Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration
@@ -232,7 +210,6 @@ impl<'a, 'b> AuthorizeCpi<'a, 'b> {
         Self {
             __program: program,
             stake: accounts.stake,
-            clock_sysvar: accounts.clock_sysvar,
             authority: accounts.authority,
             lockup_authority: accounts.lockup_authority,
             __args: args,
@@ -261,12 +238,8 @@ impl<'a, 'b> AuthorizeCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(*self.stake.key, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.clock_sysvar.key,
-            false,
-        ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.authority.key,
             true,
@@ -293,10 +266,9 @@ impl<'a, 'b> AuthorizeCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(4 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.stake.clone());
-        account_infos.push(self.clock_sysvar.clone());
         account_infos.push(self.authority.clone());
         if let Some(lockup_authority) = self.lockup_authority {
             account_infos.push(lockup_authority.clone());
@@ -318,9 +290,8 @@ impl<'a, 'b> AuthorizeCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[]` clock_sysvar
-///   2. `[signer]` authority
-///   3. `[signer, optional]` lockup_authority
+///   1. `[signer]` authority
+///   2. `[signer, optional]` lockup_authority
 #[derive(Clone, Debug)]
 pub struct AuthorizeCpiBuilder<'a, 'b> {
     instruction: Box<AuthorizeCpiBuilderInstruction<'a, 'b>>,
@@ -331,7 +302,6 @@ impl<'a, 'b> AuthorizeCpiBuilder<'a, 'b> {
         let instruction = Box::new(AuthorizeCpiBuilderInstruction {
             __program: program,
             stake: None,
-            clock_sysvar: None,
             authority: None,
             lockup_authority: None,
             arg0: None,
@@ -344,15 +314,6 @@ impl<'a, 'b> AuthorizeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn stake(&mut self, stake: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.stake = Some(stake);
-        self
-    }
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(
-        &mut self,
-        clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.clock_sysvar = Some(clock_sysvar);
         self
     }
     /// The stake or withdraw authority
@@ -424,11 +385,6 @@ impl<'a, 'b> AuthorizeCpiBuilder<'a, 'b> {
 
             stake: self.instruction.stake.expect("stake is not set"),
 
-            clock_sysvar: self
-                .instruction
-                .clock_sysvar
-                .expect("clock_sysvar is not set"),
-
             authority: self.instruction.authority.expect("authority is not set"),
 
             lockup_authority: self.instruction.lockup_authority,
@@ -445,7 +401,6 @@ impl<'a, 'b> AuthorizeCpiBuilder<'a, 'b> {
 struct AuthorizeCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     stake: Option<&'b solana_account_info::AccountInfo<'a>>,
-    clock_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
     authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     lockup_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     arg0: Option<Address>,

--- a/clients/rust/src/generated/instructions/authorize_checked.rs
+++ b/clients/rust/src/generated/instructions/authorize_checked.rs
@@ -17,8 +17,6 @@ pub const AUTHORIZE_CHECKED_DISCRIMINATOR: u32 = 10;
 pub struct AuthorizeChecked {
     /// Stake account to be updated
     pub stake: solana_address::Address,
-    /// Clock sysvar
-    pub clock_sysvar: solana_address::Address,
     /// The stake or withdraw authority
     pub authority: solana_address::Address,
     /// The new stake or withdraw authority
@@ -41,12 +39,8 @@ impl AuthorizeChecked {
         args: AuthorizeCheckedInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.stake, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.clock_sysvar,
-            false,
-        ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.authority,
             true,
@@ -111,14 +105,12 @@ impl AuthorizeCheckedInstructionArgs {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[optional]` clock_sysvar (default to `SysvarC1ock11111111111111111111111111111111`)
-///   2. `[signer]` authority
-///   3. `[signer]` new_authority
-///   4. `[signer, optional]` lockup_authority
+///   1. `[signer]` authority
+///   2. `[signer]` new_authority
+///   3. `[signer, optional]` lockup_authority
 #[derive(Clone, Debug, Default)]
 pub struct AuthorizeCheckedBuilder {
     stake: Option<solana_address::Address>,
-    clock_sysvar: Option<solana_address::Address>,
     authority: Option<solana_address::Address>,
     new_authority: Option<solana_address::Address>,
     lockup_authority: Option<solana_address::Address>,
@@ -134,13 +126,6 @@ impl AuthorizeCheckedBuilder {
     #[inline(always)]
     pub fn stake(&mut self, stake: solana_address::Address) -> &mut Self {
         self.stake = Some(stake);
-        self
-    }
-    /// `[optional account, default to 'SysvarC1ock11111111111111111111111111111111']`
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(&mut self, clock_sysvar: solana_address::Address) -> &mut Self {
-        self.clock_sysvar = Some(clock_sysvar);
         self
     }
     /// The stake or withdraw authority
@@ -189,9 +174,6 @@ impl AuthorizeCheckedBuilder {
     pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = AuthorizeChecked {
             stake: self.stake.expect("stake is not set"),
-            clock_sysvar: self.clock_sysvar.unwrap_or(solana_address::address!(
-                "SysvarC1ock11111111111111111111111111111111"
-            )),
             authority: self.authority.expect("authority is not set"),
             new_authority: self.new_authority.expect("new_authority is not set"),
             lockup_authority: self.lockup_authority,
@@ -211,8 +193,6 @@ impl AuthorizeCheckedBuilder {
 pub struct AuthorizeCheckedCpiAccounts<'a, 'b> {
     /// Stake account to be updated
     pub stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// The stake or withdraw authority
     pub authority: &'b solana_account_info::AccountInfo<'a>,
     /// The new stake or withdraw authority
@@ -227,8 +207,6 @@ pub struct AuthorizeCheckedCpi<'a, 'b> {
     pub __program: &'b solana_account_info::AccountInfo<'a>,
     /// Stake account to be updated
     pub stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// The stake or withdraw authority
     pub authority: &'b solana_account_info::AccountInfo<'a>,
     /// The new stake or withdraw authority
@@ -248,7 +226,6 @@ impl<'a, 'b> AuthorizeCheckedCpi<'a, 'b> {
         Self {
             __program: program,
             stake: accounts.stake,
-            clock_sysvar: accounts.clock_sysvar,
             authority: accounts.authority,
             new_authority: accounts.new_authority,
             lockup_authority: accounts.lockup_authority,
@@ -278,12 +255,8 @@ impl<'a, 'b> AuthorizeCheckedCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(*self.stake.key, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.clock_sysvar.key,
-            false,
-        ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.authority.key,
             true,
@@ -314,10 +287,9 @@ impl<'a, 'b> AuthorizeCheckedCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.stake.clone());
-        account_infos.push(self.clock_sysvar.clone());
         account_infos.push(self.authority.clone());
         account_infos.push(self.new_authority.clone());
         if let Some(lockup_authority) = self.lockup_authority {
@@ -340,10 +312,9 @@ impl<'a, 'b> AuthorizeCheckedCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[]` clock_sysvar
-///   2. `[signer]` authority
-///   3. `[signer]` new_authority
-///   4. `[signer, optional]` lockup_authority
+///   1. `[signer]` authority
+///   2. `[signer]` new_authority
+///   3. `[signer, optional]` lockup_authority
 #[derive(Clone, Debug)]
 pub struct AuthorizeCheckedCpiBuilder<'a, 'b> {
     instruction: Box<AuthorizeCheckedCpiBuilderInstruction<'a, 'b>>,
@@ -354,7 +325,6 @@ impl<'a, 'b> AuthorizeCheckedCpiBuilder<'a, 'b> {
         let instruction = Box::new(AuthorizeCheckedCpiBuilderInstruction {
             __program: program,
             stake: None,
-            clock_sysvar: None,
             authority: None,
             new_authority: None,
             lockup_authority: None,
@@ -367,15 +337,6 @@ impl<'a, 'b> AuthorizeCheckedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn stake(&mut self, stake: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.stake = Some(stake);
-        self
-    }
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(
-        &mut self,
-        clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.clock_sysvar = Some(clock_sysvar);
         self
     }
     /// The stake or withdraw authority
@@ -454,11 +415,6 @@ impl<'a, 'b> AuthorizeCheckedCpiBuilder<'a, 'b> {
 
             stake: self.instruction.stake.expect("stake is not set"),
 
-            clock_sysvar: self
-                .instruction
-                .clock_sysvar
-                .expect("clock_sysvar is not set"),
-
             authority: self.instruction.authority.expect("authority is not set"),
 
             new_authority: self
@@ -480,7 +436,6 @@ impl<'a, 'b> AuthorizeCheckedCpiBuilder<'a, 'b> {
 struct AuthorizeCheckedCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     stake: Option<&'b solana_account_info::AccountInfo<'a>>,
-    clock_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
     authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     new_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     lockup_authority: Option<&'b solana_account_info::AccountInfo<'a>>,

--- a/clients/rust/src/generated/instructions/authorize_checked_with_seed.rs
+++ b/clients/rust/src/generated/instructions/authorize_checked_with_seed.rs
@@ -21,8 +21,6 @@ pub struct AuthorizeCheckedWithSeed {
     pub stake: solana_address::Address,
     /// Base key of stake or withdraw authority
     pub base: solana_address::Address,
-    /// Clock sysvar
-    pub clock_sysvar: solana_address::Address,
     /// The new stake or withdraw authority
     pub new_authority: solana_address::Address,
     /// Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration
@@ -43,14 +41,10 @@ impl AuthorizeCheckedWithSeed {
         args: AuthorizeCheckedWithSeedInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.stake, false));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.base, true,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.clock_sysvar,
-            false,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.new_authority,
@@ -117,14 +111,12 @@ impl AuthorizeCheckedWithSeedInstructionArgs {
 ///
 ///   0. `[writable]` stake
 ///   1. `[signer]` base
-///   2. `[optional]` clock_sysvar (default to `SysvarC1ock11111111111111111111111111111111`)
-///   3. `[signer]` new_authority
-///   4. `[signer, optional]` lockup_authority
+///   2. `[signer]` new_authority
+///   3. `[signer, optional]` lockup_authority
 #[derive(Clone, Debug, Default)]
 pub struct AuthorizeCheckedWithSeedBuilder {
     stake: Option<solana_address::Address>,
     base: Option<solana_address::Address>,
-    clock_sysvar: Option<solana_address::Address>,
     new_authority: Option<solana_address::Address>,
     lockup_authority: Option<solana_address::Address>,
     stake_authorize: Option<StakeAuthorize>,
@@ -147,13 +139,6 @@ impl AuthorizeCheckedWithSeedBuilder {
     #[inline(always)]
     pub fn base(&mut self, base: solana_address::Address) -> &mut Self {
         self.base = Some(base);
-        self
-    }
-    /// `[optional account, default to 'SysvarC1ock11111111111111111111111111111111']`
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(&mut self, clock_sysvar: solana_address::Address) -> &mut Self {
-        self.clock_sysvar = Some(clock_sysvar);
         self
     }
     /// The new stake or withdraw authority
@@ -207,9 +192,6 @@ impl AuthorizeCheckedWithSeedBuilder {
         let accounts = AuthorizeCheckedWithSeed {
             stake: self.stake.expect("stake is not set"),
             base: self.base.expect("base is not set"),
-            clock_sysvar: self.clock_sysvar.unwrap_or(solana_address::address!(
-                "SysvarC1ock11111111111111111111111111111111"
-            )),
             new_authority: self.new_authority.expect("new_authority is not set"),
             lockup_authority: self.lockup_authority,
         };
@@ -238,8 +220,6 @@ pub struct AuthorizeCheckedWithSeedCpiAccounts<'a, 'b> {
     pub stake: &'b solana_account_info::AccountInfo<'a>,
     /// Base key of stake or withdraw authority
     pub base: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// The new stake or withdraw authority
     pub new_authority: &'b solana_account_info::AccountInfo<'a>,
     /// Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration
@@ -254,8 +234,6 @@ pub struct AuthorizeCheckedWithSeedCpi<'a, 'b> {
     pub stake: &'b solana_account_info::AccountInfo<'a>,
     /// Base key of stake or withdraw authority
     pub base: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// The new stake or withdraw authority
     pub new_authority: &'b solana_account_info::AccountInfo<'a>,
     /// Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration
@@ -274,7 +252,6 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpi<'a, 'b> {
             __program: program,
             stake: accounts.stake,
             base: accounts.base,
-            clock_sysvar: accounts.clock_sysvar,
             new_authority: accounts.new_authority,
             lockup_authority: accounts.lockup_authority,
             __args: args,
@@ -303,15 +280,11 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(*self.stake.key, false));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.base.key,
             true,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.clock_sysvar.key,
-            false,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.new_authority.key,
@@ -341,11 +314,10 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.stake.clone());
         account_infos.push(self.base.clone());
-        account_infos.push(self.clock_sysvar.clone());
         account_infos.push(self.new_authority.clone());
         if let Some(lockup_authority) = self.lockup_authority {
             account_infos.push(lockup_authority.clone());
@@ -368,9 +340,8 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpi<'a, 'b> {
 ///
 ///   0. `[writable]` stake
 ///   1. `[signer]` base
-///   2. `[]` clock_sysvar
-///   3. `[signer]` new_authority
-///   4. `[signer, optional]` lockup_authority
+///   2. `[signer]` new_authority
+///   3. `[signer, optional]` lockup_authority
 #[derive(Clone, Debug)]
 pub struct AuthorizeCheckedWithSeedCpiBuilder<'a, 'b> {
     instruction: Box<AuthorizeCheckedWithSeedCpiBuilderInstruction<'a, 'b>>,
@@ -382,7 +353,6 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpiBuilder<'a, 'b> {
             __program: program,
             stake: None,
             base: None,
-            clock_sysvar: None,
             new_authority: None,
             lockup_authority: None,
             stake_authorize: None,
@@ -402,15 +372,6 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn base(&mut self, base: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.base = Some(base);
-        self
-    }
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(
-        &mut self,
-        clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.clock_sysvar = Some(clock_sysvar);
         self
     }
     /// The new stake or withdraw authority
@@ -505,11 +466,6 @@ impl<'a, 'b> AuthorizeCheckedWithSeedCpiBuilder<'a, 'b> {
 
             base: self.instruction.base.expect("base is not set"),
 
-            clock_sysvar: self
-                .instruction
-                .clock_sysvar
-                .expect("clock_sysvar is not set"),
-
             new_authority: self
                 .instruction
                 .new_authority
@@ -530,7 +486,6 @@ struct AuthorizeCheckedWithSeedCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     stake: Option<&'b solana_account_info::AccountInfo<'a>>,
     base: Option<&'b solana_account_info::AccountInfo<'a>>,
-    clock_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
     new_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     lockup_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     stake_authorize: Option<StakeAuthorize>,

--- a/clients/rust/src/generated/instructions/authorize_with_seed.rs
+++ b/clients/rust/src/generated/instructions/authorize_with_seed.rs
@@ -21,8 +21,6 @@ pub struct AuthorizeWithSeed {
     pub stake: solana_address::Address,
     /// Base key of stake or withdraw authority
     pub base: solana_address::Address,
-    /// Clock sysvar
-    pub clock_sysvar: solana_address::Address,
     /// Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration
     pub lockup_authority: Option<solana_address::Address>,
 }
@@ -41,14 +39,10 @@ impl AuthorizeWithSeed {
         args: AuthorizeWithSeedInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.stake, false));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.base, true,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.clock_sysvar,
-            false,
         ));
         if let Some(lockup_authority) = self.lockup_authority {
             accounts.push(solana_instruction::AccountMeta::new_readonly(
@@ -112,13 +106,11 @@ impl AuthorizeWithSeedInstructionArgs {
 ///
 ///   0. `[writable]` stake
 ///   1. `[signer]` base
-///   2. `[optional]` clock_sysvar (default to `SysvarC1ock11111111111111111111111111111111`)
-///   3. `[signer, optional]` lockup_authority
+///   2. `[signer, optional]` lockup_authority
 #[derive(Clone, Debug, Default)]
 pub struct AuthorizeWithSeedBuilder {
     stake: Option<solana_address::Address>,
     base: Option<solana_address::Address>,
-    clock_sysvar: Option<solana_address::Address>,
     lockup_authority: Option<solana_address::Address>,
     new_authorized_pubkey: Option<Address>,
     stake_authorize: Option<StakeAuthorize>,
@@ -141,13 +133,6 @@ impl AuthorizeWithSeedBuilder {
     #[inline(always)]
     pub fn base(&mut self, base: solana_address::Address) -> &mut Self {
         self.base = Some(base);
-        self
-    }
-    /// `[optional account, default to 'SysvarC1ock11111111111111111111111111111111']`
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(&mut self, clock_sysvar: solana_address::Address) -> &mut Self {
-        self.clock_sysvar = Some(clock_sysvar);
         self
     }
     /// `[optional account]`
@@ -200,9 +185,6 @@ impl AuthorizeWithSeedBuilder {
         let accounts = AuthorizeWithSeed {
             stake: self.stake.expect("stake is not set"),
             base: self.base.expect("base is not set"),
-            clock_sysvar: self.clock_sysvar.unwrap_or(solana_address::address!(
-                "SysvarC1ock11111111111111111111111111111111"
-            )),
             lockup_authority: self.lockup_authority,
         };
         let args = AuthorizeWithSeedInstructionArgs {
@@ -234,8 +216,6 @@ pub struct AuthorizeWithSeedCpiAccounts<'a, 'b> {
     pub stake: &'b solana_account_info::AccountInfo<'a>,
     /// Base key of stake or withdraw authority
     pub base: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration
     pub lockup_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
 }
@@ -248,8 +228,6 @@ pub struct AuthorizeWithSeedCpi<'a, 'b> {
     pub stake: &'b solana_account_info::AccountInfo<'a>,
     /// Base key of stake or withdraw authority
     pub base: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// Lockup authority, if updating `StakeAuthorize::Withdrawer` before lockup expiration
     pub lockup_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
@@ -266,7 +244,6 @@ impl<'a, 'b> AuthorizeWithSeedCpi<'a, 'b> {
             __program: program,
             stake: accounts.stake,
             base: accounts.base,
-            clock_sysvar: accounts.clock_sysvar,
             lockup_authority: accounts.lockup_authority,
             __args: args,
         }
@@ -294,15 +271,11 @@ impl<'a, 'b> AuthorizeWithSeedCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(*self.stake.key, false));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.base.key,
             true,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.clock_sysvar.key,
-            false,
         ));
         if let Some(lockup_authority) = self.lockup_authority {
             accounts.push(solana_instruction::AccountMeta::new_readonly(
@@ -328,11 +301,10 @@ impl<'a, 'b> AuthorizeWithSeedCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(4 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.stake.clone());
         account_infos.push(self.base.clone());
-        account_infos.push(self.clock_sysvar.clone());
         if let Some(lockup_authority) = self.lockup_authority {
             account_infos.push(lockup_authority.clone());
         }
@@ -354,8 +326,7 @@ impl<'a, 'b> AuthorizeWithSeedCpi<'a, 'b> {
 ///
 ///   0. `[writable]` stake
 ///   1. `[signer]` base
-///   2. `[]` clock_sysvar
-///   3. `[signer, optional]` lockup_authority
+///   2. `[signer, optional]` lockup_authority
 #[derive(Clone, Debug)]
 pub struct AuthorizeWithSeedCpiBuilder<'a, 'b> {
     instruction: Box<AuthorizeWithSeedCpiBuilderInstruction<'a, 'b>>,
@@ -367,7 +338,6 @@ impl<'a, 'b> AuthorizeWithSeedCpiBuilder<'a, 'b> {
             __program: program,
             stake: None,
             base: None,
-            clock_sysvar: None,
             lockup_authority: None,
             new_authorized_pubkey: None,
             stake_authorize: None,
@@ -387,15 +357,6 @@ impl<'a, 'b> AuthorizeWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn base(&mut self, base: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.base = Some(base);
-        self
-    }
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(
-        &mut self,
-        clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.clock_sysvar = Some(clock_sysvar);
         self
     }
     /// `[optional account]`
@@ -491,11 +452,6 @@ impl<'a, 'b> AuthorizeWithSeedCpiBuilder<'a, 'b> {
 
             base: self.instruction.base.expect("base is not set"),
 
-            clock_sysvar: self
-                .instruction
-                .clock_sysvar
-                .expect("clock_sysvar is not set"),
-
             lockup_authority: self.instruction.lockup_authority,
             __args: args,
         };
@@ -511,7 +467,6 @@ struct AuthorizeWithSeedCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     stake: Option<&'b solana_account_info::AccountInfo<'a>>,
     base: Option<&'b solana_account_info::AccountInfo<'a>>,
-    clock_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
     lockup_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     new_authorized_pubkey: Option<Address>,
     stake_authorize: Option<StakeAuthorize>,

--- a/clients/rust/src/generated/instructions/deactivate.rs
+++ b/clients/rust/src/generated/instructions/deactivate.rs
@@ -14,8 +14,6 @@ pub const DEACTIVATE_DISCRIMINATOR: u32 = 5;
 pub struct Deactivate {
     /// Delegated stake account to be deactivated
     pub stake: solana_address::Address,
-    /// Clock sysvar
-    pub clock_sysvar: solana_address::Address,
     /// Stake authority
     pub stake_authority: solana_address::Address,
 }
@@ -30,12 +28,8 @@ impl Deactivate {
         &self,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.stake, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.clock_sysvar,
-            false,
-        ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.stake_authority,
             true,
@@ -77,12 +71,10 @@ impl Default for DeactivateInstructionData {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[optional]` clock_sysvar (default to `SysvarC1ock11111111111111111111111111111111`)
-///   2. `[signer]` stake_authority
+///   1. `[signer]` stake_authority
 #[derive(Clone, Debug, Default)]
 pub struct DeactivateBuilder {
     stake: Option<solana_address::Address>,
-    clock_sysvar: Option<solana_address::Address>,
     stake_authority: Option<solana_address::Address>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
@@ -95,13 +87,6 @@ impl DeactivateBuilder {
     #[inline(always)]
     pub fn stake(&mut self, stake: solana_address::Address) -> &mut Self {
         self.stake = Some(stake);
-        self
-    }
-    /// `[optional account, default to 'SysvarC1ock11111111111111111111111111111111']`
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(&mut self, clock_sysvar: solana_address::Address) -> &mut Self {
-        self.clock_sysvar = Some(clock_sysvar);
         self
     }
     /// Stake authority
@@ -129,9 +114,6 @@ impl DeactivateBuilder {
     pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = Deactivate {
             stake: self.stake.expect("stake is not set"),
-            clock_sysvar: self.clock_sysvar.unwrap_or(solana_address::address!(
-                "SysvarC1ock11111111111111111111111111111111"
-            )),
             stake_authority: self.stake_authority.expect("stake_authority is not set"),
         };
 
@@ -143,8 +125,6 @@ impl DeactivateBuilder {
 pub struct DeactivateCpiAccounts<'a, 'b> {
     /// Delegated stake account to be deactivated
     pub stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// Stake authority
     pub stake_authority: &'b solana_account_info::AccountInfo<'a>,
 }
@@ -155,8 +135,6 @@ pub struct DeactivateCpi<'a, 'b> {
     pub __program: &'b solana_account_info::AccountInfo<'a>,
     /// Delegated stake account to be deactivated
     pub stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// Stake authority
     pub stake_authority: &'b solana_account_info::AccountInfo<'a>,
 }
@@ -169,7 +147,6 @@ impl<'a, 'b> DeactivateCpi<'a, 'b> {
         Self {
             __program: program,
             stake: accounts.stake,
-            clock_sysvar: accounts.clock_sysvar,
             stake_authority: accounts.stake_authority,
         }
     }
@@ -196,12 +173,8 @@ impl<'a, 'b> DeactivateCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(*self.stake.key, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.clock_sysvar.key,
-            false,
-        ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.stake_authority.key,
             true,
@@ -220,10 +193,9 @@ impl<'a, 'b> DeactivateCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(3 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.stake.clone());
-        account_infos.push(self.clock_sysvar.clone());
         account_infos.push(self.stake_authority.clone());
         remaining_accounts
             .iter()
@@ -242,8 +214,7 @@ impl<'a, 'b> DeactivateCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[]` clock_sysvar
-///   2. `[signer]` stake_authority
+///   1. `[signer]` stake_authority
 #[derive(Clone, Debug)]
 pub struct DeactivateCpiBuilder<'a, 'b> {
     instruction: Box<DeactivateCpiBuilderInstruction<'a, 'b>>,
@@ -254,7 +225,6 @@ impl<'a, 'b> DeactivateCpiBuilder<'a, 'b> {
         let instruction = Box::new(DeactivateCpiBuilderInstruction {
             __program: program,
             stake: None,
-            clock_sysvar: None,
             stake_authority: None,
             __remaining_accounts: Vec::new(),
         });
@@ -264,15 +234,6 @@ impl<'a, 'b> DeactivateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn stake(&mut self, stake: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.stake = Some(stake);
-        self
-    }
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(
-        &mut self,
-        clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.clock_sysvar = Some(clock_sysvar);
         self
     }
     /// Stake authority
@@ -323,11 +284,6 @@ impl<'a, 'b> DeactivateCpiBuilder<'a, 'b> {
 
             stake: self.instruction.stake.expect("stake is not set"),
 
-            clock_sysvar: self
-                .instruction
-                .clock_sysvar
-                .expect("clock_sysvar is not set"),
-
             stake_authority: self
                 .instruction
                 .stake_authority
@@ -344,7 +300,6 @@ impl<'a, 'b> DeactivateCpiBuilder<'a, 'b> {
 struct DeactivateCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     stake: Option<&'b solana_account_info::AccountInfo<'a>>,
-    clock_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
     stake_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,

--- a/clients/rust/src/generated/instructions/delegate_stake.rs
+++ b/clients/rust/src/generated/instructions/delegate_stake.rs
@@ -16,12 +16,6 @@ pub struct DelegateStake {
     pub stake: solana_address::Address,
     /// Vote account to which this stake will be delegated
     pub vote: solana_address::Address,
-    /// Clock sysvar
-    pub clock_sysvar: solana_address::Address,
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    pub stake_history: solana_address::Address,
-    /// Unused account, formerly the stake config
-    pub unused: solana_address::Address,
     /// Stake authority
     pub stake_authority: solana_address::Address,
 }
@@ -36,22 +30,10 @@ impl DelegateStake {
         &self,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.stake, false));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.vote, false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.clock_sysvar,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.stake_history,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.unused,
-            false,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.stake_authority,
@@ -95,17 +77,11 @@ impl Default for DelegateStakeInstructionData {
 ///
 ///   0. `[writable]` stake
 ///   1. `[]` vote
-///   2. `[optional]` clock_sysvar (default to `SysvarC1ock11111111111111111111111111111111`)
-///   3. `[optional]` stake_history (default to `SysvarStakeHistory1111111111111111111111111`)
-///   4. `[]` unused
-///   5. `[signer]` stake_authority
+///   2. `[signer]` stake_authority
 #[derive(Clone, Debug, Default)]
 pub struct DelegateStakeBuilder {
     stake: Option<solana_address::Address>,
     vote: Option<solana_address::Address>,
-    clock_sysvar: Option<solana_address::Address>,
-    stake_history: Option<solana_address::Address>,
-    unused: Option<solana_address::Address>,
     stake_authority: Option<solana_address::Address>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
@@ -124,26 +100,6 @@ impl DelegateStakeBuilder {
     #[inline(always)]
     pub fn vote(&mut self, vote: solana_address::Address) -> &mut Self {
         self.vote = Some(vote);
-        self
-    }
-    /// `[optional account, default to 'SysvarC1ock11111111111111111111111111111111']`
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(&mut self, clock_sysvar: solana_address::Address) -> &mut Self {
-        self.clock_sysvar = Some(clock_sysvar);
-        self
-    }
-    /// `[optional account, default to 'SysvarStakeHistory1111111111111111111111111']`
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    #[inline(always)]
-    pub fn stake_history(&mut self, stake_history: solana_address::Address) -> &mut Self {
-        self.stake_history = Some(stake_history);
-        self
-    }
-    /// Unused account, formerly the stake config
-    #[inline(always)]
-    pub fn unused(&mut self, unused: solana_address::Address) -> &mut Self {
-        self.unused = Some(unused);
         self
     }
     /// Stake authority
@@ -172,13 +128,6 @@ impl DelegateStakeBuilder {
         let accounts = DelegateStake {
             stake: self.stake.expect("stake is not set"),
             vote: self.vote.expect("vote is not set"),
-            clock_sysvar: self.clock_sysvar.unwrap_or(solana_address::address!(
-                "SysvarC1ock11111111111111111111111111111111"
-            )),
-            stake_history: self.stake_history.unwrap_or(solana_address::address!(
-                "SysvarStakeHistory1111111111111111111111111"
-            )),
-            unused: self.unused.expect("unused is not set"),
             stake_authority: self.stake_authority.expect("stake_authority is not set"),
         };
 
@@ -192,12 +141,6 @@ pub struct DelegateStakeCpiAccounts<'a, 'b> {
     pub stake: &'b solana_account_info::AccountInfo<'a>,
     /// Vote account to which this stake will be delegated
     pub vote: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    pub stake_history: &'b solana_account_info::AccountInfo<'a>,
-    /// Unused account, formerly the stake config
-    pub unused: &'b solana_account_info::AccountInfo<'a>,
     /// Stake authority
     pub stake_authority: &'b solana_account_info::AccountInfo<'a>,
 }
@@ -210,12 +153,6 @@ pub struct DelegateStakeCpi<'a, 'b> {
     pub stake: &'b solana_account_info::AccountInfo<'a>,
     /// Vote account to which this stake will be delegated
     pub vote: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    pub stake_history: &'b solana_account_info::AccountInfo<'a>,
-    /// Unused account, formerly the stake config
-    pub unused: &'b solana_account_info::AccountInfo<'a>,
     /// Stake authority
     pub stake_authority: &'b solana_account_info::AccountInfo<'a>,
 }
@@ -229,9 +166,6 @@ impl<'a, 'b> DelegateStakeCpi<'a, 'b> {
             __program: program,
             stake: accounts.stake,
             vote: accounts.vote,
-            clock_sysvar: accounts.clock_sysvar,
-            stake_history: accounts.stake_history,
-            unused: accounts.unused,
             stake_authority: accounts.stake_authority,
         }
     }
@@ -258,22 +192,10 @@ impl<'a, 'b> DelegateStakeCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(*self.stake.key, false));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.vote.key,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.clock_sysvar.key,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.stake_history.key,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.unused.key,
             false,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
@@ -294,13 +216,10 @@ impl<'a, 'b> DelegateStakeCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(7 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(4 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.stake.clone());
         account_infos.push(self.vote.clone());
-        account_infos.push(self.clock_sysvar.clone());
-        account_infos.push(self.stake_history.clone());
-        account_infos.push(self.unused.clone());
         account_infos.push(self.stake_authority.clone());
         remaining_accounts
             .iter()
@@ -320,10 +239,7 @@ impl<'a, 'b> DelegateStakeCpi<'a, 'b> {
 ///
 ///   0. `[writable]` stake
 ///   1. `[]` vote
-///   2. `[]` clock_sysvar
-///   3. `[]` stake_history
-///   4. `[]` unused
-///   5. `[signer]` stake_authority
+///   2. `[signer]` stake_authority
 #[derive(Clone, Debug)]
 pub struct DelegateStakeCpiBuilder<'a, 'b> {
     instruction: Box<DelegateStakeCpiBuilderInstruction<'a, 'b>>,
@@ -335,9 +251,6 @@ impl<'a, 'b> DelegateStakeCpiBuilder<'a, 'b> {
             __program: program,
             stake: None,
             vote: None,
-            clock_sysvar: None,
-            stake_history: None,
-            unused: None,
             stake_authority: None,
             __remaining_accounts: Vec::new(),
         });
@@ -353,30 +266,6 @@ impl<'a, 'b> DelegateStakeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn vote(&mut self, vote: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.vote = Some(vote);
-        self
-    }
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(
-        &mut self,
-        clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.clock_sysvar = Some(clock_sysvar);
-        self
-    }
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    #[inline(always)]
-    pub fn stake_history(
-        &mut self,
-        stake_history: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.stake_history = Some(stake_history);
-        self
-    }
-    /// Unused account, formerly the stake config
-    #[inline(always)]
-    pub fn unused(&mut self, unused: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
-        self.instruction.unused = Some(unused);
         self
     }
     /// Stake authority
@@ -429,18 +318,6 @@ impl<'a, 'b> DelegateStakeCpiBuilder<'a, 'b> {
 
             vote: self.instruction.vote.expect("vote is not set"),
 
-            clock_sysvar: self
-                .instruction
-                .clock_sysvar
-                .expect("clock_sysvar is not set"),
-
-            stake_history: self
-                .instruction
-                .stake_history
-                .expect("stake_history is not set"),
-
-            unused: self.instruction.unused.expect("unused is not set"),
-
             stake_authority: self
                 .instruction
                 .stake_authority
@@ -458,9 +335,6 @@ struct DelegateStakeCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     stake: Option<&'b solana_account_info::AccountInfo<'a>>,
     vote: Option<&'b solana_account_info::AccountInfo<'a>>,
-    clock_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
-    stake_history: Option<&'b solana_account_info::AccountInfo<'a>>,
-    unused: Option<&'b solana_account_info::AccountInfo<'a>>,
     stake_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,

--- a/clients/rust/src/generated/instructions/initialize.rs
+++ b/clients/rust/src/generated/instructions/initialize.rs
@@ -17,8 +17,6 @@ pub const INITIALIZE_DISCRIMINATOR: u32 = 0;
 pub struct Initialize {
     /// Uninitialized stake account
     pub stake: solana_address::Address,
-    /// Rent sysvar
-    pub rent_sysvar: solana_address::Address,
 }
 
 impl Initialize {
@@ -32,12 +30,8 @@ impl Initialize {
         args: InitializeInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.stake, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.rent_sysvar,
-            false,
-        ));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = InitializeInstructionData::new().try_to_vec().unwrap();
         let mut args = args.try_to_vec().unwrap();
@@ -89,11 +83,9 @@ impl InitializeInstructionArgs {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[optional]` rent_sysvar (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializeBuilder {
     stake: Option<solana_address::Address>,
-    rent_sysvar: Option<solana_address::Address>,
     arg0: Option<Authorized>,
     arg1: Option<Lockup>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
@@ -107,13 +99,6 @@ impl InitializeBuilder {
     #[inline(always)]
     pub fn stake(&mut self, stake: solana_address::Address) -> &mut Self {
         self.stake = Some(stake);
-        self
-    }
-    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
-    /// Rent sysvar
-    #[inline(always)]
-    pub fn rent_sysvar(&mut self, rent_sysvar: solana_address::Address) -> &mut Self {
-        self.rent_sysvar = Some(rent_sysvar);
         self
     }
     #[inline(always)]
@@ -145,9 +130,6 @@ impl InitializeBuilder {
     pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = Initialize {
             stake: self.stake.expect("stake is not set"),
-            rent_sysvar: self.rent_sysvar.unwrap_or(solana_address::address!(
-                "SysvarRent111111111111111111111111111111111"
-            )),
         };
         let args = InitializeInstructionArgs {
             arg0: self.arg0.clone().expect("arg0 is not set"),
@@ -162,8 +144,6 @@ impl InitializeBuilder {
 pub struct InitializeCpiAccounts<'a, 'b> {
     /// Uninitialized stake account
     pub stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Rent sysvar
-    pub rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize` CPI instruction.
@@ -172,8 +152,6 @@ pub struct InitializeCpi<'a, 'b> {
     pub __program: &'b solana_account_info::AccountInfo<'a>,
     /// Uninitialized stake account
     pub stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Rent sysvar
-    pub rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: InitializeInstructionArgs,
 }
@@ -187,7 +165,6 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
         Self {
             __program: program,
             stake: accounts.stake,
-            rent_sysvar: accounts.rent_sysvar,
             __args: args,
         }
     }
@@ -214,12 +191,8 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(*self.stake.key, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.rent_sysvar.key,
-            false,
-        ));
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
@@ -236,10 +209,9 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(3 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(2 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.stake.clone());
-        account_infos.push(self.rent_sysvar.clone());
         remaining_accounts
             .iter()
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
@@ -257,7 +229,6 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[]` rent_sysvar
 #[derive(Clone, Debug)]
 pub struct InitializeCpiBuilder<'a, 'b> {
     instruction: Box<InitializeCpiBuilderInstruction<'a, 'b>>,
@@ -268,7 +239,6 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
         let instruction = Box::new(InitializeCpiBuilderInstruction {
             __program: program,
             stake: None,
-            rent_sysvar: None,
             arg0: None,
             arg1: None,
             __remaining_accounts: Vec::new(),
@@ -279,15 +249,6 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn stake(&mut self, stake: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.stake = Some(stake);
-        self
-    }
-    /// Rent sysvar
-    #[inline(always)]
-    pub fn rent_sysvar(
-        &mut self,
-        rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.rent_sysvar = Some(rent_sysvar);
         self
     }
     #[inline(always)]
@@ -342,11 +303,6 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
             __program: self.instruction.__program,
 
             stake: self.instruction.stake.expect("stake is not set"),
-
-            rent_sysvar: self
-                .instruction
-                .rent_sysvar
-                .expect("rent_sysvar is not set"),
             __args: args,
         };
         instruction.invoke_signed_with_remaining_accounts(
@@ -360,7 +316,6 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
 struct InitializeCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     stake: Option<&'b solana_account_info::AccountInfo<'a>>,
-    rent_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
     arg0: Option<Authorized>,
     arg1: Option<Lockup>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.

--- a/clients/rust/src/generated/instructions/initialize_checked.rs
+++ b/clients/rust/src/generated/instructions/initialize_checked.rs
@@ -14,8 +14,6 @@ pub const INITIALIZE_CHECKED_DISCRIMINATOR: u32 = 9;
 pub struct InitializeChecked {
     /// Uninitialized stake account
     pub stake: solana_address::Address,
-    /// Rent sysvar
-    pub rent_sysvar: solana_address::Address,
     /// The stake authority
     pub stake_authority: solana_address::Address,
     /// The withdraw authority
@@ -32,12 +30,8 @@ impl InitializeChecked {
         &self,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.stake, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.rent_sysvar,
-            false,
-        ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.stake_authority,
             false,
@@ -85,13 +79,11 @@ impl Default for InitializeCheckedInstructionData {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[optional]` rent_sysvar (default to `SysvarRent111111111111111111111111111111111`)
-///   2. `[]` stake_authority
-///   3. `[signer]` withdraw_authority
+///   1. `[]` stake_authority
+///   2. `[signer]` withdraw_authority
 #[derive(Clone, Debug, Default)]
 pub struct InitializeCheckedBuilder {
     stake: Option<solana_address::Address>,
-    rent_sysvar: Option<solana_address::Address>,
     stake_authority: Option<solana_address::Address>,
     withdraw_authority: Option<solana_address::Address>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
@@ -105,13 +97,6 @@ impl InitializeCheckedBuilder {
     #[inline(always)]
     pub fn stake(&mut self, stake: solana_address::Address) -> &mut Self {
         self.stake = Some(stake);
-        self
-    }
-    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
-    /// Rent sysvar
-    #[inline(always)]
-    pub fn rent_sysvar(&mut self, rent_sysvar: solana_address::Address) -> &mut Self {
-        self.rent_sysvar = Some(rent_sysvar);
         self
     }
     /// The stake authority
@@ -145,9 +130,6 @@ impl InitializeCheckedBuilder {
     pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializeChecked {
             stake: self.stake.expect("stake is not set"),
-            rent_sysvar: self.rent_sysvar.unwrap_or(solana_address::address!(
-                "SysvarRent111111111111111111111111111111111"
-            )),
             stake_authority: self.stake_authority.expect("stake_authority is not set"),
             withdraw_authority: self
                 .withdraw_authority
@@ -162,8 +144,6 @@ impl InitializeCheckedBuilder {
 pub struct InitializeCheckedCpiAccounts<'a, 'b> {
     /// Uninitialized stake account
     pub stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Rent sysvar
-    pub rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// The stake authority
     pub stake_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The withdraw authority
@@ -176,8 +156,6 @@ pub struct InitializeCheckedCpi<'a, 'b> {
     pub __program: &'b solana_account_info::AccountInfo<'a>,
     /// Uninitialized stake account
     pub stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Rent sysvar
-    pub rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// The stake authority
     pub stake_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The withdraw authority
@@ -192,7 +170,6 @@ impl<'a, 'b> InitializeCheckedCpi<'a, 'b> {
         Self {
             __program: program,
             stake: accounts.stake,
-            rent_sysvar: accounts.rent_sysvar,
             stake_authority: accounts.stake_authority,
             withdraw_authority: accounts.withdraw_authority,
         }
@@ -220,12 +197,8 @@ impl<'a, 'b> InitializeCheckedCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(*self.stake.key, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.rent_sysvar.key,
-            false,
-        ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.stake_authority.key,
             false,
@@ -250,10 +223,9 @@ impl<'a, 'b> InitializeCheckedCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(4 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.stake.clone());
-        account_infos.push(self.rent_sysvar.clone());
         account_infos.push(self.stake_authority.clone());
         account_infos.push(self.withdraw_authority.clone());
         remaining_accounts
@@ -273,9 +245,8 @@ impl<'a, 'b> InitializeCheckedCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` stake
-///   1. `[]` rent_sysvar
-///   2. `[]` stake_authority
-///   3. `[signer]` withdraw_authority
+///   1. `[]` stake_authority
+///   2. `[signer]` withdraw_authority
 #[derive(Clone, Debug)]
 pub struct InitializeCheckedCpiBuilder<'a, 'b> {
     instruction: Box<InitializeCheckedCpiBuilderInstruction<'a, 'b>>,
@@ -286,7 +257,6 @@ impl<'a, 'b> InitializeCheckedCpiBuilder<'a, 'b> {
         let instruction = Box::new(InitializeCheckedCpiBuilderInstruction {
             __program: program,
             stake: None,
-            rent_sysvar: None,
             stake_authority: None,
             withdraw_authority: None,
             __remaining_accounts: Vec::new(),
@@ -297,15 +267,6 @@ impl<'a, 'b> InitializeCheckedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn stake(&mut self, stake: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.stake = Some(stake);
-        self
-    }
-    /// Rent sysvar
-    #[inline(always)]
-    pub fn rent_sysvar(
-        &mut self,
-        rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.rent_sysvar = Some(rent_sysvar);
         self
     }
     /// The stake authority
@@ -365,11 +326,6 @@ impl<'a, 'b> InitializeCheckedCpiBuilder<'a, 'b> {
 
             stake: self.instruction.stake.expect("stake is not set"),
 
-            rent_sysvar: self
-                .instruction
-                .rent_sysvar
-                .expect("rent_sysvar is not set"),
-
             stake_authority: self
                 .instruction
                 .stake_authority
@@ -391,7 +347,6 @@ impl<'a, 'b> InitializeCheckedCpiBuilder<'a, 'b> {
 struct InitializeCheckedCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     stake: Option<&'b solana_account_info::AccountInfo<'a>>,
-    rent_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
     stake_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     withdraw_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.

--- a/clients/rust/src/generated/instructions/merge.rs
+++ b/clients/rust/src/generated/instructions/merge.rs
@@ -16,10 +16,6 @@ pub struct Merge {
     pub destination_stake: solana_address::Address,
     /// Source stake account for to merge.  This account will be drained
     pub source_stake: solana_address::Address,
-    /// Clock sysvar
-    pub clock_sysvar: solana_address::Address,
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    pub stake_history: solana_address::Address,
     /// Stake authority
     pub stake_authority: solana_address::Address,
 }
@@ -34,21 +30,13 @@ impl Merge {
         &self,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(
             self.destination_stake,
             false,
         ));
         accounts.push(solana_instruction::AccountMeta::new(
             self.source_stake,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.clock_sysvar,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.stake_history,
             false,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
@@ -93,15 +81,11 @@ impl Default for MergeInstructionData {
 ///
 ///   0. `[writable]` destination_stake
 ///   1. `[writable]` source_stake
-///   2. `[optional]` clock_sysvar (default to `SysvarC1ock11111111111111111111111111111111`)
-///   3. `[optional]` stake_history (default to `SysvarStakeHistory1111111111111111111111111`)
-///   4. `[signer]` stake_authority
+///   2. `[signer]` stake_authority
 #[derive(Clone, Debug, Default)]
 pub struct MergeBuilder {
     destination_stake: Option<solana_address::Address>,
     source_stake: Option<solana_address::Address>,
-    clock_sysvar: Option<solana_address::Address>,
-    stake_history: Option<solana_address::Address>,
     stake_authority: Option<solana_address::Address>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
@@ -120,20 +104,6 @@ impl MergeBuilder {
     #[inline(always)]
     pub fn source_stake(&mut self, source_stake: solana_address::Address) -> &mut Self {
         self.source_stake = Some(source_stake);
-        self
-    }
-    /// `[optional account, default to 'SysvarC1ock11111111111111111111111111111111']`
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(&mut self, clock_sysvar: solana_address::Address) -> &mut Self {
-        self.clock_sysvar = Some(clock_sysvar);
-        self
-    }
-    /// `[optional account, default to 'SysvarStakeHistory1111111111111111111111111']`
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    #[inline(always)]
-    pub fn stake_history(&mut self, stake_history: solana_address::Address) -> &mut Self {
-        self.stake_history = Some(stake_history);
         self
     }
     /// Stake authority
@@ -164,12 +134,6 @@ impl MergeBuilder {
                 .destination_stake
                 .expect("destination_stake is not set"),
             source_stake: self.source_stake.expect("source_stake is not set"),
-            clock_sysvar: self.clock_sysvar.unwrap_or(solana_address::address!(
-                "SysvarC1ock11111111111111111111111111111111"
-            )),
-            stake_history: self.stake_history.unwrap_or(solana_address::address!(
-                "SysvarStakeHistory1111111111111111111111111"
-            )),
             stake_authority: self.stake_authority.expect("stake_authority is not set"),
         };
 
@@ -183,10 +147,6 @@ pub struct MergeCpiAccounts<'a, 'b> {
     pub destination_stake: &'b solana_account_info::AccountInfo<'a>,
     /// Source stake account for to merge.  This account will be drained
     pub source_stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    pub stake_history: &'b solana_account_info::AccountInfo<'a>,
     /// Stake authority
     pub stake_authority: &'b solana_account_info::AccountInfo<'a>,
 }
@@ -199,10 +159,6 @@ pub struct MergeCpi<'a, 'b> {
     pub destination_stake: &'b solana_account_info::AccountInfo<'a>,
     /// Source stake account for to merge.  This account will be drained
     pub source_stake: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    pub stake_history: &'b solana_account_info::AccountInfo<'a>,
     /// Stake authority
     pub stake_authority: &'b solana_account_info::AccountInfo<'a>,
 }
@@ -216,8 +172,6 @@ impl<'a, 'b> MergeCpi<'a, 'b> {
             __program: program,
             destination_stake: accounts.destination_stake,
             source_stake: accounts.source_stake,
-            clock_sysvar: accounts.clock_sysvar,
-            stake_history: accounts.stake_history,
             stake_authority: accounts.stake_authority,
         }
     }
@@ -244,21 +198,13 @@ impl<'a, 'b> MergeCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(
             *self.destination_stake.key,
             false,
         ));
         accounts.push(solana_instruction::AccountMeta::new(
             *self.source_stake.key,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.clock_sysvar.key,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.stake_history.key,
             false,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
@@ -279,12 +225,10 @@ impl<'a, 'b> MergeCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(4 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.destination_stake.clone());
         account_infos.push(self.source_stake.clone());
-        account_infos.push(self.clock_sysvar.clone());
-        account_infos.push(self.stake_history.clone());
         account_infos.push(self.stake_authority.clone());
         remaining_accounts
             .iter()
@@ -304,9 +248,7 @@ impl<'a, 'b> MergeCpi<'a, 'b> {
 ///
 ///   0. `[writable]` destination_stake
 ///   1. `[writable]` source_stake
-///   2. `[]` clock_sysvar
-///   3. `[]` stake_history
-///   4. `[signer]` stake_authority
+///   2. `[signer]` stake_authority
 #[derive(Clone, Debug)]
 pub struct MergeCpiBuilder<'a, 'b> {
     instruction: Box<MergeCpiBuilderInstruction<'a, 'b>>,
@@ -318,8 +260,6 @@ impl<'a, 'b> MergeCpiBuilder<'a, 'b> {
             __program: program,
             destination_stake: None,
             source_stake: None,
-            clock_sysvar: None,
-            stake_history: None,
             stake_authority: None,
             __remaining_accounts: Vec::new(),
         });
@@ -341,24 +281,6 @@ impl<'a, 'b> MergeCpiBuilder<'a, 'b> {
         source_stake: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.source_stake = Some(source_stake);
-        self
-    }
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(
-        &mut self,
-        clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.clock_sysvar = Some(clock_sysvar);
-        self
-    }
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    #[inline(always)]
-    pub fn stake_history(
-        &mut self,
-        stake_history: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.stake_history = Some(stake_history);
         self
     }
     /// Stake authority
@@ -417,16 +339,6 @@ impl<'a, 'b> MergeCpiBuilder<'a, 'b> {
                 .source_stake
                 .expect("source_stake is not set"),
 
-            clock_sysvar: self
-                .instruction
-                .clock_sysvar
-                .expect("clock_sysvar is not set"),
-
-            stake_history: self
-                .instruction
-                .stake_history
-                .expect("stake_history is not set"),
-
             stake_authority: self
                 .instruction
                 .stake_authority
@@ -444,8 +356,6 @@ struct MergeCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     destination_stake: Option<&'b solana_account_info::AccountInfo<'a>>,
     source_stake: Option<&'b solana_account_info::AccountInfo<'a>>,
-    clock_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
-    stake_history: Option<&'b solana_account_info::AccountInfo<'a>>,
     stake_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,

--- a/clients/rust/src/generated/instructions/withdraw.rs
+++ b/clients/rust/src/generated/instructions/withdraw.rs
@@ -16,10 +16,6 @@ pub struct Withdraw {
     pub stake: solana_address::Address,
     /// Recipient account
     pub recipient: solana_address::Address,
-    /// Clock sysvar
-    pub clock_sysvar: solana_address::Address,
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    pub stake_history: solana_address::Address,
     /// Withdraw authority
     pub withdraw_authority: solana_address::Address,
     /// Lockup authority, if before lockup expiration
@@ -37,17 +33,9 @@ impl Withdraw {
         args: WithdrawInstructionArgs,
         remaining_accounts: &[solana_instruction::AccountMeta],
     ) -> solana_instruction::Instruction {
-        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.stake, false));
         accounts.push(solana_instruction::AccountMeta::new(self.recipient, false));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.clock_sysvar,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            self.stake_history,
-            false,
-        ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.withdraw_authority,
             true,
@@ -109,16 +97,12 @@ impl WithdrawInstructionArgs {
 ///
 ///   0. `[writable]` stake
 ///   1. `[writable]` recipient
-///   2. `[optional]` clock_sysvar (default to `SysvarC1ock11111111111111111111111111111111`)
-///   3. `[optional]` stake_history (default to `SysvarStakeHistory1111111111111111111111111`)
-///   4. `[signer]` withdraw_authority
-///   5. `[signer, optional]` lockup_authority
+///   2. `[signer]` withdraw_authority
+///   3. `[signer, optional]` lockup_authority
 #[derive(Clone, Debug, Default)]
 pub struct WithdrawBuilder {
     stake: Option<solana_address::Address>,
     recipient: Option<solana_address::Address>,
-    clock_sysvar: Option<solana_address::Address>,
-    stake_history: Option<solana_address::Address>,
     withdraw_authority: Option<solana_address::Address>,
     lockup_authority: Option<solana_address::Address>,
     args: Option<u64>,
@@ -139,20 +123,6 @@ impl WithdrawBuilder {
     #[inline(always)]
     pub fn recipient(&mut self, recipient: solana_address::Address) -> &mut Self {
         self.recipient = Some(recipient);
-        self
-    }
-    /// `[optional account, default to 'SysvarC1ock11111111111111111111111111111111']`
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(&mut self, clock_sysvar: solana_address::Address) -> &mut Self {
-        self.clock_sysvar = Some(clock_sysvar);
-        self
-    }
-    /// `[optional account, default to 'SysvarStakeHistory1111111111111111111111111']`
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    #[inline(always)]
-    pub fn stake_history(&mut self, stake_history: solana_address::Address) -> &mut Self {
-        self.stake_history = Some(stake_history);
         self
     }
     /// Withdraw authority
@@ -196,12 +166,6 @@ impl WithdrawBuilder {
         let accounts = Withdraw {
             stake: self.stake.expect("stake is not set"),
             recipient: self.recipient.expect("recipient is not set"),
-            clock_sysvar: self.clock_sysvar.unwrap_or(solana_address::address!(
-                "SysvarC1ock11111111111111111111111111111111"
-            )),
-            stake_history: self.stake_history.unwrap_or(solana_address::address!(
-                "SysvarStakeHistory1111111111111111111111111"
-            )),
             withdraw_authority: self
                 .withdraw_authority
                 .expect("withdraw_authority is not set"),
@@ -221,10 +185,6 @@ pub struct WithdrawCpiAccounts<'a, 'b> {
     pub stake: &'b solana_account_info::AccountInfo<'a>,
     /// Recipient account
     pub recipient: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    pub stake_history: &'b solana_account_info::AccountInfo<'a>,
     /// Withdraw authority
     pub withdraw_authority: &'b solana_account_info::AccountInfo<'a>,
     /// Lockup authority, if before lockup expiration
@@ -239,10 +199,6 @@ pub struct WithdrawCpi<'a, 'b> {
     pub stake: &'b solana_account_info::AccountInfo<'a>,
     /// Recipient account
     pub recipient: &'b solana_account_info::AccountInfo<'a>,
-    /// Clock sysvar
-    pub clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    pub stake_history: &'b solana_account_info::AccountInfo<'a>,
     /// Withdraw authority
     pub withdraw_authority: &'b solana_account_info::AccountInfo<'a>,
     /// Lockup authority, if before lockup expiration
@@ -261,8 +217,6 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
             __program: program,
             stake: accounts.stake,
             recipient: accounts.recipient,
-            clock_sysvar: accounts.clock_sysvar,
-            stake_history: accounts.stake_history,
             withdraw_authority: accounts.withdraw_authority,
             lockup_authority: accounts.lockup_authority,
             __args: args,
@@ -291,18 +245,10 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
         remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> solana_program_error::ProgramResult {
-        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(*self.stake.key, false));
         accounts.push(solana_instruction::AccountMeta::new(
             *self.recipient.key,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.clock_sysvar.key,
-            false,
-        ));
-        accounts.push(solana_instruction::AccountMeta::new_readonly(
-            *self.stake_history.key,
             false,
         ));
         accounts.push(solana_instruction::AccountMeta::new_readonly(
@@ -331,12 +277,10 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(7 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.stake.clone());
         account_infos.push(self.recipient.clone());
-        account_infos.push(self.clock_sysvar.clone());
-        account_infos.push(self.stake_history.clone());
         account_infos.push(self.withdraw_authority.clone());
         if let Some(lockup_authority) = self.lockup_authority {
             account_infos.push(lockup_authority.clone());
@@ -359,10 +303,8 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
 ///
 ///   0. `[writable]` stake
 ///   1. `[writable]` recipient
-///   2. `[]` clock_sysvar
-///   3. `[]` stake_history
-///   4. `[signer]` withdraw_authority
-///   5. `[signer, optional]` lockup_authority
+///   2. `[signer]` withdraw_authority
+///   3. `[signer, optional]` lockup_authority
 #[derive(Clone, Debug)]
 pub struct WithdrawCpiBuilder<'a, 'b> {
     instruction: Box<WithdrawCpiBuilderInstruction<'a, 'b>>,
@@ -374,8 +316,6 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
             __program: program,
             stake: None,
             recipient: None,
-            clock_sysvar: None,
-            stake_history: None,
             withdraw_authority: None,
             lockup_authority: None,
             args: None,
@@ -393,24 +333,6 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn recipient(&mut self, recipient: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.recipient = Some(recipient);
-        self
-    }
-    /// Clock sysvar
-    #[inline(always)]
-    pub fn clock_sysvar(
-        &mut self,
-        clock_sysvar: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.clock_sysvar = Some(clock_sysvar);
-        self
-    }
-    /// Stake history sysvar that carries stake warmup/cooldown history
-    #[inline(always)]
-    pub fn stake_history(
-        &mut self,
-        stake_history: &'b solana_account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.stake_history = Some(stake_history);
         self
     }
     /// Withdraw authority
@@ -481,16 +403,6 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
 
             recipient: self.instruction.recipient.expect("recipient is not set"),
 
-            clock_sysvar: self
-                .instruction
-                .clock_sysvar
-                .expect("clock_sysvar is not set"),
-
-            stake_history: self
-                .instruction
-                .stake_history
-                .expect("stake_history is not set"),
-
             withdraw_authority: self
                 .instruction
                 .withdraw_authority
@@ -511,8 +423,6 @@ struct WithdrawCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_account_info::AccountInfo<'a>,
     stake: Option<&'b solana_account_info::AccountInfo<'a>>,
     recipient: Option<&'b solana_account_info::AccountInfo<'a>>,
-    clock_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
-    stake_history: Option<&'b solana_account_info::AccountInfo<'a>>,
     withdraw_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     lockup_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     args: Option<u64>,

--- a/idl.json
+++ b/idl.json
@@ -26,24 +26,6 @@
               "kind": "instructionAccountDisplayNode",
               "label": "Stake Account"
             }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "rentSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Rent sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarRent111111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
           }
         ],
         "arguments": [
@@ -120,24 +102,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Stake Account"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {
@@ -248,56 +212,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Vote Account"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "stakeHistory",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Stake history sysvar that carries stake warmup/cooldown history"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarStakeHistory1111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "unused",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Unused account, formerly the stake config"
-            ],
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {
@@ -476,42 +390,6 @@
           },
           {
             "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "stakeHistory",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Stake history sysvar that carries stake warmup/cooldown history"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarStakeHistory1111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
             "name": "withdrawAuthority",
             "isWritable": false,
             "isSigner": true,
@@ -605,24 +483,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Stake Account"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {
@@ -825,42 +685,6 @@
           },
           {
             "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "stakeHistory",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Stake history sysvar that carries stake warmup/cooldown history"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarStakeHistory1111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
             "name": "stakeAuthority",
             "isWritable": false,
             "isSigner": true,
@@ -934,24 +758,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Base Key"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {
@@ -1065,24 +871,6 @@
           },
           {
             "kind": "instructionAccountNode",
-            "name": "rentSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Rent sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarRent111111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
             "name": "stakeAuthority",
             "isWritable": false,
             "isSigner": false,
@@ -1152,24 +940,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Stake Account"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {
@@ -1279,24 +1049,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Base Key"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "isOptional": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {

--- a/interface-idl.json
+++ b/interface-idl.json
@@ -25,23 +25,6 @@
               "kind": "instructionAccountDisplayNode",
               "label": "Stake Account"
             }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "rentSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Rent sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarRent111111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
           }
         ],
         "arguments": [
@@ -117,23 +100,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Stake Account"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {
@@ -241,53 +207,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Vote Account"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "stakeHistory",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Stake history sysvar that carries stake warmup/cooldown history"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarStakeHistory1111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "unused",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Unused account, formerly the stake config"
-            ],
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {
@@ -460,40 +379,6 @@
           },
           {
             "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "stakeHistory",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Stake history sysvar that carries stake warmup/cooldown history"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarStakeHistory1111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
             "name": "withdrawAuthority",
             "isWritable": false,
             "isSigner": true,
@@ -585,23 +470,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Stake Account"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {
@@ -753,40 +621,6 @@
           },
           {
             "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "stakeHistory",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Stake history sysvar that carries stake warmup/cooldown history"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarStakeHistory1111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
             "name": "stakeAuthority",
             "isWritable": false,
             "isSigner": true,
@@ -857,23 +691,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Base Key"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {
@@ -952,23 +769,6 @@
           },
           {
             "kind": "instructionAccountNode",
-            "name": "rentSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Rent sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarRent111111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
             "name": "stakeAuthority",
             "isWritable": false,
             "isSigner": false,
@@ -1035,23 +835,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Stake Account"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {
@@ -1157,23 +940,6 @@
             "display": {
               "kind": "instructionAccountDisplayNode",
               "label": "Base Key"
-            }
-          },
-          {
-            "kind": "instructionAccountNode",
-            "name": "clockSysvar",
-            "isWritable": false,
-            "isSigner": false,
-            "docs": [
-              "Clock sysvar"
-            ],
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "SysvarC1ock11111111111111111111111111111111"
-            },
-            "display": {
-              "kind": "instructionAccountDisplayNode",
-              "skip": "always"
             }
           },
           {

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -12,24 +12,9 @@ use {
 };
 #[cfg(feature = "bincode")]
 use {
-    crate::{config, program::ID, state::StakeStateV2},
+    crate::{program::ID, state::StakeStateV2},
     solana_instruction::{AccountMeta, Instruction},
 };
-
-// Inline some constants to avoid dependencies.
-//
-// Note: replace these inline IDs with the corresponding value from
-// `solana_sdk_ids` once the version is updated to 2.2.0.
-
-#[cfg(feature = "bincode")]
-const CLOCK_ID: Pubkey = Pubkey::from_str_const("SysvarC1ock11111111111111111111111111111111");
-
-#[cfg(feature = "bincode")]
-const RENT_ID: Pubkey = Pubkey::from_str_const("SysvarRent111111111111111111111111111111111");
-
-#[cfg(feature = "bincode")]
-const STAKE_HISTORY_ID: Pubkey =
-    Pubkey::from_str_const("SysvarStakeHistory1111111111111111111111111");
 
 // NOTE the stake program is in the process of removing dependence on all sysvars
 // once this version of the program is live on all clusters, we can remove them here
@@ -48,7 +33,6 @@ pub enum StakeInstruction {
     ///
     /// # Account references
     ///   0. `[WRITE]` Uninitialized stake account
-    ///   1. `[]` Rent sysvar
     ///
     /// [`Authorized`] carries pubkeys that must sign staker transactions
     /// and withdrawer transactions; [`Lockup`] carries information about
@@ -64,12 +48,6 @@ pub enum StakeInstruction {
             writable,
             docs = "Uninitialized stake account",
             display(label = "Stake Account")
-        )),
-        codama(account(
-            name = "rent_sysvar",
-            docs = "Rent sysvar",
-            default_value = sysvar("rent"),
-            display(skip = always)
         ))
     )]
     Initialize(
@@ -81,9 +59,8 @@ pub enum StakeInstruction {
     ///
     /// # Account references
     ///   0. `[WRITE]` Stake account to be updated
-    ///   1. `[]` Clock sysvar
-    ///   2. `[SIGNER]` The stake or withdraw authority
-    ///   3. Optional: `[SIGNER]` Lockup authority, if updating `StakeAuthorize::Withdrawer` before
+    ///   1. `[SIGNER]` The stake or withdraw authority
+    ///   2. Optional: `[SIGNER]` Lockup authority, if updating `StakeAuthorize::Withdrawer` before
     ///      lockup expiration
     #[cfg_attr(
         feature = "codama",
@@ -96,12 +73,6 @@ pub enum StakeInstruction {
             writable,
             docs = "Stake account to be updated",
             display(label = "Stake Account")
-        )),
-        codama(account(
-            name = "clock_sysvar",
-            docs = "Clock sysvar",
-            default_value = sysvar("clock"),
-            display(skip = always)
         )),
         codama(account(name = "authority", signer, docs = "The stake or withdraw authority")),
         codama(account(
@@ -121,10 +92,7 @@ pub enum StakeInstruction {
     /// # Account references
     ///   0. `[WRITE]` Initialized stake account to be delegated
     ///   1. `[]` Vote account to which this stake will be delegated
-    ///   2. `[]` Clock sysvar
-    ///   3. `[]` Stake history sysvar that carries stake warmup/cooldown history
-    ///   4. `[]` Unused account, formerly the stake config
-    ///   5. `[SIGNER]` Stake authority
+    ///   2. `[SIGNER]` Stake authority
     ///
     /// The entire balance of the staking account is staked. `DelegateStake`
     /// can be called multiple times, but re-delegation is delayed by one epoch.
@@ -144,23 +112,6 @@ pub enum StakeInstruction {
             name = "vote",
             docs = "Vote account to which this stake will be delegated",
             display(label = "Vote Account")
-        )),
-        codama(account(
-            name = "clock_sysvar",
-            docs = "Clock sysvar",
-            default_value = sysvar("clock"),
-            display(skip = always)
-        )),
-        codama(account(
-            name = "stake_history",
-            docs = "Stake history sysvar that carries stake warmup/cooldown history",
-            default_value = sysvar("stake_history"),
-            display(skip = always)
-        )),
-        codama(account(
-            name = "unused",
-            docs = "Unused account, formerly the stake config",
-            display(skip = always)
         )),
         codama(account(name = "stake_authority", signer, docs = "Stake authority"))
     )]
@@ -208,10 +159,8 @@ pub enum StakeInstruction {
     /// # Account references
     ///   0. `[WRITE]` Stake account from which to withdraw
     ///   1. `[WRITE]` Recipient account
-    ///   2. `[]` Clock sysvar
-    ///   3. `[]` Stake history sysvar that carries stake warmup/cooldown history
-    ///   4. `[SIGNER]` Withdraw authority
-    ///   5. Optional: `[SIGNER]` Lockup authority, if before lockup expiration
+    ///   2. `[SIGNER]` Withdraw authority
+    ///   3. Optional: `[SIGNER]` Lockup authority, if before lockup expiration
     ///
     /// The `u64` is the portion of the stake account balance to be withdrawn,
     /// must be `<= StakeAccount.lamports - staked_lamports`.
@@ -228,18 +177,6 @@ pub enum StakeInstruction {
             display(label = "Stake Account")
         )),
         codama(account(name = "recipient", writable, docs = "Recipient account")),
-        codama(account(
-            name = "clock_sysvar",
-            docs = "Clock sysvar",
-            default_value = sysvar("clock"),
-            display(skip = always)
-        )),
-        codama(account(
-            name = "stake_history",
-            docs = "Stake history sysvar that carries stake warmup/cooldown history",
-            default_value = sysvar("stake_history"),
-            display(skip = always)
-        )),
         codama(account(name = "withdraw_authority", signer, docs = "Withdraw authority")),
         codama(account(
             name = "lockup_authority",
@@ -263,22 +200,18 @@ pub enum StakeInstruction {
     ///
     /// # Account references
     ///   0. `[WRITE]` Delegated stake account
-    ///   1. `[]` Clock sysvar
-    ///   2. `[SIGNER]` Stake authority
+    ///   1. `[SIGNER]` Stake authority
     #[cfg_attr(
         feature = "codama",
-        codama(display(intent = "Deactivate stake", interpolated_intent = "Deactivate ${accounts.stake}")),
+        codama(display(
+            intent = "Deactivate stake",
+            interpolated_intent = "Deactivate ${accounts.stake}"
+        )),
         codama(account(
             name = "stake",
             writable,
             docs = "Delegated stake account to be deactivated",
             display(label = "Stake Account")
-        )),
-        codama(account(
-            name = "clock_sysvar",
-            docs = "Clock sysvar",
-            default_value = sysvar("clock"),
-            display(skip = always)
         )),
         codama(account(name = "stake_authority", signer, docs = "Stake authority"))
     )]
@@ -340,9 +273,7 @@ pub enum StakeInstruction {
     /// # Account references
     ///   0. `[WRITE]` Destination stake account for the merge
     ///   1. `[WRITE]` Source stake account for to merge.  This account will be drained
-    ///   2. `[]` Clock sysvar
-    ///   3. `[]` Stake history sysvar that carries stake warmup/cooldown history
-    ///   4. `[SIGNER]` Stake authority
+    ///   2. `[SIGNER]` Stake authority
     #[cfg_attr(
         feature = "codama",
         codama(display(
@@ -361,18 +292,6 @@ pub enum StakeInstruction {
             docs = "Source stake account for to merge.  This account will be drained",
             display(label = "From")
         )),
-        codama(account(
-            name = "clock_sysvar",
-            docs = "Clock sysvar",
-            default_value = sysvar("clock"),
-            display(skip = always)
-        )),
-        codama(account(
-            name = "stake_history",
-            docs = "Stake history sysvar that carries stake warmup/cooldown history",
-            default_value = sysvar("stake_history"),
-            display(skip = always)
-        )),
         codama(account(name = "stake_authority", signer, docs = "Stake authority"))
     )]
     Merge,
@@ -382,8 +301,7 @@ pub enum StakeInstruction {
     /// # Account references
     ///   0. `[WRITE]` Stake account to be updated
     ///   1. `[SIGNER]` Base key of stake or withdraw authority
-    ///   2. `[]` Clock sysvar
-    ///   3. Optional: `[SIGNER]` Lockup authority, if updating [`StakeAuthorize::Withdrawer`]
+    ///   2. Optional: `[SIGNER]` Lockup authority, if updating [`StakeAuthorize::Withdrawer`]
     ///      before lockup expiration
     #[cfg_attr(
         feature = "codama",
@@ -402,12 +320,6 @@ pub enum StakeInstruction {
             signer,
             docs = "Base key of stake or withdraw authority",
             display(label = "Base Key")
-        )),
-        codama(account(
-            name = "clock_sysvar",
-            docs = "Clock sysvar",
-            default_value = sysvar("clock"),
-            display(skip = always)
         )),
         codama(account(
             name = "lockup_authority",
@@ -432,9 +344,8 @@ pub enum StakeInstruction {
     ///
     /// # Account references
     ///   0. `[WRITE]` Uninitialized stake account
-    ///   1. `[]` Rent sysvar
-    ///   2. `[]` The stake authority
-    ///   3. `[SIGNER]` The withdraw authority
+    ///   1. `[]` The stake authority
+    ///   2. `[SIGNER]` The withdraw authority
     #[cfg_attr(
         feature = "codama",
         codama(display(
@@ -446,12 +357,6 @@ pub enum StakeInstruction {
             writable,
             docs = "Uninitialized stake account",
             display(label = "Stake Account")
-        )),
-        codama(account(
-            name = "rent_sysvar",
-            docs = "Rent sysvar",
-            default_value = sysvar("rent"),
-            display(skip = always)
         )),
         codama(account(name = "stake_authority", docs = "The stake authority")),
         codama(account(name = "withdraw_authority", signer, docs = "The withdraw authority"))
@@ -465,10 +370,9 @@ pub enum StakeInstruction {
     ///
     /// # Account references
     ///   0. `[WRITE]` Stake account to be updated
-    ///   1. `[]` Clock sysvar
-    ///   2. `[SIGNER]` The stake or withdraw authority
-    ///   3. `[SIGNER]` The new stake or withdraw authority
-    ///   4. Optional: `[SIGNER]` Lockup authority, if updating [`StakeAuthorize::Withdrawer`]
+    ///   1. `[SIGNER]` The stake or withdraw authority
+    ///   2. `[SIGNER]` The new stake or withdraw authority
+    ///   3. Optional: `[SIGNER]` Lockup authority, if updating [`StakeAuthorize::Withdrawer`]
     ///      before lockup expiration
     #[cfg_attr(
         feature = "codama",
@@ -481,12 +385,6 @@ pub enum StakeInstruction {
             writable,
             docs = "Stake account to be updated",
             display(label = "Stake Account")
-        )),
-        codama(account(
-            name = "clock_sysvar",
-            docs = "Clock sysvar",
-            default_value = sysvar("clock"),
-            display(skip = always)
         )),
         codama(account(name = "authority", signer, docs = "The stake or withdraw authority")),
         codama(account(
@@ -518,9 +416,8 @@ pub enum StakeInstruction {
     /// # Account references
     ///   0. `[WRITE]` Stake account to be updated
     ///   1. `[SIGNER]` Base key of stake or withdraw authority
-    ///   2. `[]` Clock sysvar
-    ///   3. `[SIGNER]` The new stake or withdraw authority
-    ///   4. Optional: `[SIGNER]` Lockup authority, if updating [`StakeAuthorize::Withdrawer`]
+    ///   2. `[SIGNER]` The new stake or withdraw authority
+    ///   3. Optional: `[SIGNER]` Lockup authority, if updating [`StakeAuthorize::Withdrawer`]
     ///      before lockup expiration
     #[cfg_attr(
         feature = "codama",
@@ -539,12 +436,6 @@ pub enum StakeInstruction {
             signer,
             docs = "Base key of stake or withdraw authority",
             display(label = "Base Key")
-        )),
-        codama(account(
-            name = "clock_sysvar",
-            docs = "Clock sysvar",
-            default_value = sysvar("clock"),
-            display(skip = always)
         )),
         codama(account(
             name = "new_authority",
@@ -681,8 +572,7 @@ pub enum StakeInstruction {
     ///      plus rent exempt minimum
     ///   1. `[WRITE]` Uninitialized stake account that will hold the redelegated stake
     ///   2. `[]` Vote account to which this stake will be re-delegated
-    ///   3. `[]` Unused account, formerly the stake config
-    ///   4. `[SIGNER]` Stake authority
+    ///   3. `[SIGNER]` Stake authority
     ///
     #[deprecated(since = "2.1.0", note = "Redelegate will not be enabled")]
     // NOTE: No codama attributes - this instruction is disabled and excluded from IDL
@@ -855,10 +745,7 @@ pub fn initialize(stake_pubkey: &Pubkey, authorized: &Authorized, lockup: &Locku
     Instruction::new_with_bincode(
         ID,
         &StakeInstruction::Initialize(*authorized, *lockup),
-        vec![
-            AccountMeta::new(*stake_pubkey, false),
-            AccountMeta::new_readonly(RENT_ID, false),
-        ],
+        vec![AccountMeta::new(*stake_pubkey, false)],
     )
 }
 
@@ -869,7 +756,6 @@ pub fn initialize_checked(stake_pubkey: &Pubkey, authorized: &Authorized) -> Ins
         &StakeInstruction::InitializeChecked,
         vec![
             AccountMeta::new(*stake_pubkey, false),
-            AccountMeta::new_readonly(RENT_ID, false),
             AccountMeta::new_readonly(authorized.staker, false),
             AccountMeta::new_readonly(authorized.withdrawer, true),
         ],
@@ -1035,8 +921,6 @@ pub fn merge(
     let account_metas = vec![
         AccountMeta::new(*destination_stake_pubkey, false),
         AccountMeta::new(*source_stake_pubkey, false),
-        AccountMeta::new_readonly(CLOCK_ID, false),
-        AccountMeta::new_readonly(STAKE_HISTORY_ID, false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
 
@@ -1104,7 +988,6 @@ pub fn authorize(
 ) -> Instruction {
     let mut account_metas = vec![
         AccountMeta::new(*stake_pubkey, false),
-        AccountMeta::new_readonly(CLOCK_ID, false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
 
@@ -1129,7 +1012,6 @@ pub fn authorize_checked(
 ) -> Instruction {
     let mut account_metas = vec![
         AccountMeta::new(*stake_pubkey, false),
-        AccountMeta::new_readonly(CLOCK_ID, false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
         AccountMeta::new_readonly(*new_authorized_pubkey, true),
     ];
@@ -1158,7 +1040,6 @@ pub fn authorize_with_seed(
     let mut account_metas = vec![
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new_readonly(*authority_base, true),
-        AccountMeta::new_readonly(CLOCK_ID, false),
     ];
 
     if let Some(custodian_pubkey) = custodian_pubkey {
@@ -1192,7 +1073,6 @@ pub fn authorize_checked_with_seed(
     let mut account_metas = vec![
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new_readonly(*authority_base, true),
-        AccountMeta::new_readonly(CLOCK_ID, false),
         AccountMeta::new_readonly(*new_authorized_pubkey, true),
     ];
 
@@ -1222,10 +1102,6 @@ pub fn delegate_stake(
     let account_metas = vec![
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new_readonly(*vote_pubkey, false),
-        AccountMeta::new_readonly(CLOCK_ID, false),
-        AccountMeta::new_readonly(STAKE_HISTORY_ID, false),
-        // For backwards compatibility we pass the stake config, although this account is unused
-        AccountMeta::new_readonly(config::ID, false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
     Instruction::new_with_bincode(ID, &StakeInstruction::DelegateStake, account_metas)
@@ -1242,8 +1118,6 @@ pub fn withdraw(
     let mut account_metas = vec![
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new(*to_pubkey, false),
-        AccountMeta::new_readonly(CLOCK_ID, false),
-        AccountMeta::new_readonly(STAKE_HISTORY_ID, false),
         AccountMeta::new_readonly(*withdrawer_pubkey, true),
     ];
 
@@ -1258,7 +1132,6 @@ pub fn withdraw(
 pub fn deactivate_stake(stake_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*stake_pubkey, false),
-        AccountMeta::new_readonly(CLOCK_ID, false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
     Instruction::new_with_bincode(ID, &StakeInstruction::Deactivate, account_metas)
@@ -1332,8 +1205,6 @@ fn _redelegate(
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new(*uninitialized_stake_pubkey, false),
         AccountMeta::new_readonly(*vote_pubkey, false),
-        // For backwards compatibility we pass the stake config, although this account is unused
-        AccountMeta::new_readonly(config::ID, false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
     Instruction::new_with_bincode(ID, &StakeInstruction::Redelegate, account_metas)
@@ -1419,23 +1290,4 @@ pub fn move_lamports(
     ];
 
     Instruction::new_with_bincode(ID, &StakeInstruction::MoveLamports(lamports), account_metas)
-}
-
-#[cfg(feature = "bincode")]
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[allow(deprecated)]
-    #[test]
-    fn test_constants() {
-        // Ensure that the constants are in sync with the solana program.
-        assert_eq!(CLOCK_ID, solana_sdk_ids::sysvar::clock::ID);
-
-        // Ensure that the constants are in sync with the solana program.
-        assert_eq!(STAKE_HISTORY_ID, solana_sdk_ids::sysvar::stake_history::ID);
-
-        // Ensure that the constants are in sync with the solana rent.
-        assert_eq!(RENT_ID, solana_sdk_ids::sysvar::rent::ID);
-    }
 }

--- a/program/tests/interface.rs
+++ b/program/tests/interface.rs
@@ -1140,7 +1140,7 @@ fn test_no_use_dealloc() {
                 if is_withdraw {
                     // truncating source account data makes this a self-signed withdraw
                     if instruction.accounts[0].pubkey == stake_address {
-                        instruction.accounts[4].pubkey = stake_address;
+                        instruction.accounts[2].pubkey = stake_address;
                     }
                     env.process_success(&instruction);
                 } else {

--- a/program/tests/stake_instruction.rs
+++ b/program/tests/stake_instruction.rs
@@ -708,7 +708,7 @@ fn test_stake_checked_instructions() {
 
     // Test InitializeChecked with non-signing withdrawer
     let mut instruction = initialize_checked(&stake_address, &Authorized { staker, withdrawer });
-    instruction.accounts[3] = AccountMeta::new_readonly(withdrawer, false);
+    instruction.accounts[2] = AccountMeta::new_readonly(withdrawer, false);
     process_instruction_as_one_arg(
         &mollusk,
         &instruction,
@@ -763,7 +763,7 @@ fn test_stake_checked_instructions() {
         StakeAuthorize::Staker,
         None,
     );
-    instruction.accounts[3] = AccountMeta::new_readonly(staker, false);
+    instruction.accounts[2] = AccountMeta::new_readonly(staker, false);
     process_instruction_as_one_arg(
         &mollusk,
         &instruction,
@@ -777,7 +777,7 @@ fn test_stake_checked_instructions() {
         StakeAuthorize::Withdrawer,
         None,
     );
-    instruction.accounts[3] = AccountMeta::new_readonly(withdrawer, false);
+    instruction.accounts[2] = AccountMeta::new_readonly(withdrawer, false);
     process_instruction_as_one_arg(
         &mollusk,
         &instruction,
@@ -877,7 +877,7 @@ fn test_stake_checked_instructions() {
         StakeAuthorize::Staker,
         None,
     );
-    instruction.accounts[3] = AccountMeta::new_readonly(staker, false);
+    instruction.accounts[2] = AccountMeta::new_readonly(staker, false);
     process_instruction_as_one_arg(
         &mollusk,
         &instruction,
@@ -893,7 +893,7 @@ fn test_stake_checked_instructions() {
         StakeAuthorize::Withdrawer,
         None,
     );
-    instruction.accounts[3] = AccountMeta::new_readonly(staker, false);
+    instruction.accounts[2] = AccountMeta::new_readonly(staker, false);
     process_instruction_as_one_arg(
         &mollusk,
         &instruction,


### PR DESCRIPTION
since v5 went live, the stake program on all networks is equally happy if you give it the sysvar acocunts or do not. so we can stop using these in instruction builders

closes #53 